### PR TITLE
feat(sync): auto-adjust relative file links when copying .github folder

### DIFF
--- a/docs/src/content/docs/reference/clients.mdx
+++ b/docs/src/content/docs/reference/clients.mdx
@@ -8,17 +8,17 @@ description: AI coding assistant clients supported by AllAgents.
 | Client | Skills | Agent File | Hooks | Commands |
 |--------|--------|------------|-------|----------|
 | Claude | `.claude/skills/` | `CLAUDE.md` | `.claude/hooks/` | `.claude/commands/` |
-| Copilot | `.github/skills/` | `AGENTS.md` | No | No |
-| Codex | `.codex/skills/` | `AGENTS.md` | No | No |
+| Copilot | `.agents/skills/` | `AGENTS.md` | No | `.github/prompts/` |
+| Codex | `.agents/skills/` | `AGENTS.md` | No | No |
 | Cursor | `.cursor/skills/` | `AGENTS.md` | No | No |
-| OpenCode | `.opencode/skills/` | `AGENTS.md` | No | No |
-| Gemini | `.gemini/skills/` | `GEMINI.md` | No | No |
+| OpenCode | `.agents/skills/` | `AGENTS.md` | No | `.opencode/commands/` |
+| Gemini | `.agents/skills/` | `GEMINI.md` | No | No |
 | Factory | `.factory/skills/` | `AGENTS.md` | `.factory/hooks/` | No |
-| Amp Code | No | `AGENTS.md` | No | No |
+| Amp Code | `.agents/skills/` | `AGENTS.md` | No | No |
 | VSCode | No | No | No | No |
 
 :::note
-Commands are a Claude-specific feature. Skills are the cross-client way to share reusable prompts.
+Skills are the cross-client way to share reusable prompts.
 :::
 
 ### VSCode

