### PR TITLE
fix(sync): use .copilot/ for user-scope copilot content

### DIFF
--- a/src/models/client-mapping.ts
+++ b/src/models/client-mapping.ts
@@ -104,7 +104,7 @@ export const USER_CLIENT_MAPPINGS: Record<ClientType, ClientMapping> = {
   copilot: {
     skillsPath: '.agents/skills/',
     agentFile: 'AGENTS.md',
-    githubPath: '.github/',
+    githubPath: '.copilot/',
   },
   codex: {
     skillsPath: '.agents/skills/',


### PR DESCRIPTION
## Summary
- Fix user-scope path for copilot client from `.github/` to `.copilot/`
- The `.github/` folder is for project-scope only
- `~/.copilot/` is the correct location for user-level prompts and skills per VS Code/Copilot conventions

## Changes
- `src/models/client-mapping.ts`: Change `githubPath` in `USER_CLIENT_MAPPINGS` for copilot from `.github/` to `.copilot/`

## Path mapping after this fix
| Scope | Source (plugin) | Destination |
|-------|-----------------|-------------|
| Project | `.github/` | `.github/` |
| User | `.github/` | `~/.copilot/` |

## Test plan
- [x] All 612 tests pass
- [x] Build succeeds
- [x] Lint passes