### PR TITLE
fix(marketplace): prevent duplicate auto-registration messages

### DIFF
--- a/tests/unit/core/marketplace-dedup.test.ts
+++ b/tests/unit/core/marketplace-dedup.test.ts
@@ -47,6 +47,7 @@ const {
   extractUniqueMarketplaceSources,
   findMarketplace,
   resolvePluginSpecWithAutoRegister,
+  resetAutoRegisterCache,
 } = await import('../../../src/core/marketplace.js');
 
 describe('marketplace deduplication', () => {
@@ -60,6 +61,7 @@ describe('marketplace deduplication', () => {
     testHome = join(tmpdir(), `marketplace-dedup-test-${Date.now()}`);
     process.env.HOME = testHome;
     cloneToCalls.length = 0;
+    resetAutoRegisterCache();
 
     // Spy on console.log to capture log messages
     logMessages = [];


### PR DESCRIPTION
## Summary

- Adds early-exit check in `autoRegisterMarketplace()` to skip logging when marketplace is already registered
- Prevents duplicate "Auto-registering GitHub marketplace" messages during `workspace init`

## Root Cause

The `autoRegisterMarketplace()` function was logging the message before checking if the marketplace was already registered. While `addMarketplace()` has idempotency checking internally, the console.log happened unconditionally before that check.

## Test plan

- [x] All existing tests pass (607 tests)
- [x] `marketplace-dedup.test.ts` specifically tests this deduplication behavior

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)