### PR TITLE
feat(plugin): smart scope resolution for plugin uninstall

### DIFF
--- a/src/core/user-workspace.ts
+++ b/src/core/user-workspace.ts
@@ -113,6 +113,24 @@ export async function addUserPlugin(plugin: string): Promise<ModifyResult> {
 }
 
 /**
+ * Check if a plugin exists in the user-level workspace config.
+ * @param plugin - Plugin source to find (exact match or partial match)
+ * @returns true if the plugin is found
+ */
+export async function hasUserPlugin(plugin: string): Promise<boolean> {
+  const config = await getUserWorkspaceConfig();
+  if (!config) return false;
+
+  // Exact match first
+  if (config.plugins.indexOf(plugin) !== -1) return true;
+
+  // Partial match
+  return config.plugins.some(
+    (p) => p.startsWith(`${plugin}@`) || p === plugin,
+  );
+}
+
+/**
  * Remove a plugin from the user-level workspace config.
  */
 export async function removeUserPlugin(plugin: string): Promise<ModifyResult> {

--- a/src/core/workspace-modify.ts
+++ b/src/core/workspace-modify.ts
@@ -146,6 +146,39 @@ async function addPluginToConfig(
 }
 
 /**
+ * Check if a plugin exists in .allagents/workspace.yaml (project scope)
+ * @param plugin - Plugin source to find (exact match or partial match)
+ * @param workspacePath - Path to workspace directory (default: cwd)
+ * @returns true if the plugin is found
+ */
+export async function hasPlugin(
+  plugin: string,
+  workspacePath: string = process.cwd(),
+): Promise<boolean> {
+  const configPath = join(workspacePath, CONFIG_DIR, WORKSPACE_CONFIG_FILE);
+  if (!existsSync(configPath)) return false;
+
+  try {
+    const content = await readFile(configPath, 'utf-8');
+    const config = load(content) as WorkspaceConfig;
+
+    // Exact match first
+    if (config.plugins.indexOf(plugin) !== -1) return true;
+
+    // Partial match
+    if (!isPluginSpec(plugin)) {
+      return config.plugins.some(
+        (p) => p.startsWith(`${plugin}@`) || p === plugin,
+      );
+    }
+
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Remove a plugin from .allagents/workspace.yaml
  * @param plugin - Plugin source to remove (exact match or partial match)
  * @param workspacePath - Path to workspace directory (default: cwd)

--- a/tests/cli/plugin-uninstall-scope.test.ts
+++ b/tests/cli/plugin-uninstall-scope.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
+import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { dump } from 'js-yaml';
+
+describe('plugin uninstall smart scope resolution', () => {
+  let tempHome: string;
+  let tempProject: string;
+  let originalHome: string;
+
+  beforeEach(async () => {
+    tempHome = await mkdtemp(join(tmpdir(), 'allagents-uninstall-home-'));
+    tempProject = await mkdtemp(join(tmpdir(), 'allagents-uninstall-proj-'));
+    originalHome = process.env.HOME || '';
+    process.env.HOME = tempHome;
+  });
+
+  afterEach(async () => {
+    process.env.HOME = originalHome;
+    await rm(tempHome, { recursive: true, force: true });
+    await rm(tempProject, { recursive: true, force: true });
+  });
+
+  async function setupProjectWorkspace(plugins: string[]) {
+    const configDir = join(tempProject, '.allagents');
+    await mkdir(configDir, { recursive: true });
+    await writeFile(
+      join(configDir, 'workspace.yaml'),
+      dump({ repositories: [], plugins, clients: ['claude'] }, { lineWidth: -1 }),
+    );
+  }
+
+  async function setupUserWorkspace(plugins: string[]) {
+    const configDir = join(tempHome, '.allagents');
+    await mkdir(configDir, { recursive: true });
+    await writeFile(
+      join(configDir, 'workspace.yaml'),
+      dump({ repositories: [], plugins, clients: ['claude'] }, { lineWidth: -1 }),
+    );
+  }
+
+  test('hasPlugin returns true for exact match in project scope', async () => {
+    await setupProjectWorkspace(['my-plugin@marketplace']);
+    const { hasPlugin } = await import('../../src/core/workspace-modify.js');
+    expect(await hasPlugin('my-plugin@marketplace', tempProject)).toBe(true);
+  });
+
+  test('hasPlugin returns true for partial match in project scope', async () => {
+    await setupProjectWorkspace(['my-plugin@marketplace']);
+    const { hasPlugin } = await import('../../src/core/workspace-modify.js');
+    expect(await hasPlugin('my-plugin', tempProject)).toBe(true);
+  });
+
+  test('hasPlugin returns false when plugin not in project scope', async () => {
+    await setupProjectWorkspace(['other-plugin@marketplace']);
+    const { hasPlugin } = await import('../../src/core/workspace-modify.js');
+    expect(await hasPlugin('my-plugin', tempProject)).toBe(false);
+  });
+
+  test('hasPlugin returns false when no project workspace exists', async () => {
+    const { hasPlugin } = await import('../../src/core/workspace-modify.js');
+    expect(await hasPlugin('my-plugin', tempProject)).toBe(false);
+  });
+
+  test('hasUserPlugin returns true for exact match in user scope', async () => {
+    await setupUserWorkspace(['my-plugin@marketplace']);
+    const { hasUserPlugin } = await import('../../src/core/user-workspace.js');
+    expect(await hasUserPlugin('my-plugin@marketplace')).toBe(true);
+  });
+
+  test('hasUserPlugin returns true for partial match in user scope', async () => {
+    await setupUserWorkspace(['my-plugin@marketplace']);
+    const { hasUserPlugin } = await import('../../src/core/user-workspace.js');
+    expect(await hasUserPlugin('my-plugin')).toBe(true);
+  });
+
+  test('hasUserPlugin returns false when plugin not in user scope', async () => {
+    await setupUserWorkspace(['other-plugin@marketplace']);
+    const { hasUserPlugin } = await import('../../src/core/user-workspace.js');
+    expect(await hasUserPlugin('my-plugin')).toBe(false);
+  });
+
+  test('hasUserPlugin returns false when no user workspace exists', async () => {
+    const { hasUserPlugin } = await import('../../src/core/user-workspace.js');
+    expect(await hasUserPlugin('my-plugin')).toBe(false);
+  });
+
+  test('removePlugin succeeds when plugin is in project scope', async () => {
+    await setupProjectWorkspace(['my-plugin@marketplace']);
+    const { removePlugin } = await import('../../src/core/workspace-modify.js');
+    const result = await removePlugin('my-plugin@marketplace', tempProject);
+    expect(result.success).toBe(true);
+  });
+
+  test('removeUserPlugin succeeds when plugin is in user scope', async () => {
+    await setupUserWorkspace(['my-plugin@marketplace']);
+    const { removeUserPlugin } = await import('../../src/core/user-workspace.js');
+    const result = await removeUserPlugin('my-plugin@marketplace');
+    expect(result.success).toBe(true);
+  });
+
+  test('removePlugin fails when plugin only in user scope', async () => {
+    await setupProjectWorkspace([]);
+    await setupUserWorkspace(['my-plugin@marketplace']);
+    const { removePlugin } = await import('../../src/core/workspace-modify.js');
+    const result = await removePlugin('my-plugin@marketplace', tempProject);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('not found');
+  });
+});


### PR DESCRIPTION
## Summary

- When no `--scope` flag is given, `plugin uninstall` now checks both project and user scopes and removes the plugin from all scopes where it exists
- Adds `hasPlugin()` and `hasUserPlugin()` helpers for non-destructive scope lookup
- Always shows scope label in install/uninstall success messages (e.g. `(project scope)`, `(user scope)`, `(project + user scope)`)
- Shows clear `Plugin not found` error when plugin doesn't exist in any scope

**Before:** `allagents plugin uninstall foo` would fail if `foo` was only in user scope, requiring the user to guess `--scope user`.

**After:** `allagents plugin uninstall foo` finds and removes `foo` from whichever scope(s) it exists in.

## Test plan

- [x] New tests in `tests/cli/plugin-uninstall-scope.test.ts` (11 tests)
- [x] All existing tests pass (478 total, 0 failures)
- [ ] Manual test: install plugin in user scope, run `plugin uninstall <name>` without `--scope` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)