### PR TITLE
refactor(cli): rename workspace plugin remove to uninstall

### DIFF
--- a/src/cli/commands/workspace.ts
+++ b/src/cli/commands/workspace.ts
@@ -303,8 +303,9 @@ pluginSubcommand
   });
 
 pluginSubcommand
-  .command('remove <plugin>')
-  .description('Remove plugin from .allagents/workspace.yaml')
+  .command('uninstall <plugin>')
+  .alias('remove')
+  .description('Uninstall plugin from .allagents/workspace.yaml')
   .action(async (plugin: string) => {
     try {
       const result = await removePlugin(plugin);
@@ -314,7 +315,7 @@ pluginSubcommand
         process.exit(1);
       }
 
-      console.log(`✓ Removed plugin: ${plugin}`);
+      console.log(`✓ Uninstalled plugin: ${plugin}`);
 
       const syncOk = await runSyncAndPrint();
       if (!syncOk) {


### PR DESCRIPTION
## Summary
- Renames `workspace plugin remove` to `workspace plugin uninstall` as the primary command
- Keeps `remove` as an alias for backwards compatibility
- Aligns with Claude Code's CLI convention (`uninstall|remove`)

Closes #37

## Test plan
- [x] Pre-commit hooks pass (lint, typecheck, tests)
- [ ] Verify `allagents workspace plugin uninstall <plugin>` works
- [ ] Verify `allagents workspace plugin remove <plugin>` still works as alias
- [ ] Verify help output shows `uninstall|remove <plugin>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)