### PR TITLE
refactor(cli): group plugin list by installed/available

### DIFF
--- a/src/cli/commands/plugin.ts
+++ b/src/cli/commands/plugin.ts
@@ -639,21 +639,16 @@ const pluginListCmd = command({
         for (const entry of installedPlugins) {
           console.log(`  ❯ ${entry.name}@${entry.marketplace}`);
           console.log(`    Version: ${entry.version ?? 'unknown'}`);
-          console.log(`    Scope: ${entry.installed?.scope}`);
-          console.log();
+          console.log(`    Scope: ${entry.installed?.scope}\n`);
         }
       }
 
       // Print available plugins
       if (availablePlugins.length > 0) {
-        if (installedPlugins.length > 0) {
-          console.log(); // Extra spacing between sections
-        }
         console.log('Available plugins:\n');
         for (const entry of availablePlugins) {
           console.log(`  ❯ ${entry.name}@${entry.marketplace}`);
-          console.log(`    Version: ${entry.version ?? 'unknown'}`);
-          console.log();
+          console.log(`    Version: ${entry.version ?? 'unknown'}\n`);
         }
       }
     } catch (error) {


### PR DESCRIPTION
## Summary
- Remove enabled/disabled status from plugin list output
- Group plugins into "Installed plugins" and "Available plugins" sections
- Cleaner, more intuitive output format

## Before
```
Installed plugins:

  ❯ superpowers@superpowers-dev
    Version: a98c5df
    Status: ✗ disabled
  ❯ cargowise@wtg-ai-prompts
    Version: 895d037
    Scope: project
    Status: ✓ enabled
```

## After
```
Installed plugins:

  ❯ cargowise@wtg-ai-prompts
    Version: 895d037
    Scope: project

Available plugins:

  ❯ superpowers@superpowers-dev
    Version: a98c5df
```

## Test plan
- [x] All existing tests pass
- [ ] Manual verification of `allagents plugin list` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)