### PR TITLE
feat(cli): add enriched help text with examples and metadata

### DIFF
--- a/src/cli/commands/plugin.ts
+++ b/src/cli/commands/plugin.ts
@@ -8,6 +8,15 @@ import {
   getWellKnownMarketplaces,
 } from '../../core/marketplace.js';
 import { isJsonMode, jsonOutput } from '../json-output.js';
+import { buildDescription } from '../help.js';
+import {
+  marketplaceListMeta,
+  marketplaceAddMeta,
+  marketplaceRemoveMeta,
+  marketplaceUpdateMeta,
+  pluginListMeta,
+  pluginValidateMeta,
+} from '../metadata/plugin.js';
 
 // =============================================================================
 // plugin marketplace list
@@ -15,7 +24,7 @@ import { isJsonMode, jsonOutput } from '../json-output.js';
 
 const marketplaceListCmd = command({
   name: 'list',
-  description: 'List registered marketplaces',
+  description: buildDescription(marketplaceListMeta),
   args: {},
   handler: async () => {
     try {
@@ -81,7 +90,7 @@ const marketplaceListCmd = command({
 
 const marketplaceAddCmd = command({
   name: 'add',
-  description: 'Add a marketplace from GitHub URL, owner/repo, local path, or well-known name',
+  description: buildDescription(marketplaceAddMeta),
   args: {
     source: positional({ type: string, displayName: 'source' }),
     name: option({ type: optional(string), long: 'name', short: 'n', description: 'Custom name for the marketplace' }),
@@ -139,7 +148,7 @@ const marketplaceAddCmd = command({
 
 const marketplaceRemoveCmd = command({
   name: 'remove',
-  description: 'Remove a marketplace from registry (does not delete files)',
+  description: buildDescription(marketplaceRemoveMeta),
   args: {
     name: positional({ type: string, displayName: 'name' }),
   },
@@ -190,7 +199,7 @@ const marketplaceRemoveCmd = command({
 
 const marketplaceUpdateCmd = command({
   name: 'update',
-  description: 'Update marketplace(s) from remote',
+  description: buildDescription(marketplaceUpdateMeta),
   args: {
     name: positional({ type: optional(string), displayName: 'name' }),
   },
@@ -281,7 +290,7 @@ const marketplaceCmd = subcommands({
 
 const pluginListCmd = command({
   name: 'list',
-  description: 'List available plugins from registered marketplaces',
+  description: buildDescription(pluginListMeta),
   args: {
     marketplace: positional({ type: optional(string), displayName: 'marketplace' }),
   },
@@ -377,7 +386,7 @@ const pluginListCmd = command({
 
 const pluginValidateCmd = command({
   name: 'validate',
-  description: 'Validate plugin structure at the given path',
+  description: buildDescription(pluginValidateMeta),
   args: {
     path: positional({ type: string, displayName: 'path' }),
   },

--- a/src/cli/commands/self.ts
+++ b/src/cli/commands/self.ts
@@ -4,6 +4,8 @@ import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { isJsonMode, jsonOutput } from '../json-output.js';
+import { buildDescription } from '../help.js';
+import { updateMeta } from '../metadata/self.js';
 
 /**
  * Detect package manager from a script path
@@ -44,7 +46,7 @@ function getCurrentVersion(): string {
 
 const updateCmd = command({
   name: 'update',
-  description: 'Update allagents to the latest version',
+  description: buildDescription(updateMeta),
   args: {
     npm: flag({ long: 'npm', description: 'Force update using npm' }),
     bun: flag({ long: 'bun', description: 'Force update using bun' }),

--- a/src/cli/commands/workspace.ts
+++ b/src/cli/commands/workspace.ts
@@ -4,6 +4,8 @@ import { syncWorkspace } from '../../core/sync.js';
 import { getWorkspaceStatus } from '../../core/status.js';
 import { addPlugin, removePlugin } from '../../core/workspace-modify.js';
 import { isJsonMode, jsonOutput } from '../json-output.js';
+import { buildDescription } from '../help.js';
+import { initMeta, syncMeta, statusMeta, pluginInstallMeta, pluginUninstallMeta } from '../metadata/workspace.js';
 
 /**
  * Build a JSON-friendly sync data object from a sync result.
@@ -100,7 +102,7 @@ async function runSyncAndPrint(): Promise<{ ok: boolean; syncData: ReturnType<ty
 
 const initCmd = command({
   name: 'init',
-  description: 'Create new workspace and sync plugins',
+  description: buildDescription(initMeta),
   args: {
     path: positional({ type: optional(string), displayName: 'path' }),
     from: option({ type: optional(string), long: 'from', description: 'Copy workspace.yaml from existing template/workspace' }),
@@ -160,7 +162,7 @@ const initCmd = command({
 
 const syncCmd = command({
   name: 'sync',
-  description: 'Sync plugins to workspace',
+  description: buildDescription(syncMeta),
   args: {
     offline: flag({ long: 'offline', description: 'Use cached plugins without fetching latest from remote' }),
     dryRun: flag({ long: 'dry-run', short: 'n', description: 'Simulate sync without making changes' }),
@@ -299,7 +301,7 @@ const syncCmd = command({
 
 const statusCmd = command({
   name: 'status',
-  description: 'Show sync status of plugins',
+  description: buildDescription(statusMeta),
   args: {},
   handler: async () => {
     try {
@@ -369,7 +371,7 @@ const statusCmd = command({
 
 const pluginInstallCmd = command({
   name: 'install',
-  description: 'Install plugin to .allagents/workspace.yaml (supports plugin@marketplace, GitHub URL, or local path)',
+  description: buildDescription(pluginInstallMeta),
   args: {
     plugin: positional({ type: string, displayName: 'plugin' }),
   },
@@ -433,7 +435,7 @@ const pluginInstallCmd = command({
 
 const pluginUninstallCmd = command({
   name: 'uninstall',
-  description: 'Uninstall plugin from .allagents/workspace.yaml',
+  description: buildDescription(pluginUninstallMeta),
   aliases: ['remove'],
   args: {
     plugin: positional({ type: string, displayName: 'plugin' }),

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -1,0 +1,25 @@
+/**
+ * Command metadata type and help text builder for enriched --help output.
+ */
+export interface CommandMeta {
+  description: string;
+  whenToUse: string;
+  examples: string[];
+  expectedOutput: string;
+}
+
+/**
+ * Build an enriched description string from structured command metadata.
+ * The result is used as the `description` field in cmd-ts command definitions,
+ * so that --help output includes examples, when-to-use, and expected output.
+ */
+export function buildDescription(meta: CommandMeta): string {
+  let desc = meta.description;
+  desc += `\n\nWhen to use: ${meta.whenToUse}`;
+  desc += '\n\nExamples:';
+  for (const ex of meta.examples) {
+    desc += `\n  $ ${ex}`;
+  }
+  desc += `\n\nOutput: ${meta.expectedOutput}`;
+  return desc;
+}

--- a/src/cli/metadata/plugin.ts
+++ b/src/cli/metadata/plugin.ts
@@ -1,0 +1,68 @@
+import type { CommandMeta } from '../help.js';
+
+export const marketplaceListMeta: CommandMeta = {
+  description: 'List registered marketplaces',
+  whenToUse: 'To see which plugin marketplaces are currently registered on your system',
+  examples: [
+    'allagents plugin marketplace list',
+  ],
+  expectedOutput:
+    'Shows each marketplace with source, path, and last updated date. If none registered, shows well-known marketplace suggestions.',
+};
+
+export const marketplaceAddMeta: CommandMeta = {
+  description: 'Add a marketplace from GitHub URL, owner/repo, local path, or well-known name',
+  whenToUse: 'To register a new marketplace so its plugins become available for installation',
+  examples: [
+    'allagents plugin marketplace add official',
+    'allagents plugin marketplace add https://github.com/user/marketplace',
+    'allagents plugin marketplace add user/marketplace --name custom',
+    'allagents plugin marketplace add ../local-marketplace',
+  ],
+  expectedOutput:
+    'Confirms the marketplace was added with its name and local path. Exit 1 if the source is invalid or unreachable.',
+};
+
+export const marketplaceRemoveMeta: CommandMeta = {
+  description: 'Remove a marketplace from registry (does not delete files)',
+  whenToUse: 'To unregister a marketplace you no longer need, without deleting its cached files',
+  examples: [
+    'allagents plugin marketplace remove official',
+    'allagents plugin marketplace remove custom',
+  ],
+  expectedOutput:
+    'Confirms removal from registry and notes that files were not deleted. Exit 1 if marketplace not found.',
+};
+
+export const marketplaceUpdateMeta: CommandMeta = {
+  description: 'Update marketplace(s) from remote',
+  whenToUse: 'To pull the latest plugin definitions from remote marketplace repositories',
+  examples: [
+    'allagents plugin marketplace update',
+    'allagents plugin marketplace update official',
+  ],
+  expectedOutput:
+    'Shows update status per marketplace. Exit 0 if all succeed, exit 1 if any fail.',
+};
+
+export const pluginListMeta: CommandMeta = {
+  description: 'List available plugins from registered marketplaces',
+  whenToUse: 'To browse available plugins before installing one into your workspace',
+  examples: [
+    'allagents plugin list',
+    'allagents plugin list official',
+  ],
+  expectedOutput:
+    'Lists plugins grouped by marketplace with install-ready names (plugin@marketplace). Shows total count.',
+};
+
+export const pluginValidateMeta: CommandMeta = {
+  description: 'Validate plugin structure at the given path',
+  whenToUse: 'When developing a plugin, to check that its structure conforms to the expected format',
+  examples: [
+    'allagents plugin validate ./my-plugin',
+    'allagents plugin validate ../shared-plugins/eslint-config',
+  ],
+  expectedOutput:
+    'Reports validation results. Exit 0 if valid, exit 1 if structure errors are found.',
+};

--- a/src/cli/metadata/self.ts
+++ b/src/cli/metadata/self.ts
@@ -1,0 +1,13 @@
+import type { CommandMeta } from '../help.js';
+
+export const updateMeta: CommandMeta = {
+  description: 'Update allagents to the latest version',
+  whenToUse: 'To upgrade allagents to the latest published version using your package manager',
+  examples: [
+    'allagents self update',
+    'allagents self update --npm',
+    'allagents self update --bun',
+  ],
+  expectedOutput:
+    'Shows current version, runs the update, then shows the new version. Exit 1 if the update fails.',
+};

--- a/src/cli/metadata/workspace.ts
+++ b/src/cli/metadata/workspace.ts
@@ -1,0 +1,59 @@
+import type { CommandMeta } from '../help.js';
+
+export const initMeta: CommandMeta = {
+  description: 'Create new workspace and sync plugins',
+  whenToUse: 'When starting a new project or adding allagents to an existing repo for the first time',
+  examples: [
+    'allagents workspace init',
+    'allagents workspace init ./my-project',
+    'allagents workspace init --from ../template-workspace/.allagents/workspace.yaml',
+  ],
+  expectedOutput:
+    'Creates .allagents/workspace.yaml and syncs plugins. Shows sync results per plugin. Exit 0 on success, exit 1 on failure.',
+};
+
+export const syncMeta: CommandMeta = {
+  description: 'Sync plugins to workspace',
+  whenToUse: 'After modifying workspace.yaml or pulling shared config changes',
+  examples: [
+    'allagents workspace sync',
+    'allagents workspace sync --dry-run',
+    'allagents workspace sync --client claude',
+    'allagents workspace sync --offline',
+  ],
+  expectedOutput:
+    'Lists synced files with status per plugin. Exit 0 on success, exit 1 if any files failed.',
+};
+
+export const statusMeta: CommandMeta = {
+  description: 'Show sync status of plugins',
+  whenToUse: 'To check which plugins are configured and whether they are available locally',
+  examples: [
+    'allagents workspace status',
+  ],
+  expectedOutput:
+    'Lists all configured plugins with availability status and configured clients. Exit 0 on success, exit 1 if workspace is not initialized.',
+};
+
+export const pluginInstallMeta: CommandMeta = {
+  description: 'Install plugin to .allagents/workspace.yaml (supports plugin@marketplace, GitHub URL, or local path)',
+  whenToUse: 'To add a new plugin to your workspace and immediately sync it',
+  examples: [
+    'allagents workspace plugin install my-plugin@official',
+    'allagents workspace plugin install https://github.com/user/plugin',
+    'allagents workspace plugin install ../local-plugin',
+  ],
+  expectedOutput:
+    'Confirms the plugin was added, then runs sync. Shows sync results. Exit 0 on success, exit 1 on failure.',
+};
+
+export const pluginUninstallMeta: CommandMeta = {
+  description: 'Uninstall plugin from .allagents/workspace.yaml',
+  whenToUse: 'To remove a plugin from your workspace config and re-sync',
+  examples: [
+    'allagents workspace plugin uninstall my-plugin@official',
+    'allagents workspace plugin uninstall https://github.com/user/plugin',
+  ],
+  expectedOutput:
+    'Confirms the plugin was removed, then runs sync to clean up. Exit 0 on success, exit 1 on failure.',
+};

--- a/tests/e2e/cli-enriched-help.test.ts
+++ b/tests/e2e/cli-enriched-help.test.ts
@@ -1,0 +1,79 @@
+import { describe, test, expect } from 'bun:test';
+import { buildDescription, type CommandMeta } from '../../src/cli/help.js';
+import { initMeta, syncMeta, statusMeta, pluginInstallMeta, pluginUninstallMeta } from '../../src/cli/metadata/workspace.js';
+import { marketplaceListMeta, marketplaceAddMeta, marketplaceRemoveMeta, marketplaceUpdateMeta, pluginListMeta, pluginValidateMeta } from '../../src/cli/metadata/plugin.js';
+import { updateMeta } from '../../src/cli/metadata/self.js';
+
+/**
+ * All command metadata objects that must have enriched help.
+ */
+const allCommandMetas: { name: string; meta: CommandMeta }[] = [
+  { name: 'workspace init', meta: initMeta },
+  { name: 'workspace sync', meta: syncMeta },
+  { name: 'workspace status', meta: statusMeta },
+  { name: 'workspace plugin install', meta: pluginInstallMeta },
+  { name: 'workspace plugin uninstall', meta: pluginUninstallMeta },
+  { name: 'plugin marketplace list', meta: marketplaceListMeta },
+  { name: 'plugin marketplace add', meta: marketplaceAddMeta },
+  { name: 'plugin marketplace remove', meta: marketplaceRemoveMeta },
+  { name: 'plugin marketplace update', meta: marketplaceUpdateMeta },
+  { name: 'plugin list', meta: pluginListMeta },
+  { name: 'plugin validate', meta: pluginValidateMeta },
+  { name: 'self update', meta: updateMeta },
+];
+
+describe('buildDescription', () => {
+  test('produces a string containing all enriched sections', () => {
+    const meta: CommandMeta = {
+      description: 'Test command',
+      whenToUse: 'When testing',
+      examples: ['allagents test', 'allagents test --flag'],
+      expectedOutput: 'Shows test output.',
+    };
+    const desc = buildDescription(meta);
+    expect(desc).toContain('Test command');
+    expect(desc).toContain('When to use: When testing');
+    expect(desc).toContain('Examples:');
+    expect(desc).toContain('$ allagents test');
+    expect(desc).toContain('$ allagents test --flag');
+    expect(desc).toContain('Output: Shows test output.');
+  });
+});
+
+describe('enriched help metadata', () => {
+  for (const { name, meta } of allCommandMetas) {
+    describe(name, () => {
+      test('has a non-empty description', () => {
+        expect(meta.description.length).toBeGreaterThan(0);
+      });
+
+      test('has a non-empty whenToUse', () => {
+        expect(meta.whenToUse.length).toBeGreaterThan(0);
+      });
+
+      test('has at least one example', () => {
+        expect(meta.examples.length).toBeGreaterThanOrEqual(1);
+      });
+
+      test('has a non-empty expectedOutput', () => {
+        expect(meta.expectedOutput.length).toBeGreaterThan(0);
+      });
+
+      test('buildDescription output includes "When to use:" section', () => {
+        const desc = buildDescription(meta);
+        expect(desc).toContain('When to use:');
+      });
+
+      test('buildDescription output includes "Examples:" section with at least one $ example', () => {
+        const desc = buildDescription(meta);
+        expect(desc).toContain('Examples:');
+        expect(desc).toMatch(/\$ /);
+      });
+
+      test('buildDescription output includes "Output:" section', () => {
+        const desc = buildDescription(meta);
+        expect(desc).toContain('Output:');
+      });
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- Add structured metadata (examples, when-to-use, expected output) to every command's --help
- Create `src/cli/metadata/` with typed metadata per command group
- Create `src/cli/help.ts` with `CommandMeta` type and `buildDescription()` helper
- Metadata renders inline in cmd-ts descriptions — no monkey-patching needed

## Test plan
- [x] E2e tests verify all 12 commands have Examples, When to use, and Output sections
- [x] All 361 tests pass (257 existing + 19 cmd-ts e2e + 85 enriched help)
- [x] Build succeeds, pre-push hooks pass (lint, typecheck, test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)