### PR TITLE
fix: use path.join for cross-platform path in error message

### DIFF
--- a/src/core/marketplace.ts
+++ b/src/core/marketplace.ts
@@ -847,7 +847,7 @@ export async function resolvePluginSpecWithAutoRegister(
   if (!resolved) {
     return {
       success: false,
-      error: `Plugin '${pluginName}' not found in marketplace '${marketplaceName}'\n  Expected at: ${marketplace.path}/${expectedSubpath}/${pluginName}/`,
+      error: `Plugin '${pluginName}' not found in marketplace '${marketplaceName}'\n  Expected at: ${join(marketplace.path, expectedSubpath, pluginName)}`,
     };
   }
 


### PR DESCRIPTION
## Summary
- Replace string interpolation with forward slashes with `path.join()` for the "Expected at" path in plugin resolution error messages
- Ensures correct path separators on Windows (backslashes) instead of mixing forward/backward slashes

## Problem
On Windows, the error message was showing malformed paths like:
```
Expected at: C:\Users\username\.allagents\marketplaces\WTG.AI.Prompts/plugins/ediprod/
```
The forward slashes at the end were inconsistent with the Windows backslashes.

## Solution
Use `path.join()` which automatically uses the correct separator for the platform:
```typescript
// Before
error: `...Expected at: ${marketplace.path}/${expectedSubpath}/${pluginName}/`

// After  
error: `...Expected at: ${join(marketplace.path, expectedSubpath, pluginName)}`
```

## Test plan
- [x] All existing tests pass (554 passed)
- [ ] Manual verification on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)