### PR TITLE
fix(test): use dependency injection to isolate plugin tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "docs:install": "bun install --cwd docs",
     "docs:build": "bun run --cwd docs build",
     "dev": "bun run src/cli/index.ts",
-    "test": "bun test tests/unit/validators tests/unit/utils tests/unit/models && bun test tests/unit/core/marketplace.test.ts tests/unit/core/sync.test.ts tests/unit/core/transform-glob.test.ts tests/unit/core/github-fetch.test.ts && bun test tests/unit/core/plugin.test.ts",
+    "test": "bun test",
     "test:watch": "bun test --watch",
     "test:coverage": "bun test --coverage",
     "test:integration": "bats tests/integration/*.bats",


### PR DESCRIPTION
## Summary
- Replace `mock.module()` with dependency injection in `plugin.test.ts` to prevent mock leakage during parallel test execution
- Add `FetchDeps` interface to `fetchPlugin()` for optional dependency injection
- Simplify test script from sequential 3-stage execution to plain `bun test`

## Problem
`bun test` failed when running all tests in parallel because `plugin.test.ts` used `mock.module()` to mock `node:fs/promises.mkdir`, which leaked to other test files (like `sync.test.ts`) causing their `mkdir` calls to silently do nothing.

## Solution
Use dependency injection instead of global module mocking. The `fetchPlugin()` function now accepts an optional `deps` parameter for testing, keeping tests isolated without polluting the module registry.

## Test plan
- [x] `bun test` passes with all 173 tests running in parallel
- [x] `bun run typecheck` passes
- [x] Pre-push hooks pass (lint, typecheck, test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)