--- a/src/utils/link-adjuster.ts
+++ b/src/utils/link-adjuster.ts
@@ -1,0 +1,197 @@
+import { dirname, join, normalize, isAbsolute } from 'node:path';
+
+/**
+ * Options for adjusting links in content
+ */
+export interface LinkAdjustOptions {
+  /**
+   * Map of skill folder name to resolved name.
+   * Used when skills are renamed due to conflicts.
+   */
+  skillNameMap?: Map<string, string>;
+  /**
+   * Path to skills in workspace (e.g., '.agents/skills/')
+   */
+  workspaceSkillsPath: string;
+}
+
+/**
+ * Mapping of plugin-relative paths to workspace destinations.
+ * Keys are path prefixes as they appear in relative paths from .github/ folder.
+ */
+interface PathMapping {
+  /** Pattern to match (normalized path prefix) */
+  pattern: string;
+  /** Function to transform the matched path */
+  transform: (matchedPath: string, options: LinkAdjustOptions) => string;
+}
+
+/**
+ * Path mappings from plugin structure to workspace structure.
+ * These patterns match paths relative to the .github/ folder that point to plugin content.
+ */
+const PATH_MAPPINGS: PathMapping[] = [
+  {
+    // skills/ at plugin root -> workspace skills path
+    // e.g., ../../skills/foo -> ../../.agents/skills/foo
+    pattern: 'skills/',
+    transform: (matchedPath: string, options: LinkAdjustOptions) => {
+      // Extract the skill folder name and remaining path
+      const skillsPrefix = 'skills/';
+      const afterSkills = matchedPath.substring(skillsPrefix.length);
+      const parts = afterSkills.split('/');
+      const skillFolderName = parts[0] ?? '';
+      const restOfPath = parts.slice(1).join('/');
+
+      // Check if skill was renamed
+      const resolvedName = options.skillNameMap?.get(skillFolderName) ?? skillFolderName;
+
+      // Build new path with workspace skills path
+      const newPath = join(options.workspaceSkillsPath, resolvedName, restOfPath);
+      return newPath;
+    },
+  },
+];
+
+/**
+ * Regular expression patterns for detecting links in content
+ */
+const LINK_PATTERNS = {
+  // #file:path pattern (GitHub Copilot file reference)
+  fileReference: /#file:([^\s\])"'`]+)/g,
+  // Standard markdown link [text](path)
+  markdownLink: /\[([^\]]*)\]\(([^)]+)\)/g,
+};
+
+/**
+ * Check if a path is a URL (http/https) or absolute
+ */
+function isUrlOrAbsolute(path: string): boolean {
+  return (
+    path.startsWith('http://') ||
+    path.startsWith('https://') ||
+    path.startsWith('mailto:') ||
+    isAbsolute(path)
+  );
+}
+
+/**
+ * Adjust a single relative path from plugin .github/ structure to workspace structure.
+ *
+ * This function handles paths that go from .github/some/nested/file.md back up to plugin root
+ * and then into plugin content folders like skills/, commands/, or agents/.
+ *
+ * @param relativePath - The relative path as it appears in the link
+ * @param sourceFileRelPath - The relative path of the source file within .github/ (e.g., 'instructions/cargowise.md')
+ * @param options - Link adjustment options
+ * @returns Adjusted path or original if no adjustment needed
+ */
+export function adjustRelativePath(
+  relativePath: string,
+  sourceFileRelPath: string,
+  options: LinkAdjustOptions,
+): string {
+  // Skip URLs and absolute paths
+  if (isUrlOrAbsolute(relativePath)) {
+    return relativePath;
+  }
+
+  // Skip paths that don't go up (they stay within .github/)
+  if (!relativePath.startsWith('../')) {
+    return relativePath;
+  }
+
+  // Normalize the relative path
+  const normalized = normalize(relativePath);
+
+  // Calculate how the path resolves from the source file's perspective
+  // sourceFileRelPath is relative to .github/, e.g., 'instructions/cargowise.md'
+  const sourceDir = dirname(sourceFileRelPath);
+
+  // Count how many ../ we need to exit .github/ folder
+  // Split the source directory to count nesting depth
+  const sourceDepth = sourceDir === '.' ? 0 : sourceDir.split('/').filter(Boolean).length;
+
+  // Count ../ segments in the original path
+  const upSegments = normalized.split('/').filter((s) => s === '..').length;
+
+  // We need (sourceDepth + 1) ../ to exit .github/ and reach workspace root
+  // +1 because we're inside .github/ itself
+  const exitsGithub = upSegments > sourceDepth;
+
+  if (!exitsGithub) {
+    // Path stays within .github/, no adjustment needed
+    return relativePath;
+  }
+
+  // Calculate what the path resolves to at plugin root level
+  // The path exits .github/ and goes to plugin root, then somewhere else
+  // We need to figure out where it points to in the plugin structure
+
+  // How many ../ are left after exiting .github/?
+  // Total ../ minus (depth to exit .github/)
+  const levelsAboveGithub = upSegments - (sourceDepth + 1);
+
+  // The remaining path after all ../ segments
+  const pathParts = normalized.split('/');
+  const afterUpParts = pathParts.slice(upSegments);
+  const targetPath = afterUpParts.join('/');
+
+  // If the path goes above the plugin root (levelsAboveGithub > 0), we can't adjust it
+  if (levelsAboveGithub > 0) {
+    return relativePath;
+  }
+
+  // Now targetPath is relative to plugin root
+  // Check if it matches any of our mappings
+  for (const mapping of PATH_MAPPINGS) {
+    if (targetPath.startsWith(mapping.pattern)) {
+      const transformedTarget = mapping.transform(targetPath, options);
+
+      // Build the new path from the source file's location
+      // We need to go up from source file to workspace root, then to the transformed target
+      // From .github/foo/bar.md: ../../ goes to workspace root
+      // From .github/bar.md: ../ goes to workspace root
+      const upToRoot = '../'.repeat(sourceDepth + 1);
+      return upToRoot + transformedTarget;
+    }
+  }
+
+  // No mapping matched, return original
+  return relativePath;
+}
+
+/**
+ * Adjust all relative links in markdown content.
+ *
+ * @param content - The markdown content to process
+ * @param sourceFileRelPath - The relative path of the source file within .github/ (e.g., 'instructions/cargowise.md')
+ * @param options - Link adjustment options
+ * @returns Content with adjusted links
+ */
+export function adjustLinksInContent(
+  content: string,
+  sourceFileRelPath: string,
+  options: LinkAdjustOptions,
+): string {
+  let result = content;
+
+  // Replace #file: references
+  result = result.replace(LINK_PATTERNS.fileReference, (_match, path) => {
+    const adjustedPath = adjustRelativePath(path, sourceFileRelPath, options);
+    return `#file:${adjustedPath}`;
+  });
+
+  // Replace markdown links [text](path)
+  // Need to be careful not to adjust URLs
+  result = result.replace(LINK_PATTERNS.markdownLink, (match, text, path) => {
+    // Skip anchor links
+    if (path.startsWith('#')) {
+      return match;
+    }
+    const adjustedPath = adjustRelativePath(path, sourceFileRelPath, options);
+    return `[${text}](${adjustedPath})`;
+  });
+
+  return result;
+}

