### PR TITLE
feat(sync): copy MCP config to VS Code

### DIFF
--- a/src/cli/commands/workspace.ts
+++ b/src/cli/commands/workspace.ts
@@ -33,6 +33,14 @@ function buildSyncData(result: SyncResult) {
       copyResults: pr.copyResults,
     })),
     purgedPaths: result.purgedPaths ?? [],
+    ...(result.mcpResult && {
+      mcpServers: {
+        added: result.mcpResult.added,
+        skipped: result.mcpResult.skipped,
+        addedServers: result.mcpResult.addedServers,
+        skippedServers: result.mcpResult.skippedServers,
+      },
+    }),
   };
 }
 
@@ -226,6 +234,14 @@ const syncCmd = command({
         console.log('\nWarnings:');
         for (const warning of result.warnings) {
           console.log(`  \u26A0 ${warning}`);
+        }
+      }
+
+      // Print MCP server sync results
+      if (result.mcpResult && (result.mcpResult.added > 0 || result.mcpResult.skipped > 0)) {
+        console.log(`\nMCP servers: ${result.mcpResult.added} added, ${result.mcpResult.skipped} skipped`);
+        for (const name of result.mcpResult.addedServers) {
+          console.log(`  + ${name}`);
         }
       }
 

--- a/src/cli/tui/actions/sync.ts
+++ b/src/cli/tui/actions/sync.ts
@@ -46,6 +46,9 @@ export async function runSync(context: TuiContext): Promise<void> {
         lines.push(
           `Copied: ${userResult.totalCopied}  Failed: ${userResult.totalFailed}  Skipped: ${userResult.totalSkipped}`,
         );
+        if (userResult.mcpResult && (userResult.mcpResult.added > 0 || userResult.mcpResult.skipped > 0)) {
+          lines.push(`MCP servers: ${userResult.mcpResult.added} added, ${userResult.mcpResult.skipped} skipped`);
+        }
         p.note(lines.join('\n'), 'User Sync');
       }
     }

--- a/src/core/sync.ts
+++ b/src/core/sync.ts
@@ -46,6 +46,8 @@ import {
   generateVscodeWorkspace,
   getWorkspaceOutputPath,
 } from './vscode-workspace.js';
+import { syncVscodeMcpConfig } from './vscode-mcp.js';
+import type { McpMergeResult } from './vscode-mcp.js';
 
 /**
  * Result of deduplicating clients by skillsPath
@@ -115,6 +117,8 @@ export interface SyncResult {
   error?: string;
   /** Warnings for plugins that were skipped during sync */
   warnings?: string[];
