### PR TITLE
refactor(cli): rename workspace plugin add to install

### DIFF
--- a/.claude/commands/allagents/workspace.md
+++ b/.claude/commands/allagents/workspace.md
@@ -15,7 +15,7 @@ Help the user manage their allagents workspace by running CLI commands and editi
 | `init` | `allagents workspace init <path>` | Create new workspace from template |
 | `sync` | `allagents workspace sync [--offline] [--dry-run] [--client <client>]` | Sync plugins to all repositories |
 | `status` | `allagents workspace status` | Show plugin and client status |
-| `add` | `allagents workspace add <plugin>` | Add a plugin (local path or GitHub URL) |
+| `install` | `allagents workspace plugin install <plugin>` | Install a plugin (local path or GitHub URL) |
 | `remove` | `allagents workspace remove <plugin>` | Remove a plugin from workspace |
 
 ## Sync Options
@@ -32,7 +32,7 @@ Based on user's request or provided arguments:
 2. **"init" subcommand**: Run `allagents workspace init <path>` with provided path
 3. **"sync" subcommand**: Run `allagents workspace sync` with any flags
 4. **"status" subcommand**: Run `allagents workspace status`
-5. **"add" subcommand**: Run `allagents workspace add <plugin>` with provided plugin
+5. **"install" subcommand**: Run `allagents workspace plugin install <plugin>` with provided plugin
 6. **"remove" subcommand**: Run `allagents workspace remove <plugin>` with provided plugin
 
 ## workspace.yaml Structure

--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ allagents workspace init my-workspace --from owner/repo/path/to/template
 # Add a marketplace (or let auto-registration handle it)
 allagents plugin marketplace add anthropics/claude-plugins-official
 
-# Add plugins to workspace
-allagents workspace plugin add code-review@claude-plugins-official
-allagents workspace plugin add my-plugin@someuser/their-repo
+# Install plugins to workspace
+allagents workspace plugin install code-review@claude-plugins-official
+allagents workspace plugin install my-plugin@someuser/their-repo
 
 # Sync plugins to workspace
 allagents workspace sync
@@ -113,8 +113,8 @@ allagents workspace sync [options]
 # Show status of workspace and plugins
 allagents workspace status
 
-# Add a plugin to .allagents/workspace.yaml (auto-registers marketplace if needed)
-allagents workspace plugin add <plugin@marketplace>
+# Install a plugin to .allagents/workspace.yaml (auto-registers marketplace if needed)
+allagents workspace plugin install <plugin@marketplace>
 
 # Remove a plugin from .allagents/workspace.yaml
 allagents workspace plugin remove <plugin>

--- a/docs/src/content/docs/getting-started/quick-start.mdx
+++ b/docs/src/content/docs/getting-started/quick-start.mdx
@@ -26,10 +26,10 @@ allagents workspace init my-workspace --from myorg/templates/nodejs
 
 This fetches the workspace configuration directly from GitHub and sets up your workspace instantly.
 
-## Add Plugins
+## Install Plugins
 
 ```bash
-allagents workspace plugin add code-review@claude-plugins-official
+allagents workspace plugin install code-review@claude-plugins-official
 ```
 
 ## Sync Plugins

--- a/docs/src/content/docs/reference/cli.mdx
+++ b/docs/src/content/docs/reference/cli.mdx
@@ -9,7 +9,7 @@ description: Complete reference for AllAgents CLI commands.
 allagents workspace init <path> [--from <source>]
 allagents workspace sync [--offline] [--dry-run] [--client <client>]
 allagents workspace status
-allagents workspace plugin add <plugin@marketplace>
+allagents workspace plugin install <plugin@marketplace>
 allagents workspace plugin remove <plugin>
 ```
 

--- a/src/cli/commands/workspace.ts
+++ b/src/cli/commands/workspace.ts
@@ -271,9 +271,9 @@ const pluginSubcommand = new Command('plugin').description(
 );
 
 pluginSubcommand
-  .command('add <plugin>')
+  .command('install <plugin>')
   .description(
-    'Add plugin to .allagents/workspace.yaml (supports plugin@marketplace, GitHub URL, or local path)',
+    'Install plugin to .allagents/workspace.yaml (supports plugin@marketplace, GitHub URL, or local path)',
   )
   .action(async (plugin: string) => {
     try {
@@ -287,7 +287,7 @@ pluginSubcommand
       if (result.autoRegistered) {
         console.log(`✓ Auto-registered marketplace: ${result.autoRegistered}`);
       }
-      console.log(`✓ Added plugin: ${plugin}`);
+      console.log(`✓ Installed plugin: ${plugin}`);
 
       const syncOk = await runSyncAndPrint();
       if (!syncOk) {


### PR DESCRIPTION
## Summary
- Renames `allagents workspace plugin add` to `allagents workspace plugin install`
- Aligns with industry-standard CLI conventions (e.g., `claude plugin install`, `npm install`)
- Updates all documentation: README, CLI reference, quick start guide, and Claude command helper

## Test plan
- [x] All 257 tests pass
- [x] `allagents workspace plugin --help` shows `install` subcommand
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)