### PR TITLE
fix: handle Windows absolute paths in local marketplace source

### DIFF
--- a/tests/unit/core/marketplace-branch.test.ts
+++ b/tests/unit/core/marketplace-branch.test.ts
@@ -97,4 +97,16 @@ describe('parseMarketplaceSource Windows local paths', () => {
     expect(result!.type).toBe('local');
     expect(result!.name).toBe('plugins');
   });
+
+  it('should parse UNC paths', () => {
+    const result = parseMarketplaceSource('\\\\server\\share\\marketplace');
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe('local');
+  });
+
+  it('should parse relative path with backslashes as local', () => {
+    const result = parseMarketplaceSource('some\\local\\path');
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe('local');
+  });
 });

--- a/tests/unit/core/marketplace-remove-cascade.test.ts
+++ b/tests/unit/core/marketplace-remove-cascade.test.ts
@@ -147,4 +147,26 @@ describe('removeMarketplace cascade', () => {
     expect(result.success).toBe(true);
     expect(existsSync(marketplacePath)).toBe(false);
   });
+
+  it('should not delete the source directory for local marketplaces', async () => {
+    const localSourceDir = join(testDir, 'external-marketplace');
+    await mkdir(localSourceDir, { recursive: true });
+    await writeFile(join(localSourceDir, 'README.md'), '# My Marketplace', 'utf-8');
+
+    await writeRegistry({
+      'local-mp': {
+        name: 'local-mp',
+        source: { type: 'local', location: localSourceDir },
+        path: localSourceDir,
+      },
+    });
+
+    const { existsSync } = await import('node:fs');
+    expect(existsSync(localSourceDir)).toBe(true);
+
+    const result = await removeMarketplace('local-mp');
+    expect(result.success).toBe(true);
+    // Local source directory must NOT be deleted
+    expect(existsSync(localSourceDir)).toBe(true);
+  });
 });


### PR DESCRIPTION
## Problem

Two bugs with local marketplace sources on Windows:

1. **Cannot add local marketplace with Windows path** — \llagents plugin marketplace add D:/GitHub/WiseTechGlobal/WTG.AI.Prompts\ fails with \Invalid marketplace source\
2. **Removing a local marketplace deletes the original source directory** — \emoveMarketplace\ calls \m()\ on the user's original directory instead of only cleaning up cached clones

## Root Cause

1. \parseMarketplaceSource\ only checks for Unix-style local paths (starting with \/\ or \.\). Windows absolute paths like \D:/...\ are not recognized and fall through to the GitHub shorthand check.
2. \emoveMarketplace\ unconditionally deletes \ntry.path\ for all marketplace types, but local marketplaces point directly to the user's source directory (not a cached copy).

## Fix

1. Added regex check for Windows drive letter paths (\/^[a-zA-Z]:[\\\/]/\) in \parseMarketplaceSource\
2. Skip directory deletion in \emoveMarketplace\ when \source.type === 'local'\

## Testing

- 3 new unit tests for Windows path parsing (forward slashes, backslashes, lowercase drive)
- 1 new unit test verifying local marketplace removal preserves the source directory
- E2E verified: add + remove local marketplace on Windows, original directory preserved