### PR TITLE
feat(client): give vscode the same features as copilot

### DIFF
--- a/docs/src/content/docs/reference/clients.mdx
+++ b/docs/src/content/docs/reference/clients.mdx
@@ -15,7 +15,7 @@ description: AI coding assistant clients supported by AllAgents.
 | Gemini | `.agents/skills/` | `GEMINI.md` | No | No |
 | Factory | `.factory/skills/` | `AGENTS.md` | `.factory/hooks/` | No |
 | Amp Code | `.agents/skills/` | `AGENTS.md` | No | No |
-| VSCode | No | No | No | No |
+| VSCode | `.agents/skills/` | `AGENTS.md` | No | `.github/prompts/` |
 
 :::note
 Skills are the cross-client way to share reusable prompts.
@@ -23,4 +23,4 @@ Skills are the cross-client way to share reusable prompts.
 
 ### VSCode
 
-VSCode is a special client type. Instead of syncing skills or agent files, adding `vscode` to `clients` triggers automatic `.code-workspace` file generation during `workspace sync`. See the [Workspaces guide](/guides/workspaces/#vscode-workspace-generation) for details.
+VSCode syncs the same skills, agent file, and commands as Copilot. Additionally, adding `vscode` to `clients` triggers automatic `.code-workspace` file generation and MCP config syncing during `workspace sync`. See the [Workspaces guide](/guides/workspaces/#vscode-workspace-generation) for details.

--- a/examples/workspaces/multi-repo/.allagents/workspace.yaml
+++ b/examples/workspaces/multi-repo/.allagents/workspace.yaml
@@ -28,6 +28,7 @@ plugins:
 
 clients:
   - copilot
+  - vscode
   - claude
   - opencode
   - codex

--- a/src/cli/tui/actions/clients.ts
+++ b/src/cli/tui/actions/clients.ts
@@ -47,8 +47,7 @@ export async function runManageClients(context: TuiContext, cache?: TuiCache): P
       currentClients = userConfig?.clients ?? [];
     }
 
-    // All supported clients except vscode
-    const allClients = ClientTypeSchema.options.filter((c) => c !== 'vscode');
+    const allClients = ClientTypeSchema.options;
 
     const selectedClients = await multiselect({
       message: `Select AI clients [${scope}]`,

--- a/src/cli/tui/actions/init.ts
+++ b/src/cli/tui/actions/init.ts
@@ -30,9 +30,8 @@ export async function runInit(): Promise<void> {
       return;
     }
 
-    // Client selection - all supported clients except vscode (it's a workspace generator, not an AI client)
-    const allClients = ClientTypeSchema.options.filter((c) => c !== 'vscode');
-    const defaultClients = ['claude', 'copilot', 'codex', 'opencode'];
+    const allClients = ClientTypeSchema.options;
+    const defaultClients = ['claude', 'copilot', 'vscode', 'codex', 'opencode'];
 
     const selectedClients = await multiselect({
       message: 'Which AI clients do you use?',

--- a/src/models/client-mapping.ts
+++ b/src/models/client-mapping.ts
@@ -63,8 +63,9 @@ export const CLIENT_MAPPINGS: Record<ClientType, ClientMapping> = {
     agentFile: 'AGENTS.md',
   },
   vscode: {
-    skillsPath: '',
-    agentFile: '',
+    skillsPath: '.agents/skills/',
+    agentFile: 'AGENTS.md',
+    githubPath: '.github/',
   },
 };
 
@@ -133,7 +134,8 @@ export const USER_CLIENT_MAPPINGS: Record<ClientType, ClientMapping> = {
     agentFile: 'AGENTS.md',
   },
   vscode: {
-    skillsPath: '',
-    agentFile: '',
+    skillsPath: '.agents/skills/',
+    agentFile: 'AGENTS.md',
+    githubPath: '.copilot/',
   },
 };

--- a/src/templates/default/.allagents/workspace.yaml
+++ b/src/templates/default/.allagents/workspace.yaml
@@ -14,5 +14,6 @@ plugins: []
 clients:
   - claude
   - copilot
+  - vscode
   - codex
   - opencode

--- a/tests/unit/core/sync-dedup.test.ts
+++ b/tests/unit/core/sync-dedup.test.ts
@@ -89,24 +89,19 @@ describe('deduplicateClientsByPath', () => {
     expect(result.clientGroups.get('claude')).toEqual(['claude']);
   });
 
-  it('should handle vscode with empty skillsPath as unique client', () => {
-    // vscode has empty skillsPath ('') and should not be grouped with other clients
+  it('should group vscode with copilot/codex (all use .agents/skills/)', () => {
     const clients = ['copilot', 'vscode', 'codex'] as const;
     const result = deduplicateClientsByPath([...clients], CLIENT_MAPPINGS);
 
-    // vscode should be its own group (not grouped with copilot/codex)
-    expect(result.representativeClients).toHaveLength(2);
+    // All three share .agents/skills/ so should be in one group
+    expect(result.representativeClients).toHaveLength(1);
     expect(result.representativeClients).toContain('copilot');
-    expect(result.representativeClients).toContain('vscode');
 
-    // copilot group should have copilot and codex (both use .agents/skills/)
     const copilotGroup = result.clientGroups.get('copilot');
-    expect(copilotGroup).toHaveLength(2);
+    expect(copilotGroup).toHaveLength(3);
     expect(copilotGroup).toContain('copilot');
+    expect(copilotGroup).toContain('vscode');
     expect(copilotGroup).toContain('codex');
-
-    // vscode should be in its own group
-    expect(result.clientGroups.get('vscode')).toEqual(['vscode']);
   });
 });
 

--- a/tests/unit/models/client-mapping.test.ts
+++ b/tests/unit/models/client-mapping.test.ts
@@ -45,8 +45,8 @@ describe('CLIENT_MAPPINGS', () => {
     expect(CLIENT_MAPPINGS.ampcode.skillsPath).toBe('.agents/skills/');
   });
 
-  test('vscode has empty skillsPath (not applicable)', () => {
-    expect(CLIENT_MAPPINGS.vscode.skillsPath).toBe('');
+  test('vscode uses universal .agents/skills/ path', () => {
+    expect(CLIENT_MAPPINGS.vscode.skillsPath).toBe('.agents/skills/');
   });
 
   test('project paths are relative (no leading /)', () => {
@@ -100,8 +100,8 @@ describe('USER_CLIENT_MAPPINGS', () => {
     expect(USER_CLIENT_MAPPINGS.ampcode.skillsPath).toBe('.agents/skills/');
   });
 
-  test('vscode has empty skillsPath (not applicable)', () => {
-    expect(USER_CLIENT_MAPPINGS.vscode.skillsPath).toBe('');
+  test('vscode uses universal ~/.agents/skills/ path', () => {
+    expect(USER_CLIENT_MAPPINGS.vscode.skillsPath).toBe('.agents/skills/');
   });
 
   test('user paths are relative to home directory (no leading /)', () => {


### PR DESCRIPTION
## Summary
- Give VSCode client the same skill/agent/command syncing as Copilot (`.agents/skills/`, `AGENTS.md`, `.github/prompts/`)
- Add `vscode` to default client lists in workspace templates and examples
- Update client comparison table in docs to reflect new VSCode capabilities
- Include `vscode` in TUI client selection (init and manage clients)

## Test plan
- [x] All 647 existing tests pass
- [x] Updated `client-mapping.test.ts` to verify vscode uses `.agents/skills/`
- [x] Updated `sync-dedup.test.ts` to verify vscode groups with copilot/codex