+  /** Result of syncing MCP server configs to VS Code */
+  mcpResult?: McpMergeResult;
 }
 
 /**
@@ -123,6 +127,8 @@ export interface SyncResult {
 export function mergeSyncResults(a: SyncResult, b: SyncResult): SyncResult {
   const warnings = [...(a.warnings || []), ...(b.warnings || [])];
   const purgedPaths = [...(a.purgedPaths || []), ...(b.purgedPaths || [])];
+  // Use whichever mcpResult is present (only user-scope sync produces one)
+  const mcpResult = a.mcpResult ?? b.mcpResult;
   return {
     success: a.success && b.success,
     pluginResults: [...a.pluginResults, ...b.pluginResults],
@@ -132,6 +138,7 @@ export function mergeSyncResults(a: SyncResult, b: SyncResult): SyncResult {
     totalGenerated: a.totalGenerated + b.totalGenerated,
     ...(warnings.length > 0 && { warnings }),
     ...(purgedPaths.length > 0 && { purgedPaths }),
+    ...(mcpResult && { mcpResult }),
   };
 }
 
@@ -1483,6 +1490,15 @@ export async function syncUserWorkspace(
     await saveSyncState(homeDir, syncedFiles);
   }
 
+  // Sync MCP server configs to VS Code if vscode client is configured
+  let mcpResult: McpMergeResult | undefined;
+  if (clients.includes('vscode') && validPlugins.length > 0) {
+    mcpResult = syncVscodeMcpConfig(validPlugins, { dryRun });
+    if (mcpResult.warnings.length > 0) {
+      warnings.push(...mcpResult.warnings);
+    }
+  }
+
   return {
     success: totalFailed === 0,
     pluginResults,
@@ -1491,6 +1507,7 @@ export async function syncUserWorkspace(
     totalSkipped,
     totalGenerated,
     ...(warnings.length > 0 && { warnings }),
+    ...(mcpResult && { mcpResult }),
   };
 }
 

--- a/src/core/vscode-mcp.ts
+++ b/src/core/vscode-mcp.ts
@@ -1,0 +1,152 @@
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import JSON5 from 'json5';
+import { getHomeDir } from '../constants.js';
+import type { ValidatedPlugin } from './sync.js';
+
+/**
+ * Result of merging MCP server configs into VS Code
+ */
+export interface McpMergeResult {
+  added: number;
+  skipped: number;
+  warnings: string[];
+  addedServers: string[];
+  skippedServers: string[];
+}
+
+/**
+ * Get the cross-platform path to VS Code's user-level mcp.json
+ */
+export function getVscodeMcpConfigPath(): string {
+  const platform = process.platform;
+  if (platform === 'win32') {
+    const appData = process.env.APPDATA;
+    if (!appData) {
+      throw new Error('APPDATA environment variable not set');
+    }
+    return join(appData, 'Code', 'User', 'mcp.json');
+  }
+  const home = getHomeDir();
+  if (platform === 'darwin') {
+    return join(home, 'Library', 'Application Support', 'Code', 'User', 'mcp.json');
+  }
+  // Linux
+  return join(home, '.config', 'Code', 'User', 'mcp.json');
+}
+
+/**
+ * Read .mcp.json from a plugin root directory.
+ * Returns the mcpServers object or null if absent/invalid.
+ */
+export function readPluginMcpConfig(pluginPath: string): Record<string, unknown> | null {
+  const mcpPath = join(pluginPath, '.mcp.json');
+  if (!existsSync(mcpPath)) {
+    return null;
+  }
+  try {
+    const content = readFileSync(mcpPath, 'utf-8');
+    const parsed = JSON5.parse(content);
+    if (parsed && typeof parsed === 'object' && parsed.mcpServers && typeof parsed.mcpServers === 'object') {
+      return parsed.mcpServers as Record<string, unknown>;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Collect MCP servers from all validated plugins.
+ * First-plugin-wins for duplicate server names.
+ */
+export function collectMcpServers(
+  validatedPlugins: ValidatedPlugin[],
+): { servers: Map<string, unknown>; warnings: string[] } {
+  const servers = new Map<string, unknown>();
+  const warnings: string[] = [];
+
+  for (const plugin of validatedPlugins) {
+    const mcpServers = readPluginMcpConfig(plugin.resolved);
+    if (!mcpServers) continue;
+
+    for (const [name, config] of Object.entries(mcpServers)) {
+      if (servers.has(name)) {
+        warnings.push(`MCP server '${name}' from ${plugin.plugin} conflicts with earlier plugin (skipped)`);
+      } else {
+        servers.set(name, config);
+      }
+    }
+  }
+
+  return { servers, warnings };
+}
+
+/**
+ * Sync MCP server configs from plugins into VS Code's user-level mcp.json.
+ *
+ * - New server names are added
+ * - Existing server names are skipped (non-destructive)
+ * - Other keys in mcp.json are preserved
+ */
+export function syncVscodeMcpConfig(
+  validatedPlugins: ValidatedPlugin[],
+  options?: { dryRun?: boolean; configPath?: string },
+): McpMergeResult {
+  const dryRun = options?.dryRun ?? false;
+  const configPath = options?.configPath ?? getVscodeMcpConfigPath();
+
+  // Collect servers from all plugins
+  const { servers: pluginServers, warnings } = collectMcpServers(validatedPlugins);
+
+  const result: McpMergeResult = {
+    added: 0,
+    skipped: 0,
+    warnings: [...warnings],
+    addedServers: [],
+    skippedServers: [],
+  };
+
+  if (pluginServers.size === 0) {
+    return result;
+  }
+
+  // Read existing VS Code mcp.json (or start fresh)
+  let existingConfig: Record<string, unknown> = {};
+  if (existsSync(configPath)) {
+    try {
+      const content = readFileSync(configPath, 'utf-8');
+      existingConfig = JSON5.parse(content);
+    } catch {
+      // If invalid, start fresh but warn
+      result.warnings.push(`Could not parse existing ${configPath}, starting fresh`);
+      existingConfig = {};
+    }
+  }
+
+  // Get or create the servers object (VS Code uses "servers" key)
+  const existingServers = (existingConfig.servers as Record<string, unknown>) ?? {};
+
+  for (const [name, config] of pluginServers) {
+    if (name in existingServers) {
+      result.skipped++;
+      result.skippedServers.push(name);
+    } else {
+      existingServers[name] = config;
+      result.added++;
+      result.addedServers.push(name);
+    }
+  }
+
+  // Write back if there were changes and not dry-run
+  if (result.added > 0 && !dryRun) {
+    existingConfig.servers = existingServers;
+    const dir = dirname(configPath);
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+    writeFileSync(configPath, `${JSON.stringify(existingConfig, null, 2)}\n`, 'utf-8');
+  }
+
+  return result;
+}

--- a/tests/unit/core/vscode-mcp.test.ts
+++ b/tests/unit/core/vscode-mcp.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
+import { join } from 'node:path';
+import { mkdirSync, writeFileSync, rmSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import {
+  getVscodeMcpConfigPath,
+  readPluginMcpConfig,
+  collectMcpServers,
+  syncVscodeMcpConfig,
+} from '../../../src/core/vscode-mcp.js';
+import type { ValidatedPlugin } from '../../../src/core/sync.js';
+
+/** Create a temp directory for each test */
+function makeTempDir(): string {
+  const dir = join(tmpdir(), `allagents-mcp-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+/** Helper to create a validated plugin with a resolved path */
+function makePlugin(resolved: string, plugin = 'test-plugin'): ValidatedPlugin {
+  return { plugin, resolved, success: true };
+}
+
+describe('getVscodeMcpConfigPath', () => {
+  test('returns a valid path for current platform', () => {
+    const path = getVscodeMcpConfigPath();
+    expect(path).toContain('mcp.json');
+    expect(path).toContain('Code');
+  });
+});
+
+describe('readPluginMcpConfig', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test('returns null when no .mcp.json exists', () => {
+    const result = readPluginMcpConfig(tempDir);
+    expect(result).toBeNull();
+  });
+
+  test('returns servers when valid .mcp.json exists', () => {
+    writeFileSync(
+      join(tempDir, '.mcp.json'),
+      JSON.stringify({
+        mcpServers: {
+          ediprod: { type: 'http', url: 'https://ediprod.mcp.wtg.zone' },
+        },
+      }),
+    );
+
+    const result = readPluginMcpConfig(tempDir);
+    expect(result).toEqual({
+      ediprod: { type: 'http', url: 'https://ediprod.mcp.wtg.zone' },
+    });
+  });
+
+  test('returns null for invalid JSON', () => {
+    writeFileSync(join(tempDir, '.mcp.json'), 'not valid json {{{');
+    const result = readPluginMcpConfig(tempDir);
+    expect(result).toBeNull();
+  });
+});
+
+describe('collectMcpServers', () => {
+  let tempDir1: string;
+  let tempDir2: string;
+
+  beforeEach(() => {
+    tempDir1 = makeTempDir();
+    tempDir2 = makeTempDir();
+  });
+
+  afterEach(() => {
+    rmSync(tempDir1, { recursive: true, force: true });
+    rmSync(tempDir2, { recursive: true, force: true });
+  });
+
+  test('merges servers from multiple plugins', () => {
+    writeFileSync(
+      join(tempDir1, '.mcp.json'),
+      JSON.stringify({ mcpServers: { server1: { type: 'http', url: 'https://a.test' } } }),
+    );
+    writeFileSync(
+      join(tempDir2, '.mcp.json'),
+      JSON.stringify({ mcpServers: { server2: { type: 'http', url: 'https://b.test' } } }),
+    );
+
+    const { servers, warnings } = collectMcpServers([
+      makePlugin(tempDir1, 'plugin-a'),
+      makePlugin(tempDir2, 'plugin-b'),
+    ]);
+
+    expect(servers.size).toBe(2);
+    expect(servers.get('server1')).toEqual({ type: 'http', url: 'https://a.test' });
+    expect(servers.get('server2')).toEqual({ type: 'http', url: 'https://b.test' });
+    expect(warnings).toHaveLength(0);
+  });
+
+  test('warns on duplicate server names, first plugin wins', () => {
+    writeFileSync(
+      join(tempDir1, '.mcp.json'),
+      JSON.stringify({ mcpServers: { dup: { type: 'http', url: 'https://first.test' } } }),
+    );
+    writeFileSync(
+      join(tempDir2, '.mcp.json'),
+      JSON.stringify({ mcpServers: { dup: { type: 'http', url: 'https://second.test' } } }),
+    );
+
+    const { servers, warnings } = collectMcpServers([
+      makePlugin(tempDir1, 'plugin-a'),
+      makePlugin(tempDir2, 'plugin-b'),
+    ]);
+
+    expect(servers.size).toBe(1);
+    expect(servers.get('dup')).toEqual({ type: 'http', url: 'https://first.test' });
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('plugin-b');
+    expect(warnings[0]).toContain('dup');
+  });
+});
+
+describe('syncVscodeMcpConfig', () => {
+  let tempDir: string;
+  let pluginDir: string;
+  let configPath: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir();
+    pluginDir = makeTempDir();
+    configPath = join(tempDir, 'mcp.json');
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+    rmSync(pluginDir, { recursive: true, force: true });
+  });
+
+  test('adds new servers to empty config', () => {
+    writeFileSync(
+      join(pluginDir, '.mcp.json'),
+      JSON.stringify({
+        mcpServers: {
+          ediprod: { type: 'http', url: 'https://ediprod.mcp.wtg.zone' },
+          wtgkb: { type: 'http', url: 'https://wtgkb.mcp.wtg.zone' },
+        },
+      }),
+    );
+
+    const result = syncVscodeMcpConfig([makePlugin(pluginDir)], { configPath });
+
+    expect(result.added).toBe(2);
+    expect(result.skipped).toBe(0);
+    expect(result.addedServers).toEqual(['ediprod', 'wtgkb']);
+
+    // Verify file was written
+    const written = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(written.servers.ediprod).toEqual({ type: 'http', url: 'https://ediprod.mcp.wtg.zone' });
+    expect(written.servers.wtgkb).toEqual({ type: 'http', url: 'https://wtgkb.mcp.wtg.zone' });
+  });
+
+  test('preserves existing servers and other keys', () => {
+    // Pre-existing VS Code config with existing server and custom key
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        servers: {
+          existing: { type: 'http', url: 'https://existing.test' },
+        },
+        customKey: 'preserved',
+      }),
+    );
+
+    writeFileSync(
+      join(pluginDir, '.mcp.json'),
+      JSON.stringify({
+        mcpServers: { newserver: { type: 'http', url: 'https://new.test' } },
+      }),
+    );
+
+    const result = syncVscodeMcpConfig([makePlugin(pluginDir)], { configPath });
+
+    expect(result.added).toBe(1);
+    expect(result.addedServers).toEqual(['newserver']);
+
+    const written = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(written.servers.existing).toEqual({ type: 'http', url: 'https://existing.test' });
+    expect(written.servers.newserver).toEqual({ type: 'http', url: 'https://new.test' });
+    expect(written.customKey).toBe('preserved');
+  });
+
+  test('skips servers that already exist', () => {
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        servers: {
+          ediprod: { type: 'http', url: 'https://user-configured.test' },
+        },
+      }),
+    );
+
+    writeFileSync(
+      join(pluginDir, '.mcp.json'),
+      JSON.stringify({
+        mcpServers: { ediprod: { type: 'http', url: 'https://plugin.test' } },
+      }),
+    );
+
+    const result = syncVscodeMcpConfig([makePlugin(pluginDir)], { configPath });
+
+    expect(result.added).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(result.skippedServers).toEqual(['ediprod']);
+
+    // Verify original value is preserved
+    const written = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(written.servers.ediprod.url).toBe('https://user-configured.test');
+  });
+
+  test('dry-run does not write file', () => {
+    writeFileSync(
+      join(pluginDir, '.mcp.json'),
+      JSON.stringify({
+        mcpServers: { ediprod: { type: 'http', url: 'https://ediprod.test' } },
+      }),
+    );
+
+    const result = syncVscodeMcpConfig([makePlugin(pluginDir)], { configPath, dryRun: true });
+
+    expect(result.added).toBe(1);
+    expect(result.addedServers).toEqual(['ediprod']);
+    // File should NOT have been created
+    expect(existsSync(configPath)).toBe(false);
+  });
+
+  test('no-op when no plugins have .mcp.json', () => {
+    // pluginDir has no .mcp.json
+    const result = syncVscodeMcpConfig([makePlugin(pluginDir)], { configPath });
+
+    expect(result.added).toBe(0);
+    expect(result.skipped).toBe(0);
+    expect(result.addedServers).toEqual([]);
+    expect(result.skippedServers).toEqual([]);
+    expect(existsSync(configPath)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Read `.mcp.json` files from plugin repos and merge MCP server entries into VS Code's user-level `mcp.json` during user-scope sync
- Only activates when `vscode` is in workspace.yaml clients list
- New servers are added, existing ones are skipped (non-destructive)
- Results displayed in both CLI and TUI output

Closes #110

## Test plan
- [x] `bun run typecheck` passes
- [x] 11 new unit tests in `tests/unit/core/vscode-mcp.test.ts` all pass
- [x] Full test suite (623 tests) passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)