### PR TITLE
refactor(cli): migrate from Commander.js to cmd-ts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "allagents",
       "dependencies": {
-        "commander": "^11.1.0",
+        "cmd-ts": "^0.14.3",
         "execa": "^8.0.1",
         "fast-glob": "^3.3.3",
         "gray-matter": "^4.0.3",
@@ -60,6 +60,8 @@
 
     "@types/node": ["@types/node@20.19.30", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g=="],
 
+    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
@@ -74,21 +76,27 @@
 
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
+    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
     "clone": ["clone@1.0.4", "", {}, "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg=="],
 
-    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+    "cmd-ts": ["cmd-ts@0.14.3", "", { "dependencies": { "chalk": "^5.4.1", "debug": "^4.4.1", "didyoumean": "^1.2.2", "strip-ansi": "^7.1.0" } }, "sha512-i9miaLBHGPn4T4vUFUdAdWoQ9HI8ato6usFrhubO21o/MQGqI6Nsqyd4ncZusT2chvPetNMmTt0JWkbaAOdWPg=="],
 
-    "commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
+    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 
     "console.table": ["console.table@0.10.0", "", { "dependencies": { "easy-table": "1.1.0" } }, "sha512-dPyZofqggxuvSf7WXvNjuRfnsOk1YazkVP8FdxH4tcH2c37wc79/Yl6Bhr7Lsu00KMgy2ql/qCMuNu8xctZM8g=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "defaults": ["defaults@1.0.4", "", { "dependencies": { "clone": "^1.0.2" } }, "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A=="],
 
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "didyoumean": ["didyoumean@1.2.2", "", {}, "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
@@ -186,6 +194,8 @@
 
     "minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
 
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
     "nice-try": ["nice-try@1.0.5", "", {}, "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="],
 
     "npm-run-path": ["npm-run-path@5.3.0", "", { "dependencies": { "path-key": "^4.0.0" } }, "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ=="],
@@ -237,6 +247,8 @@
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
+
+    "strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
     "strip-bom-string": ["strip-bom-string@1.0.0", "", {}, "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g=="],
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "commander": "^11.1.0",
+    "cmd-ts": "^0.14.3",
     "execa": "^8.0.1",
     "fast-glob": "^3.3.3",
     "gray-matter": "^4.0.3",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,30 +1,27 @@
 #!/usr/bin/env node
 
-import { Command } from 'commander';
+import { subcommands, run } from 'cmd-ts';
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { workspaceCommand } from './commands/workspace.js';
-import { pluginCommand } from './commands/plugin.js';
-import { selfCommand } from './commands/self.js';
+import { workspaceCmd } from './commands/workspace.js';
+import { pluginCmd } from './commands/plugin.js';
+import { selfCmd } from './commands/self.js';
 
 // Read version from package.json
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const packageJsonPath = join(__dirname, '..', 'package.json');
 const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
 
-const program = new Command();
+const app = subcommands({
+  name: 'allagents',
+  description: 'CLI tool for managing multi-repo AI agent workspaces with plugin synchronization',
+  version: packageJson.version,
+  cmds: {
+    workspace: workspaceCmd,
+    plugin: pluginCmd,
+    self: selfCmd,
+  },
+});
 
-program
-  .name('allagents')
-  .description(
-    'CLI tool for managing multi-repo AI agent workspaces with plugin synchronization',
-  )
-  .version(packageJson.version);
-
-// Add commands
-program.addCommand(workspaceCommand);
-program.addCommand(pluginCommand);
-program.addCommand(selfCommand);
-
-program.parse();
+run(app, process.argv.slice(2));

--- a/tests/e2e/cli-help.test.ts
+++ b/tests/e2e/cli-help.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from 'bun:test';
+import { execa } from 'execa';
+import { resolve } from 'node:path';
+
+const CLI = resolve(import.meta.dir, '../../dist/index.js');
+
+async function runCli(args: string[]) {
+  try {
+    const result = await execa('node', [CLI, ...args]);
+    return { stdout: result.stdout, stderr: result.stderr, exitCode: 0 };
+  } catch (error: any) {
+    return { stdout: error.stdout || '', stderr: error.stderr || '', exitCode: error.exitCode || 1 };
+  }
+}
+
+describe('CLI e2e help output', () => {
+  // 1. Root help
+  it('allagents --help outputs help text with workspace, plugin, self subcommands', async () => {
+    const { stdout, exitCode } = await runCli(['--help']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('workspace');
+    expect(stdout).toContain('plugin');
+    expect(stdout).toContain('self');
+  });
+
+  // 2. Version
+  it('allagents --version outputs version matching package.json', async () => {
+    const pkg = await import('../../package.json');
+    const { stdout, exitCode } = await runCli(['--version']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain(pkg.version);
+  });
+
+  // 3. Workspace help
+  it('allagents workspace --help lists init, sync, status, plugin subcommands', async () => {
+    const { stdout, exitCode } = await runCli(['workspace', '--help']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('init');
+    expect(stdout).toContain('sync');
+    expect(stdout).toContain('status');
+    expect(stdout).toContain('plugin');
+  });
+
+  // 4. Workspace sync help
+  it('allagents workspace sync --help shows --offline, --dry-run/-n, --client/-c flags', async () => {
+    const { stdout, exitCode } = await runCli(['workspace', 'sync', '--help']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('--offline');
+    expect(stdout).toContain('--dry-run');
+    expect(stdout).toMatch(/-n[\s,]/);
+    expect(stdout).toContain('--client');
+    expect(stdout).toMatch(/-c[\s,]/);
+  });
+
+  // 5. Workspace init help
+  it('allagents workspace init --help shows optional path positional and --from option', async () => {
+    const { stdout, exitCode } = await runCli(['workspace', 'init', '--help']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('path');
+    expect(stdout).toContain('--from');
+  });
+
+  // 6. Workspace status help
+  it('allagents workspace status --help exits 0', async () => {
+    const { stdout, exitCode } = await runCli(['workspace', 'status', '--help']);
+    expect(exitCode).toBe(0);
+    expect(stdout.length).toBeGreaterThan(0);
+  });
+
+  // 7. Workspace plugin help
+  it('allagents workspace plugin --help lists install and uninstall subcommands', async () => {
+    const { stdout, exitCode } = await runCli(['workspace', 'plugin', '--help']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('install');
+    expect(stdout).toContain('uninstall');
+  });
+
+  // 8. Workspace plugin install help
+  it('allagents workspace plugin install --help shows required plugin positional', async () => {
+    const { stdout, exitCode } = await runCli(['workspace', 'plugin', 'install', '--help']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('plugin');
+  });
+
+  // 9. Workspace plugin uninstall help and alias shown in parent
+  it('allagents workspace plugin uninstall --help exits 0', async () => {
+    const { stdout, exitCode } = await runCli(['workspace', 'plugin', 'uninstall', '--help']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('plugin');
+  });
+
+  it('allagents workspace plugin --help shows remove alias for uninstall', async () => {
+    const { stdout, exitCode } = await runCli(['workspace', 'plugin', '--help']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('remove');
+  });
+
+  // 10. Plugin help
+  it('allagents plugin --help lists marketplace, list, validate subcommands', async () => {
+    const { stdout, exitCode } = await runCli(['plugin', '--help']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('marketplace');
+    expect(stdout).toContain('list');
+    expect(stdout).toContain('validate');
+  });
+
+  // 11. Plugin marketplace help
+  it('allagents plugin marketplace --help lists list, add, remove, update', async () => {
+    const { stdout, exitCode } = await runCli(['plugin', 'marketplace', '--help']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('list');
+    expect(stdout).toContain('add');
+    expect(stdout).toContain('remove');
+    expect(stdout).toContain('update');
+  });
+
+  // 12. Plugin marketplace add help
+  it('allagents plugin marketplace add --help shows --name/-n option', async () => {
+    const { stdout, exitCode } = await runCli(['plugin', 'marketplace', 'add', '--help']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('--name');
+    expect(stdout).toMatch(/-n[\s,]/);
+  });
+
+  // 13. Plugin list help
+  it('allagents plugin list --help shows optional marketplace positional', async () => {
+    const { stdout, exitCode } = await runCli(['plugin', 'list', '--help']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toMatch(/marketplace/i);
+  });
+
+  // 14. Plugin validate help
+  it('allagents plugin validate --help shows required path positional', async () => {
+    const { stdout, exitCode } = await runCli(['plugin', 'validate', '--help']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('path');
+  });
+
+  // 15. Self help
+  it('allagents self --help lists update subcommand', async () => {
+    const { stdout, exitCode } = await runCli(['self', '--help']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('update');
+  });
+
+  // 16. Self update help
+  it('allagents self update --help shows --npm and --bun flags', async () => {
+    const { stdout, exitCode } = await runCli(['self', 'update', '--help']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('--npm');
+    expect(stdout).toContain('--bun');
+  });
+});
+
+describe('CLI e2e error cases', () => {
+  // 17. Unknown subcommand
+  it('allagents unknown exits with non-zero and stderr has error message', async () => {
+    const { stderr, exitCode } = await runCli(['unknown']);
+    expect(exitCode).not.toBe(0);
+    expect(stderr.length).toBeGreaterThan(0);
+  });
+
+  // 18. Missing required arg
+  it('allagents workspace plugin install (no plugin arg) exits with non-zero', async () => {
+    const { exitCode } = await runCli(['workspace', 'plugin', 'install']);
+    expect(exitCode).not.toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Replace Commander.js with cmd-ts for type-safe CLI argument parsing
- Same commands, same behavior, same output — no user-facing changes
- Add 19 e2e tests covering all CLI help output and error cases
- Remove `commander` dependency, add `cmd-ts@0.14.3`

## Test plan
- [x] All 276 tests pass (257 existing + 19 new e2e)
- [x] Build succeeds (0.79 MB bundle)
- [x] CLI smoke tests: `--help`, `--version`, all nested subcommand help
- [x] Pre-push hooks pass (lint, typecheck, test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)