### PR TITLE
fix(marketplace): always return registeredAs when auto-registering

### DIFF
--- a/src/core/marketplace.ts
+++ b/src/core/marketplace.ts
@@ -858,6 +858,7 @@ export async function resolvePluginSpecWithAutoRegister(
   // Check if marketplace is already registered (by name, then by source location)
   const sourceLocation = owner && repo ? `${owner}/${repo}` : undefined;
   let marketplace = await findMarketplace(marketplaceName, sourceLocation);
+  let didAutoRegister = false;
 
   // If not registered, try auto-registration
   if (!marketplace) {
@@ -870,6 +871,7 @@ export async function resolvePluginSpecWithAutoRegister(
       };
     }
     marketplace = await getMarketplace(autoRegResult.name ?? marketplaceName);
+    didAutoRegister = true;
   }
 
   if (!marketplace) {
@@ -914,11 +916,15 @@ export async function resolvePluginSpecWithAutoRegister(
     };
   }
 
+  // Return registeredAs when we auto-registered OR when the canonical name differs
+  const shouldReturnRegisteredAs =
+    didAutoRegister || marketplace.name !== marketplaceName;
+
   return {
     success: true,
     path: resolved.path,
     pluginName: resolved.plugin,
-    ...(marketplace.name !== marketplaceName && { registeredAs: marketplace.name }),
+    ...(shouldReturnRegisteredAs && { registeredAs: marketplace.name }),
   };
 }
 


### PR DESCRIPTION
## Summary

- Fixes bug where `allagents plugin install development@WiseTechGlobal/WTG.AI.Prompts` does not auto-register the marketplace
- The marketplace was being registered but `registeredAs` was only returned when the canonical name differed from the repo name
- Now tracks whether auto-registration occurred and always returns `registeredAs` in that case

## Root Cause

In `resolvePluginSpecWithAutoRegister()`, the return statement only set `registeredAs` when:
```typescript
marketplace.name !== marketplaceName
```

For `plugin@owner/repo` format, if the manifest's canonical name matches the repo name, this condition is false even though we just auto-registered.

## Fix

Track whether auto-registration happened with a `didAutoRegister` flag and return `registeredAs` whenever we auto-registered OR when the name differs.

## Test plan

- [x] All 602 existing tests pass
- [ ] Manual test: `allagents plugin install development@WiseTechGlobal/WTG.AI.Prompts` should show the marketplace in `allagents plugin marketplace list`

🤖 Generated with [Claude Code](https://claude.com/claude-code)