### PR TITLE
fix(workspace): embed repository paths directly in WORKSPACE-RULES

### DIFF
--- a/src/core/sync.ts
+++ b/src/core/sync.ts
@@ -1262,12 +1262,12 @@ export async function syncWorkspace(
     }
 
     // Step 5c: Copy workspace files with GitHub cache
-    // When repositories is empty, skip WORKSPACE-RULES injection into any agent files
+    // Pass repositories so paths are embedded directly in WORKSPACE-RULES
     workspaceFileResults = await copyWorkspaceFiles(
       sourcePath,
       workspacePath,
       filesToCopy,
-      { dryRun, githubCache, skipWorkspaceRules: !hasRepositories },
+      { dryRun, githubCache, repositories: config.repositories },
     );
 
     // If claude is a client and CLAUDE.md doesn't exist, copy AGENTS.md to CLAUDE.md

--- a/src/core/transform.ts
+++ b/src/core/transform.ts
@@ -6,7 +6,7 @@ import { CLIENT_MAPPINGS, isUniversalClient } from '../models/client-mapping.js'
 import type { ClientMapping } from '../models/client-mapping.js';
 import type { ClientType, WorkspaceFile, SyncMode } from '../models/workspace-config.js';
 import { validateSkill } from '../validators/skill.js';
-import { WORKSPACE_RULES } from '../constants.js';
+import { generateWorkspaceRules, type WorkspaceRepository } from '../constants.js';
 import { parseFileSource } from '../utils/plugin-path.js';
 import { createSymlink } from '../utils/symlink.js';
 
@@ -21,10 +21,10 @@ const AGENT_FILES = ['AGENTS.md', 'CLAUDE.md'] as const;
  * - If file exists without markers: appends rules
  * - If file exists with markers: replaces content between markers (idempotent)
  * @param filePath - Path to the agent file (CLAUDE.md or AGENTS.md)
- * @param rules - Optional custom rules content (defaults to WORKSPACE_RULES constant)
+ * @param repositories - Array of repositories to include in the rules (paths embedded directly)
  */
-export async function ensureWorkspaceRules(filePath: string, rules?: string): Promise<void> {
-  const rulesContent = rules ?? WORKSPACE_RULES;
+export async function ensureWorkspaceRules(filePath: string, repositories: WorkspaceRepository[]): Promise<void> {
+  const rulesContent = generateWorkspaceRules(repositories);
   const startMarker = '<!-- WORKSPACE-RULES:START -->';
   const endMarker = '<!-- WORKSPACE-RULES:END -->';
 
@@ -48,11 +48,6 @@ export async function ensureWorkspaceRules(filePath: string, rules?: string): Pr
     await writeFile(filePath, content + rulesContent, 'utf-8');
   }
 }
-
-/**
- * @deprecated Use ensureWorkspaceRules instead
- */
-export const injectWorkspaceRules = ensureWorkspaceRules;
 
 /**
  * Result of a file copy operation
@@ -108,11 +103,11 @@ export interface WorkspaceCopyOptions extends CopyOptions {
    */
   githubCache?: Map<string, string>;
   /**
-   * Skip WORKSPACE-RULES injection into agent files.
-   * Used when repositories is empty/absent — agent files should not receive rules
-   * that reference repository paths.
+   * Repositories to embed in WORKSPACE-RULES.
+   * When provided, rules include actual repository paths directly.
+   * When empty/absent, WORKSPACE-RULES injection is skipped.
    */
