### PR TITLE
test(sync): verify WORKSPACE-RULES appends without replacing content

### DIFF
--- a/tests/unit/core/sync.test.ts
+++ b/tests/unit/core/sync.test.ts
@@ -297,12 +297,15 @@ clients:
       const result = await syncWorkspace(testDir);
       expect(result.success).toBe(true);
 
-      // Both files should have WORKSPACE-RULES appended
+      // CLAUDE.md should have WORKSPACE-RULES appended (not replaced)
       const claudeContent = await readFile(join(testDir, 'CLAUDE.md'), 'utf-8');
+      expect(claudeContent).toContain('# Claude Agent');
       expect(claudeContent).toContain('<!-- WORKSPACE-RULES:START -->');
       expect(claudeContent).toContain('<!-- WORKSPACE-RULES:END -->');
 
+      // AGENTS.md should have WORKSPACE-RULES appended (not replaced)
       const agentsContent = await readFile(join(testDir, 'AGENTS.md'), 'utf-8');
+      expect(agentsContent).toContain('# Agents');
       expect(agentsContent).toContain('<!-- WORKSPACE-RULES:START -->');
       expect(agentsContent).toContain('<!-- WORKSPACE-RULES:END -->');
     });


### PR DESCRIPTION
## Summary
Add assertions to verify original content (`# Claude Agent`, `# Agents`) is preserved when WORKSPACE-RULES are injected into agent files.

## Test plan
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)