### PR TITLE
docs: add auto-update check and self update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,11 +299,25 @@ model: claude-3-opus    # Optional
 Skill instructions go here...
 ```
 
+### Self Commands
+
+```bash
+# Update to latest version (auto-detects package manager)
+allagents self update
+
+# Force a specific package manager
+allagents self update --npm
+allagents self update --bun
+```
+
+When using the interactive TUI, AllAgents automatically checks for newer versions in the background and shows a notice on startup when an update is available.
+
 ## Storage Locations
 
 ```
 ~/.allagents/
 ├── marketplaces.json              # Registry of marketplaces
+├── version-check.json             # Cached update check (auto-managed)
 └── marketplaces/                  # Cloned marketplace repos
     ├── claude-plugins-official/
     └── someuser-their-repo/

--- a/docs/src/content/docs/getting-started/installation.mdx
+++ b/docs/src/content/docs/getting-started/installation.mdx
@@ -32,3 +32,15 @@ After installation, verify it's working:
 ```bash
 allagents --version
 ```
+
+## Updating
+
+AllAgents automatically checks for new versions in the background when you use the interactive TUI. If an update is available, you'll see a notice on startup.
+
+To update manually:
+
+```bash
+allagents self update
+```
+
+This auto-detects whether you installed with npm or bun and uses the same package manager. You can also force a specific one with `--npm` or `--bun`.

--- a/docs/src/content/docs/reference/cli.mdx
+++ b/docs/src/content/docs/reference/cli.mdx
@@ -56,6 +56,36 @@ Sync state is tracked in `.allagents/sync-state.json`.
 
 When `--scope user` is used, the plugin is added to the user-level config at `~/.allagents/workspace.yaml` instead of the project workspace. User-scoped plugins sync to user directories (`~/.claude/`, `~/.codex/`, etc.) and are available across all projects.
 
+## Self Commands
+
+```bash
+allagents self update [--npm] [--bun]
+```
+
+### self update
+
+Update AllAgents to the latest published version.
+
+| Flag | Description |
+|------|-------------|
+| `--npm` | Force update using npm |
+| `--bun` | Force update using bun |
+
+If neither flag is provided, AllAgents auto-detects the package manager used during installation.
+
+### Automatic Update Notifications
+
+When running the interactive TUI (`allagents` with no arguments), AllAgents checks the npm registry for newer versions in the background. If an update is available, a notice is shown on the next startup:
+
+```
+allagents v0.13.4
+
+  ℹ Update available: 0.13.4 → 0.14.0
+    Run `allagents self update` to upgrade.
+```
+
+The check runs at most once every 24 hours and never blocks startup. Results are cached at `~/.allagents/version-check.json`.
+
 ## Plugin Commands
 
 ```bash


### PR DESCRIPTION
## Summary
- Add `Self Commands` section to CLI reference docs with `self update` command and auto-update notification behavior
- Add `Updating` section to installation docs
- Add self update commands and `version-check.json` to README storage locations

Follow-up to #74 (auto-update check feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)