### PR TITLE
fix: use correct branch when fetching agent files from GitHub URLs

### DIFF
--- a/src/core/github-fetch.ts
+++ b/src/core/github-fetch.ts
@@ -57,7 +57,7 @@ export interface FetchWorkspaceResult {
  * @param branch - Optional branch name (defaults to default branch if not specified)
  * @returns File content or null if not found
  */
-async function fetchFileFromGitHub(
+export async function fetchFileFromGitHub(
   owner: string,
   repo: string,
   path: string,

--- a/src/core/sync.ts
+++ b/src/core/sync.ts
@@ -583,8 +583,14 @@ async function validatePlugin(
   }
 
   if (isGitHubUrl(pluginSource)) {
-    // Fetch remote plugin (with force option)
-    const fetchResult = await fetchPlugin(pluginSource, { force });
+    // Parse URL to extract branch and subpath
+    const parsed = parseGitHubUrl(pluginSource);
+
+    // Fetch remote plugin (with force option and branch if specified)
+    const fetchResult = await fetchPlugin(pluginSource, {
+      force,
+      ...(parsed?.branch && { branch: parsed.branch }),
+    });
     if (!fetchResult.success) {
       return {
         plugin: pluginSource,
@@ -594,7 +600,6 @@ async function validatePlugin(
       };
     }
     // Handle subpath in GitHub URL (e.g., /tree/main/plugins/name)
-    const parsed = parseGitHubUrl(pluginSource);
     const resolvedPath = parsed?.subpath
       ? join(fetchResult.cachePath, parsed.subpath)
       : fetchResult.cachePath;

--- a/src/utils/plugin-path.ts
+++ b/src/utils/plugin-path.ts
@@ -248,19 +248,37 @@ export function parsePluginSource(
 }
 
 /**
+ * Sanitize a branch name for use in filesystem paths
+ * Replaces slashes and other problematic characters with underscores
+ * @param branch - Branch name to sanitize
+ * @returns Sanitized branch name safe for use in paths
+ */
+function sanitizeBranchForPath(branch: string): string {
+  // Replace forward slashes, backslashes, colons, and other problematic chars
+  return branch.replace(/[/\\:*?"<>|]/g, '_');
+}
+
+/**
  * Get cache directory path for a GitHub plugin
  * @param owner - Repository owner
  * @param repo - Repository name
+ * @param branch - Optional branch name (if specified, creates branch-specific cache)
  * @returns Cache directory path
  */
-export function getPluginCachePath(owner: string, repo: string): string {
+export function getPluginCachePath(owner: string, repo: string, branch?: string): string {
   const homeDir = process.env.HOME || process.env.USERPROFILE || '~';
+  const basePath = `${owner}-${repo}`;
+
+  // If branch is specified, create a branch-specific cache path
+  // This allows concurrent use of different branches from the same repo
+  const cacheName = branch ? `${basePath}@${sanitizeBranchForPath(branch)}` : basePath;
+
   return resolve(
     homeDir,
     '.allagents',
     'plugins',
     'marketplaces',
-    `${owner}-${repo}`,
+    cacheName,
   );
 }
 


### PR DESCRIPTION
## Summary

- Fixed a bug where `workspace init --from` with a GitHub URL containing a branch (e.g., `/tree/feat/my-branch/path`) would fetch agent files (AGENTS.md, CLAUDE.md) from the default branch instead of the specified branch
- Implemented branch-specific cache paths to allow concurrent use of different branches from the same repository

## Changes

- **github-fetch.ts**: Export `fetchFileFromGitHub` to allow workspace.ts to fetch agent files directly
- **plugin.ts**: Add `branch` option to `fetchPlugin` and clone with specific branch when provided  
- **plugin-path.ts**: Add `branch` parameter to `getPluginCachePath` for branch-specific cache paths (e.g., `owner-repo@feat_branch`)
- **sync.ts**: Pass branch from parsed URL when validating workspace sources
- **workspace.ts**: Fetch agent files directly from GitHub during init when `--from` is a URL

## Test plan

- [x] `npm test` - all 152 tests pass
- [x] Manual test: `allagents workspace init ~/test --from https://github.com/WiseTechGlobal/WTG.AI.Prompts/tree/feat/allagents-workspace/plugins/cargowise` now correctly fetches AGENTS.md from the `feat/allagents-workspace` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)