--- a/tests/unit/utils/link-adjuster.test.ts
+++ b/tests/unit/utils/link-adjuster.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'bun:test';
+import { adjustRelativePath, adjustLinksInContent } from '../../../src/utils/link-adjuster.js';
+
+describe('adjustRelativePath', () => {
+  const defaultOptions = {
+    workspaceSkillsPath: '.agents/skills/',
+  };
+
+  it('adjusts skills path from .github root to workspace path', () => {
+    // File at .github/copilot-instructions.md linking to ../skills/foo/SKILL.md
+    // One ../ from .github/ goes to plugin root
+    // After copy to workspace, skills are at .agents/skills/
+    const result = adjustRelativePath('../skills/foo/SKILL.md', 'copilot-instructions.md', defaultOptions);
+    expect(result).toBe('../.agents/skills/foo/SKILL.md');
+  });
+
+  it('adjusts skills path from nested .github folder', () => {
+    // File at .github/instructions/cargowise.instructions.md
+    // ../../ goes: first ../ to .github/, second ../ to plugin root
+    // Then skills/cw-coding/SKILL.md from plugin root
+    const result = adjustRelativePath(
+      '../../skills/cw-coding/SKILL.md',
+      'instructions/cargowise.instructions.md',
+      defaultOptions,
+    );
+    expect(result).toBe('../../.agents/skills/cw-coding/SKILL.md');
+  });
+
+  it('resolves renamed skills using skillNameMap', () => {
+    const options = {
+      workspaceSkillsPath: '.agents/skills/',
+      skillNameMap: new Map([['my-skill', 'plugin-name:my-skill']]),
+    };
+    // File at .github/instructions/file.md, link needs ../../ to reach plugin root
+    const result = adjustRelativePath('../../skills/my-skill/SKILL.md', 'instructions/file.md', options);
+    expect(result).toBe('../../.agents/skills/plugin-name:my-skill/SKILL.md');
+  });
+
+  it('leaves URLs unchanged', () => {
+    const result = adjustRelativePath('https://example.com/docs', 'file.md', defaultOptions);
+    expect(result).toBe('https://example.com/docs');
+  });
+
+  it('leaves absolute paths unchanged', () => {
+    const result = adjustRelativePath('/absolute/path/to/file.md', 'file.md', defaultOptions);
+    expect(result).toBe('/absolute/path/to/file.md');
+  });
+
+  it('leaves paths within .github unchanged', () => {
+    // Link to another file in .github/prompts/ - doesn't exit .github
+    const result = adjustRelativePath('../prompts/other.md', 'instructions/file.md', defaultOptions);
+    expect(result).toBe('../prompts/other.md');
+  });
+
+  it('leaves paths that do not match mappings unchanged', () => {
+    // Link to commands/ - no mapping for this
+    const result = adjustRelativePath('../../commands/foo.md', 'instructions/file.md', defaultOptions);
+    expect(result).toBe('../../commands/foo.md');
+  });
+
+  it('handles deeply nested file paths', () => {
+    // File at .github/deep/nested/path/file.md (depth 3)
+    // Need 4 ../ to exit .github and reach plugin root
+    const result = adjustRelativePath(
+      '../../../../skills/foo/SKILL.md',
+      'deep/nested/path/file.md',
+      defaultOptions,
+    );
+    expect(result).toBe('../../../../.agents/skills/foo/SKILL.md');
+  });
+});
+
+describe('adjustLinksInContent', () => {
+  const defaultOptions = {
+    workspaceSkillsPath: '.agents/skills/',
+  };
+
+  it('adjusts #file: references', () => {
+    // File at .github/instructions/file.md, ../../ exits .github
+    const content = 'See #file:../../skills/foo/SKILL.md for details';
+    const result = adjustLinksInContent(content, 'instructions/file.md', defaultOptions);
+    expect(result).toBe('See #file:../../.agents/skills/foo/SKILL.md for details');
+  });
+
+  it('adjusts markdown links', () => {
+    // File at .github/instructions/file.md
+    const content = 'See [Skill Guide](../../skills/foo/SKILL.md) for details';
+    const result = adjustLinksInContent(content, 'instructions/file.md', defaultOptions);
+    expect(result).toBe('See [Skill Guide](../../.agents/skills/foo/SKILL.md) for details');
+  });
+
+  it('adjusts multiple links in content', () => {
+    const content = `
+# Instructions
+
+See #file:../../skills/skill1/SKILL.md for skill 1.
+
+And [Skill 2](../../skills/skill2/README.md) for skill 2.
+`;
+    const result = adjustLinksInContent(content, 'instructions/file.md', defaultOptions);
+    expect(result).toContain('#file:../../.agents/skills/skill1/SKILL.md');
+    expect(result).toContain('[Skill 2](../../.agents/skills/skill2/README.md)');
+  });
+
+  it('preserves anchor links', () => {
+    const content = 'See [Section](#section) for more info';
+    const result = adjustLinksInContent(content, 'file.md', defaultOptions);
+    expect(result).toBe('See [Section](#section) for more info');
+  });
+
+  it('preserves external URLs in markdown links', () => {
+    const content = 'See [Docs](https://example.com/docs) for info';
+    const result = adjustLinksInContent(content, 'file.md', defaultOptions);
+    expect(result).toBe('See [Docs](https://example.com/docs) for info');
+  });
+
+  it('handles complex content with mixed link types', () => {
+    // File at .github/instructions/copilot.md
+    const content = `
+# Copilot Instructions
+
+Reference the [Skill Guide](../../skills/my-skill/SKILL.md) or use #file:../../skills/other-skill/index.ts.
+
+For external docs, see [GitHub](https://github.com) and [internal section](#setup).
+
+Local files stay: [Local](./local.md)
+`;
+    const result = adjustLinksInContent(content, 'instructions/copilot.md', defaultOptions);
+
+    // Skills paths adjusted (../../ to reach plugin root)
+    expect(result).toContain('[Skill Guide](../../.agents/skills/my-skill/SKILL.md)');
+    expect(result).toContain('#file:../../.agents/skills/other-skill/index.ts');
+
+    // External URLs unchanged
+    expect(result).toContain('[GitHub](https://github.com)');
+
+    // Anchor unchanged
+    expect(result).toContain('[internal section](#setup)');
+
+    // Local relative path unchanged (stays within .github)
+    expect(result).toContain('[Local](./local.md)');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds automatic adjustment of relative file links when copying `.github` folder content from plugins to workspace
- Detects and rewrites `#file:` references (GitHub Copilot format) and standard markdown links `[text](path)`
- Maps plugin skill paths to workspace skill paths (e.g., `../../skills/` → `../../.agents/skills/`)
- Supports skill name resolution when skills are renamed due to conflicts

## Example

**Before (in plugin):**
```markdown
See #file:../../skills/cw-coding/SKILL.md for details.
Also check [API Guide](../../skills/cw-api/README.md).
```

**After (in workspace):**
```markdown
See #file:../../.agents/skills/cw-coding/SKILL.md for details.
Also check [API Guide](../../.agents/skills/cw-api/README.md).
```

## Test plan
- [x] Unit tests for `adjustRelativePath` function
- [x] Unit tests for `adjustLinksInContent` function  
- [x] Integration tests for `copyGitHubContent` with link adjustment
- [x] E2E validation with test plugin

Closes #128