### PR TITLE
fix(tui): erase cancelled prompt instead of showing strikethrough

### DIFF
--- a/src/cli/tui/actions/init.ts
+++ b/src/cli/tui/actions/init.ts
@@ -1,5 +1,6 @@
 import * as p from '@clack/prompts';
 import { initWorkspace } from '../../../core/workspace.js';
+import { text } from '../prompts.js';
 
 /**
  * Guided workspace initialization action.
@@ -7,7 +8,7 @@ import { initWorkspace } from '../../../core/workspace.js';
  */
 export async function runInit(): Promise<void> {
   try {
-    const targetPath = await p.text({
+    const targetPath = await text({
       message: 'Where should the workspace be created?',
       placeholder: '.',
       defaultValue: '.',
@@ -17,7 +18,7 @@ export async function runInit(): Promise<void> {
       return;
     }
 
-    const fromSource = await p.text({
+    const fromSource = await text({
       message: 'Template source (leave empty for default)',
       placeholder: 'GitHub URL, path, or leave empty',
       defaultValue: '',

--- a/src/cli/tui/actions/plugins.ts
+++ b/src/cli/tui/actions/plugins.ts
@@ -14,6 +14,7 @@ import {
 import { getWorkspaceStatus } from '../../../core/status.js';
 import type { TuiContext } from '../context.js';
 import type { TuiCache } from '../cache.js';
+import { select, multiselect, text, confirm } from '../prompts.js';
 
 /**
  * Get marketplace list, using cache when available.
@@ -56,7 +57,7 @@ async function installSelectedPlugin(
   // Determine scope
   let scope: 'project' | 'user' = 'user';
   if (context.hasWorkspace) {
-    const scopeChoice = await p.select({
+    const scopeChoice = await select({
       message: 'Install scope',
       options: [
         { label: 'Project (this workspace)', value: 'project' as const },
@@ -144,7 +145,7 @@ export async function runInstallPlugin(context: TuiContext, cache?: TuiCache): P
       return;
     }
 
-    const selected = await p.select({
+    const selected = await select({
       message: 'Select a plugin to install',
       options: allPlugins,
     });
@@ -178,7 +179,7 @@ export async function runManagePlugins(context: TuiContext, cache?: TuiCache): P
       value: plugin.source,
     }));
 
-    const selected = await p.multiselect({
+    const selected = await multiselect({
       message: 'Select plugins to remove',
       options,
       required: false,
@@ -196,7 +197,7 @@ export async function runManagePlugins(context: TuiContext, cache?: TuiCache): P
     // Determine scope
     let scope: 'project' | 'user' = context.hasWorkspace ? 'project' : 'user';
     if (context.hasWorkspace) {
-      const scopeChoice = await p.select({
+      const scopeChoice = await select({
         message: 'Remove from which scope?',
         options: [
           { label: 'Project (this workspace)', value: 'project' as const },
@@ -266,7 +267,7 @@ export async function runBrowseMarketplaces(
         { label: 'Back', value: '__back__' },
       ];
 
-      const selected = await p.select({
+      const selected = await select({
         message: 'Marketplaces',
         options,
       });
@@ -276,7 +277,7 @@ export async function runBrowseMarketplaces(
       }
 
       if (selected === '__add__') {
-        const source = await p.text({
+        const source = await text({
           message: 'Marketplace source (GitHub URL, owner/repo, or name)',
           placeholder: 'e.g., anthropics/claude-plugins-official',
         });
@@ -320,7 +321,7 @@ async function runMarketplaceDetail(
   cache?: TuiCache,
 ): Promise<void> {
   while (true) {
-    const action = await p.select({
+    const action = await select({
       message: `Marketplace: ${marketplaceName}`,
       options: [
         { label: 'Browse plugins', value: 'browse' as const },
@@ -352,7 +353,7 @@ async function runMarketplaceDetail(
           });
         pluginOptions.push({ label: 'Back', value: '__back__' });
 
-        const selectedPlugin = await p.select({
+        const selectedPlugin = await select({
           message: 'Select a plugin to install',
           options: pluginOptions,
         });
@@ -394,7 +395,7 @@ async function runMarketplaceDetail(
     }
 
     if (action === 'remove') {
-      const confirmed = await p.confirm({
+      const confirmed = await confirm({
         message: `Remove marketplace "${marketplaceName}"?`,
       });
 

--- a/src/cli/tui/actions/update.ts
+++ b/src/cli/tui/actions/update.ts
@@ -1,5 +1,6 @@
 import * as p from '@clack/prompts';
 import { execa } from 'execa';
+import { confirm } from '../prompts.js';
 
 /**
  * Self-update action.
@@ -7,7 +8,7 @@ import { execa } from 'execa';
  */
 export async function runUpdate(): Promise<void> {
   try {
-    const confirmed = await p.confirm({
+    const confirmed = await confirm({
       message: 'Check for and install updates?',
     });
 

--- a/src/cli/tui/prompts.ts
+++ b/src/cli/tui/prompts.ts
@@ -1,0 +1,67 @@
+import * as p from '@clack/prompts';
+import { cursor, erase } from 'sisteransi';
+
+/**
+ * Erase the cancelled prompt output from the terminal.
+ *
+ * When @clack/prompts renders a cancel state, it shows the prompt message
+ * with the selected value crossed out (strikethrough). This is confusing
+ * because pressing ESC should cleanly return to the previous menu.
+ *
+ * This function moves the cursor up past the cancelled prompt's rendered
+ * lines and erases them, so the user sees a clean return.
+ */
+function eraseCancelledPrompt(lines = 2): void {
+  process.stdout.write(cursor.move(0, -lines) + erase.down());
+}
+
+type SelectOptions<T> = Parameters<typeof p.select<T>>[0];
+type MultiselectOptions<T> = Parameters<typeof p.multiselect<T>>[0];
+type TextOptions = Parameters<typeof p.text>[0];
+type ConfirmOptions = Parameters<typeof p.confirm>[0];
+
+/**
+ * Wrapper around p.select that erases the strikethrough on cancel.
+ */
+export async function select<T>(opts: SelectOptions<T>): Promise<T | symbol> {
+  const result = await p.select<T>(opts);
+  if (p.isCancel(result)) {
+    eraseCancelledPrompt();
+  }
+  return result;
+}
+
+/**
+ * Wrapper around p.multiselect that erases the strikethrough on cancel.
+ */
+export async function multiselect<T>(
+  opts: MultiselectOptions<T>,
+): Promise<T[] | symbol> {
+  const result = await p.multiselect<T>(opts);
+  if (p.isCancel(result)) {
+    eraseCancelledPrompt();
+  }
+  return result;
+}
+
+/**
+ * Wrapper around p.text that erases the strikethrough on cancel.
+ */
+export async function text(opts: TextOptions): Promise<string | symbol> {
+  const result = await p.text(opts);
+  if (p.isCancel(result)) {
+    eraseCancelledPrompt();
+  }
+  return result;
+}
+
+/**
+ * Wrapper around p.confirm that erases the strikethrough on cancel.
+ */
+export async function confirm(opts: ConfirmOptions): Promise<boolean | symbol> {
+  const result = await p.confirm(opts);
+  if (p.isCancel(result)) {
+    eraseCancelledPrompt();
+  }
+  return result;
+}

--- a/src/cli/tui/wizard.ts
+++ b/src/cli/tui/wizard.ts
@@ -4,6 +4,7 @@ import { relative } from 'node:path';
 import packageJson from '../../../package.json';
 import { TuiCache } from './cache.js';
 import { getTuiContext, type TuiContext } from './context.js';
+import { select } from './prompts.js';
 import { runInit } from './actions/init.js';
 import { runSync } from './actions/sync.js';
 import { runStatus } from './actions/status.js';
@@ -99,7 +100,7 @@ export async function runWizard(): Promise<void> {
   while (true) {
     p.note(buildSummary(context), 'Workspace');
 
-    const action = await p.select<MenuAction>({
+    const action = await select<MenuAction>({
       message: 'What would you like to do?',
       options: buildMenuOptions(context),
     });

--- a/tests/unit/cli/tui-prompts.test.ts
+++ b/tests/unit/cli/tui-prompts.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, mock, beforeEach, afterEach } from 'bun:test';
+
+// Mock @clack/prompts and sisteransi before importing the wrapper.
+// These mocks are scoped to this file — placed under tests/unit/cli/
+// to avoid leaking into src/cli/tui/__tests__/ where context.test.ts
+// imports real modules.
+const cancelSymbol = Symbol('clack:cancel');
+const mockSelect = mock(() => Promise.resolve('value' as unknown));
+const mockMultiselect = mock(() => Promise.resolve(['value'] as unknown));
+const mockText = mock(() => Promise.resolve('text' as unknown));
+const mockConfirm = mock(() => Promise.resolve(true as unknown));
+const mockIsCancel = mock((v: unknown) => v === cancelSymbol);
+
+mock.module('@clack/prompts', () => ({
+  select: mockSelect,
+  multiselect: mockMultiselect,
+  text: mockText,
+  confirm: mockConfirm,
+  isCancel: mockIsCancel,
+}));
+
+const mockCursorMove = mock(() => '\x1b[MOVE]');
+const mockEraseDown = mock(() => '\x1b[ERASE]');
+mock.module('sisteransi', () => ({
+  cursor: { move: mockCursorMove },
+  erase: { down: mockEraseDown },
+}));
+
+let stdoutWrites: string[] = [];
+const originalWrite = process.stdout.write;
+
+const { select, multiselect, text, confirm } = await import(
+  '../../../src/cli/tui/prompts.js'
+);
+
+describe('TUI prompt wrappers', () => {
+  beforeEach(() => {
+    stdoutWrites = [];
+    process.stdout.write = ((data: string) => {
+      stdoutWrites.push(data);
+      return true;
+    }) as typeof process.stdout.write;
+  });
+
+  afterEach(() => {
+    process.stdout.write = originalWrite;
+    mockSelect.mockReset();
+    mockMultiselect.mockReset();
+    mockText.mockReset();
+    mockConfirm.mockReset();
+    mockCursorMove.mockReset();
+    mockEraseDown.mockReset();
+  });
+
+  describe('select', () => {
+    it('returns value without erasing when not cancelled', async () => {
+      mockSelect.mockResolvedValueOnce('chosen');
+      const result = await select({ message: 'Pick', options: [] });
+      expect(result).toBe('chosen');
+      expect(stdoutWrites).toHaveLength(0);
+    });
+
+    it('erases prompt output when cancelled', async () => {
+      mockSelect.mockResolvedValueOnce(cancelSymbol);
+      const result = await select({ message: 'Pick', options: [] });
+      expect(result).toBe(cancelSymbol);
+      expect(mockCursorMove).toHaveBeenCalledWith(0, -2);
+      expect(mockEraseDown).toHaveBeenCalled();
+      expect(stdoutWrites.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('multiselect', () => {
+    it('returns value without erasing when not cancelled', async () => {
+      mockMultiselect.mockResolvedValueOnce(['a', 'b']);
+      const result = await multiselect({ message: 'Pick', options: [] });
+      expect(result).toEqual(['a', 'b']);
+      expect(stdoutWrites).toHaveLength(0);
+    });
+
+    it('erases prompt output when cancelled', async () => {
+      mockMultiselect.mockResolvedValueOnce(cancelSymbol);
+      const result = await multiselect({ message: 'Pick', options: [] });
+      expect(result).toBe(cancelSymbol);
+      expect(mockCursorMove).toHaveBeenCalledWith(0, -2);
+      expect(mockEraseDown).toHaveBeenCalled();
+    });
+  });
+
+  describe('text', () => {
+    it('returns value without erasing when not cancelled', async () => {
+      mockText.mockResolvedValueOnce('hello');
+      const result = await text({ message: 'Type' });
+      expect(result).toBe('hello');
+      expect(stdoutWrites).toHaveLength(0);
+    });
+
+    it('erases prompt output when cancelled', async () => {
+      mockText.mockResolvedValueOnce(cancelSymbol);
+      const result = await text({ message: 'Type' });
+      expect(result).toBe(cancelSymbol);
+      expect(mockCursorMove).toHaveBeenCalledWith(0, -2);
+      expect(mockEraseDown).toHaveBeenCalled();
+    });
+  });
+
+  describe('confirm', () => {
+    it('returns value without erasing when not cancelled', async () => {
+      mockConfirm.mockResolvedValueOnce(true);
+      const result = await confirm({ message: 'Sure?' });
+      expect(result).toBe(true);
+      expect(stdoutWrites).toHaveLength(0);
+    });
+
+    it('erases prompt output when cancelled', async () => {
+      mockConfirm.mockResolvedValueOnce(cancelSymbol);
+      const result = await confirm({ message: 'Sure?' });
+      expect(result).toBe(cancelSymbol);
+      expect(mockCursorMove).toHaveBeenCalledWith(0, -2);
+      expect(mockEraseDown).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- When pressing ESC in TUI menus, @clack/prompts renders the selected item with strikethrough styling, misleading users into thinking the item was removed
- Added `src/cli/tui/prompts.ts` with wrapper functions (`select`, `multiselect`, `text`, `confirm`) that detect cancellation and erase the cancelled prompt output using ANSI escape sequences
- ESC still functions as cancel (industry standard per fzf, bubbletea, clack) but the confusing strikethrough is replaced with a clean return to the parent menu
- Migrated all TUI prompt calls to use the wrappers

## Test plan
- [x] Unit tests for all 4 wrapper functions (cancel and non-cancel paths)
- [x] Manual: run `allagents`, navigate to "Manage marketplaces", press ESC — should return cleanly without strikethrough
- [x] Manual: run `allagents`, navigate to "Manage plugins", press ESC — same clean behavior

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)