### PR TITLE
refactor(cli): move update command under self namespace

### DIFF
--- a/src/cli/commands/self.ts
+++ b/src/cli/commands/self.ts
@@ -37,7 +37,11 @@ function getCurrentVersion(): string {
   }
 }
 
-export const updateCommand = new Command('update')
+export const selfCommand = new Command('self')
+  .description('Manage the allagents installation');
+
+selfCommand
+  .command('update')
   .description('Update allagents to the latest version')
   .option('--npm', 'Force update using npm')
   .option('--bun', 'Force update using bun')

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -6,7 +6,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { workspaceCommand } from './commands/workspace.js';
 import { pluginCommand } from './commands/plugin.js';
-import { updateCommand } from './commands/update.js';
+import { selfCommand } from './commands/self.js';
 
 // Read version from package.json
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -25,6 +25,6 @@ program
 // Add commands
 program.addCommand(workspaceCommand);
 program.addCommand(pluginCommand);
-program.addCommand(updateCommand);
+program.addCommand(selfCommand);
 
 program.parse();

--- a/tests/unit/cli/update.test.ts
+++ b/tests/unit/cli/update.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'bun:test';
-import { detectPackageManagerFromPath } from '../../../src/cli/commands/update.js';
+import { detectPackageManagerFromPath } from '../../../src/cli/commands/self.js';
 
 describe('update command', () => {
   describe('detectPackageManagerFromPath', () => {


### PR DESCRIPTION
## Summary
- Moves the `update` command under a new `self` parent command, changing usage from `allagents update` to `allagents self update`
- Follows the industry-standard pattern used by `rustup self update` and `composer self-update` for CLI self-management
- The `self` namespace is ready for future subcommands (e.g., `self version`, `self uninstall`)

## Test plan
- [x] All 257 existing tests pass
- [x] `allagents self --help` shows the update subcommand
- [x] `allagents self update --help` shows --npm and --bun options
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)