### PR TITLE
fix(marketplace): delete files when removing marketplace

### DIFF
--- a/src/cli/commands/plugin.ts
+++ b/src/cli/commands/plugin.ts
@@ -348,14 +348,13 @@ const marketplaceRemoveCmd = command({
         return;
       }
 
-      console.log(`\u2713 Marketplace '${name}' removed from registry`);
+      console.log(`\u2713 Marketplace '${name}' removed`);
       if (result.removedUserPlugins && result.removedUserPlugins.length > 0) {
         console.log(`  Removed ${result.removedUserPlugins.length} user plugin(s):`);
         for (const p of result.removedUserPlugins) {
           console.log(`    - ${p}`);
         }
       }
-      console.log(`  Note: Files at ${result.marketplace?.path} were not deleted`);
     } catch (error) {
       if (error instanceof Error) {
         if (isJsonMode()) {

--- a/src/core/marketplace.ts
+++ b/src/core/marketplace.ts
@@ -351,8 +351,7 @@ export async function addMarketplace(
 }
 
 /**
- * Remove a marketplace from the registry
- * Note: Does not delete cloned files
+ * Remove a marketplace from the registry and delete its files
  */
 export async function removeMarketplace(name: string): Promise<MarketplaceResult> {
   const registry = await loadRegistry();
@@ -367,6 +366,11 @@ export async function removeMarketplace(name: string): Promise<MarketplaceResult
   const entry = registry.marketplaces[name];
   delete registry.marketplaces[name];
   await saveRegistry(registry);
+
+  // Delete the cached directory
+  if (existsSync(entry.path)) {
+    await rm(entry.path, { recursive: true, force: true });
+  }
 
   // Cascade: remove user-level plugins referencing this marketplace
   const { removeUserPluginsForMarketplace } = await import('./user-workspace.js');

--- a/tests/unit/core/marketplace-remove-cascade.test.ts
+++ b/tests/unit/core/marketplace-remove-cascade.test.ts
@@ -126,4 +126,25 @@ describe('removeMarketplace cascade', () => {
     expect(result.success).toBe(true);
     expect(result.removedUserPlugins).toEqual([]);
   });
+
+  it('should delete the marketplace directory when it exists', async () => {
+    const marketplacePath = join(testDir, '.allagents', 'plugins', 'marketplaces', 'my-marketplace');
+    await mkdir(marketplacePath, { recursive: true });
+    await writeFile(join(marketplacePath, 'manifest.yaml'), 'name: my-marketplace', 'utf-8');
+
+    await writeRegistry({
+      'my-marketplace': {
+        name: 'my-marketplace',
+        source: { type: 'github', location: 'owner/repo' },
+        path: marketplacePath,
+      },
+    });
+
+    const { existsSync } = await import('node:fs');
+    expect(existsSync(marketplacePath)).toBe(true);
+
+    const result = await removeMarketplace('my-marketplace');
+    expect(result.success).toBe(true);
+    expect(existsSync(marketplacePath)).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

- `marketplace remove` now deletes the cloned directory in addition to removing from registry
- Previously files were left on disk with a note saying "Files were not deleted"
- Added test to verify directory deletion behavior

## Test plan

- [x] Existing tests pass
- [x] New test verifies directory is deleted when it exists
- [ ] Manual test: `allagents plugin marketplace add` then `remove` should clean up completely