### PR TITLE
fix(update): resolve package.json path correctly for version detection

### DIFF
--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -1,5 +1,8 @@
 import { Command } from 'commander';
 import { execa } from 'execa';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 /**
  * Detect package manager from a script path
@@ -23,14 +26,12 @@ function detectPackageManager(): 'bun' | 'npm' {
 /**
  * Get current installed version from package.json
  */
-async function getCurrentVersion(): Promise<string> {
-  // Import package.json to get version
-  // Using dynamic import to handle ESM
+function getCurrentVersion(): string {
   try {
-    const { createRequire } = await import('node:module');
-    const require = createRequire(import.meta.url);
-    const pkg = require('../../../package.json');
-    return pkg.version;
+    const __dirname = dirname(fileURLToPath(import.meta.url));
+    const packageJsonPath = join(__dirname, '..', 'package.json');
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+    return packageJson.version;
   } catch {
     return 'unknown';
   }
@@ -58,7 +59,7 @@ export const updateCommand = new Command('update')
         packageManager = detectPackageManager();
       }
 
-      const currentVersion = await getCurrentVersion();
+      const currentVersion = getCurrentVersion();
       console.log(`Current version: ${currentVersion}`);
       console.log(`Updating allagents using ${packageManager}...\n`);
 


### PR DESCRIPTION
## Summary
- Fix `allagents update` showing "Current version: undefined" instead of the actual version
- Use the same `fileURLToPath`/`dirname` pattern as `cli/index.ts` to resolve package.json
- The previous `createRequire` approach used `../../../package.json` which was incorrect when running from the compiled `dist/` directory

## Test plan
- [x] `bun test update` - all 7 tests pass
- [x] `bun run build` - builds successfully
- [x] `bun run dist/index.js --version` - shows correct version

🤖 Generated with [Claude Code](https://claude.com/claude-code)