### PR TITLE
fix(user-scope): exclude claude from default user-scope clients

### DIFF
--- a/src/core/user-workspace.ts
+++ b/src/core/user-workspace.ts
@@ -20,10 +20,13 @@ import { parseMarketplaceManifest } from '../utils/marketplace-manifest-parser.j
 import type { ModifyResult } from './workspace-modify.js';
 
 /**
- * All supported client types for user-scope installations.
+ * Default clients for user-scope installations.
+ * Note: 'claude' is excluded because user-scope plugins should not modify
+ * project-level Claude config. Claude is only included for project-scoped
+ * (.allagents) installations.
  */
-const ALL_CLIENTS: ClientType[] = [
-  'claude', 'copilot', 'codex', 'cursor', 'opencode', 'gemini', 'factory', 'ampcode',
+const DEFAULT_USER_CLIENTS: ClientType[] = [
+  'copilot', 'codex', 'cursor', 'opencode', 'gemini', 'factory', 'ampcode',
 ];
 
 /**
@@ -56,7 +59,7 @@ export async function ensureUserWorkspace(): Promise<void> {
   const defaultConfig: WorkspaceConfig = {
     repositories: [],
     plugins: [],
-    clients: [...ALL_CLIENTS],
+    clients: [...DEFAULT_USER_CLIENTS],
   };
 
   await mkdir(getAllagentsDir(), { recursive: true });

--- a/tests/unit/core/user-workspace.test.ts
+++ b/tests/unit/core/user-workspace.test.ts
@@ -39,7 +39,9 @@ describe('user-workspace', () => {
       const config = await getUserWorkspaceConfig();
       expect(config).toBeTruthy();
       expect(config!.plugins).toEqual([]);
-      expect(config!.clients).toContain('claude');
+      // User-scope should NOT include claude (only project-scope does)
+      expect(config!.clients).not.toContain('claude');
+      expect(config!.clients).toContain('copilot');
     });
 
     test('does not overwrite existing config', async () => {
@@ -55,10 +57,11 @@ describe('user-workspace', () => {
       expect(config!.plugins).toContain(pluginDir);
     });
 
-    test('creates default config with all clients', async () => {
+    test('creates default config with user-scope clients (excludes claude)', async () => {
       await ensureUserWorkspace();
       const config = await getUserWorkspaceConfig();
-      expect(config!.clients).toContain('claude');
+      // User-scope excludes claude (only project-scope includes it)
+      expect(config!.clients).not.toContain('claude');
       expect(config!.clients).toContain('copilot');
       expect(config!.clients).toContain('codex');
       expect(config!.clients).toContain('cursor');


### PR DESCRIPTION
## Summary
- Removes `claude` from the default clients list for user-scoped plugins
- User-scoped plugins (installed via `--global`) should not modify project-level Claude config
- Claude remains included as a default client for project-scoped (`.allagents`) installations

## Reason for Change
Claude plugins uses `~/.claude/settings` instead of putting files into `~/.claude/skills`. This might cause duplicate skills. The main reason we want to use AllAgents is to provide the same claude plugin experience to non-claude AI tools.

## Test plan
- [x] Existing tests updated to verify `claude` is NOT in user-scope defaults
- [x] All tests pass