### PR TITLE
fix(sync): correct skill directory tracking in state

### DIFF
--- a/src/core/sync.ts
+++ b/src/core/sync.ts
@@ -306,16 +306,15 @@ export function collectSyncedPaths(
       const mapping = CLIENT_MAPPINGS[client];
 
       // Check if this is a skill directory (copy results for skills point to the dir)
-      const isSkillDir =
-        mapping.skillsPath &&
-        (relativePath === mapping.skillsPath.replace(/\/$/, '') ||
-          relativePath.startsWith(mapping.skillsPath));
-
-      // Track skill directories with trailing /
-      if (isSkillDir && !relativePath.includes('/')) {
-        // This is the skill directory itself
-        result[client]?.push(`${relativePath}/`);
-        break;
+      // e.g., relativePath = '.claude/skills/my-skill', skillsPath = '.claude/skills/'
+      if (mapping.skillsPath && relativePath.startsWith(mapping.skillsPath)) {
+        const skillName = relativePath.slice(mapping.skillsPath.length);
+        // If skillName has no '/', this is a skill directory (not a file inside)
+        if (!skillName.includes('/')) {
+          // Track skill directory with trailing / for efficient rm -rf
+          result[client]?.push(`${relativePath}/`);
+          break;
+        }
       }
 
       // Check if file belongs to this client's paths


### PR DESCRIPTION
## Summary

- Fix dead code in `collectSyncedPaths` that never tracked skill directories correctly
- The condition `!relativePath.includes('/')` was never true for skill paths like `.claude/skills/my-skill`
- Now correctly extracts skill name and checks if it's a directory (no nested `/`)

## Changes

| File | Change |
|------|--------|
| `src/core/sync.ts` | Fix skill directory detection logic |
| `tests/unit/core/sync.test.ts` | Add 2 tests for skill tracking |

## Test Plan

- [x] Verify skill directories tracked with trailing `/` in state
- [x] Verify skill directory purged when plugin removed
- [x] All existing tests pass (133 total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)