-  skipWorkspaceRules?: boolean;
+  repositories?: WorkspaceRepository[];
 }
 
 /**
@@ -650,7 +645,7 @@ export async function copyWorkspaceFiles(
   files: WorkspaceFile[],
   options: WorkspaceCopyOptions = {},
 ): Promise<CopyResult[]> {
-  const { dryRun = false, githubCache, skipWorkspaceRules = false } = options;
+  const { dryRun = false, githubCache, repositories = [] } = options;
   const results: CopyResult[] = [];
 
   // Separate string patterns from object entries
@@ -832,12 +827,12 @@ export async function copyWorkspaceFiles(
   }
 
   // Inject WORKSPACE-RULES into all copied agent files (idempotent)
-  // Skip when repositories is empty/absent — rules reference repository paths that don't exist
-  if (!dryRun && !skipWorkspaceRules) {
+  // Skip when repositories is empty — rules reference repository paths that don't exist
+  if (!dryRun && repositories.length > 0) {
     for (const agentFile of copiedAgentFiles) {
       const targetPath = join(workspacePath, agentFile);
       try {
-        await injectWorkspaceRules(targetPath);
+        await ensureWorkspaceRules(targetPath, repositories);
       } catch (error) {
         results.push({
           source: 'WORKSPACE-RULES',

--- a/src/core/workspace-repo.ts
+++ b/src/core/workspace-repo.ts
@@ -163,6 +163,7 @@ export async function listRepositories(
 /**
  * Ensure WORKSPACE-RULES are injected into agent files for all configured clients.
  * Lightweight alternative to full syncWorkspace() — only touches agent files.
+ * Repository paths are embedded directly in the rules.
  */
 export async function updateAgentFiles(
   workspacePath: string = process.cwd(),
@@ -184,7 +185,8 @@ export async function updateAgentFiles(
   // Always include AGENTS.md as it's the universal fallback
   agentFiles.add('AGENTS.md');
 
+  // Pass repositories directly so paths are embedded in the rules
   for (const agentFile of agentFiles) {
-    await ensureWorkspaceRules(join(workspacePath, agentFile));
+    await ensureWorkspaceRules(join(workspacePath, agentFile), config.repositories);
   }
 }

--- a/tests/unit/core/sync.test.ts
+++ b/tests/unit/core/sync.test.ts
@@ -4,7 +4,7 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { syncWorkspace, purgeWorkspace, getPurgePaths } from '../../../src/core/sync.js';
-import { CONFIG_DIR, WORKSPACE_CONFIG_FILE, WORKSPACE_RULES } from '../../../src/constants.js';
+import { CONFIG_DIR, WORKSPACE_CONFIG_FILE } from '../../../src/constants.js';
 
 describe('sync', () => {
   let testDir: string;

--- a/tests/unit/core/transform-glob.test.ts
+++ b/tests/unit/core/transform-glob.test.ts
@@ -263,7 +263,7 @@ describe('copyWorkspaceFiles with glob patterns', () => {
       expect(results[0].error).toContain('GitHub cache not found');
     });
 
-    it('should inject WORKSPACE-RULES into AGENTS.md from GitHub source', async () => {
+    it('should inject WORKSPACE-RULES into AGENTS.md from GitHub source when repositories provided', async () => {
       // Create a mock GitHub cache directory
       const mockCacheDir = await mkdtemp(join(tmpdir(), 'allagents-github-cache-'));
       await mkdir(join(mockCacheDir, 'plugins', 'test'), { recursive: true });
@@ -272,15 +272,17 @@ describe('copyWorkspaceFiles with glob patterns', () => {
       const githubCache = new Map<string, string>();
       githubCache.set('owner/repo', mockCacheDir);
 
+      // Pass repositories so WORKSPACE-RULES are injected with embedded paths
       const results = await copyWorkspaceFiles(sourceDir, destDir, [
         { dest: 'AGENTS.md', source: 'owner/repo/plugins/test/AGENTS.md' },
-      ], { githubCache });
+      ], { githubCache, repositories: [{ path: '../myrepo', description: 'test repo' }] });
 
       expect(results.length).toBe(1);
       expect(results[0].action).toBe('copied');
 
       const content = await readFile(join(destDir, 'AGENTS.md'), 'utf-8');
       expect(content).toContain('WORKSPACE-RULES');
+      expect(content).toContain('../myrepo'); // Embedded repo path
 
       // Cleanup
       await rm(mockCacheDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- Fixes issue where agents don't always read workspace.yaml, causing them to only search in the workspace folder instead of target repositories
- Replaces indirect "read workspace.yaml" instruction with actual repository paths embedded directly in AGENTS.md/CLAUDE.md
- Agents now see repository paths immediately in their context without needing to parse additional files

## Changes
- Add `generateWorkspaceRules()` function that generates rules with embedded repository paths
- Update `ensureWorkspaceRules()` to require repositories parameter
- Update all call sites (`sync.ts`, `workspace.ts`, `workspace-repo.ts`, `transform.ts`) to pass repositories from config
- Repository descriptions are included when available

## Before
```markdown
## Rule: Workspace Discovery
TRIGGER: Any task
ACTION: Read `.allagents/workspace.yaml` to get repository paths
```

## After
```markdown
## Workspace Repositories
The following repositories are part of this workspace:
- ../allagents - primary project
- ../dotagents - related project

## Rule: Use Repository Paths
TRIGGER: File operations (read, search, modify)
ACTION: Use the repository paths listed above, not assumptions
```

## Test plan
- [x] All existing tests pass (608 pass, 0 fail)
- [x] TypeScript compiles without errors
- [x] Build succeeds

Closes #121