### PR TITLE
fix(plugin): deduplicate concurrent fetches and reject duplicate entries

### DIFF
--- a/tests/unit/core/user-workspace-dedup.test.ts
+++ b/tests/unit/core/user-workspace-dedup.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'bun:test';
+import { resolveGitHubIdentity } from '../../../src/core/user-workspace.js';
+
+describe('resolveGitHubIdentity', () => {
+  test('resolves GitHub URL to owner/repo', async () => {
+    const id = await resolveGitHubIdentity('https://github.com/Owner/Repo');
+    expect(id).toBe('owner/repo');
+  });
+
+  test('normalizes different URL forms to same identity', async () => {
+    const urls = [
+      'https://github.com/Owner/Repo',
+      'https://github.com/Owner/Repo.git',
+      'github.com/Owner/Repo',
+      'gh:Owner/Repo',
+    ];
+    const identities = await Promise.all(urls.map(resolveGitHubIdentity));
+    expect(new Set(identities).size).toBe(1);
+    expect(identities[0]).toBe('owner/repo');
+  });
+
+  test('returns null for local paths', async () => {
+    const id = await resolveGitHubIdentity('/some/local/path');
+    expect(id).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- **Fetch coalescing**: Added single-flight pattern to `fetchPlugin` so concurrent calls for the same cache path share a single git operation instead of racing (fixes "not something we can merge" errors on shallow clones)
- **Semantic dedup at install**: `addPluginToUserConfig` now resolves plugin sources to their GitHub `owner/repo` identity and rejects duplicates (e.g., a direct URL and a marketplace spec pointing to the same repo)
- **Semantic uninstall**: `removeUserPlugin` now matches by GitHub identity as a fallback, so uninstalling a marketplace spec also finds a direct URL entry for the same repo
- Pull failures on cached repos are treated as non-fatal since the cached version is still usable

## Background

A user's `workspace.yaml` contained both a direct GitHub URL and a marketplace spec resolving to the same repo:

```yaml
plugins:
  - https://github.com/WiseTechGlobal/mcp-ediprod/
  - ediprod@wtg-ai-prompts     # marketplace manifest points to same repo
  - cargowise@wtg-ai-prompts
```

During sync, `validateAllPlugins` ran `Promise.all` on every plugin. Both ediprod entries triggered `fetchPlugin` → `git pull` concurrently on the same shallow-cloned cache directory, causing:

```
not something we can merge in .git/FETCH_HEAD
```

This cascaded into `resolvePluginSpec` returning null, which triggered `refreshMarketplace` to delete and re-clone the entire marketplace — even though it was perfectly fine.

## How to manually reproduce (before fix)

1. Register a marketplace that has a URL-sourced plugin (e.g. `wtg-ai-prompts` with `ediprod` pointing to `WiseTechGlobal/mcp-ediprod`)

2. Add both the direct URL and the marketplace spec to `~/.allagents/workspace.yaml`:
   ```yaml
   plugins:
     - https://github.com/WiseTechGlobal/mcp-ediprod/
     - ediprod@wtg-ai-prompts
   ```

3. Run uninstall then install of any plugin from that marketplace:
   ```bash
   npx allagents plugin uninstall cargowise@wtg-ai-prompts --scope user
   npx allagents plugin install cargowise@wtg-ai-prompts --scope user
   ```

4. **Before fix**: You see `Plugin not found in cached marketplace, refreshing 'wtg-ai-prompts'...` because the concurrent pull on the shared cache directory fails, causing the marketplace plugin resolution to return null and trigger a full marketplace refresh.

5. **After fix**: The install succeeds without the spurious refresh message. Additionally, step 2 is now prevented — `addUserPlugin` rejects the second entry with: `Plugin duplicates existing entry 'https://github.com/WiseTechGlobal/mcp-ediprod/': both resolve to wisetechglobal/mcp-ediprod`

## Test plan

- [x] `fetchPlugin` coalescing: concurrent calls return same object, single pull
- [x] `fetchPlugin` pull failure: cached repo returns `success: true` (non-fatal)
- [x] `resolveGitHubIdentity`: normalizes URL forms, returns null for local paths
- [x] Full test suite passes (563 pass, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)