### PR TITLE
fix(docs): remove unreadable mermaid diagram

### DIFF
--- a/docs/.astro/content-modules.mjs
+++ b/docs/.astro/content-modules.mjs
@@ -1,13 +1,13 @@
 
 export default new Map([
 ["src/content/docs/index.mdx", () => import("astro:content-layer-deferred-module?astro%3Acontent-layer-deferred-module=&fileName=src%2Fcontent%2Fdocs%2Findex.mdx&astroContentModuleFlag=true")],
-["src/content/docs/getting-started/installation.mdx", () => import("astro:content-layer-deferred-module?astro%3Acontent-layer-deferred-module=&fileName=src%2Fcontent%2Fdocs%2Fgetting-started%2Finstallation.mdx&astroContentModuleFlag=true")],
-["src/content/docs/getting-started/introduction.mdx", () => import("astro:content-layer-deferred-module?astro%3Acontent-layer-deferred-module=&fileName=src%2Fcontent%2Fdocs%2Fgetting-started%2Fintroduction.mdx&astroContentModuleFlag=true")],
-["src/content/docs/getting-started/quick-start.mdx", () => import("astro:content-layer-deferred-module?astro%3Acontent-layer-deferred-module=&fileName=src%2Fcontent%2Fdocs%2Fgetting-started%2Fquick-start.mdx&astroContentModuleFlag=true")],
-["src/content/docs/guides/marketplaces.mdx", () => import("astro:content-layer-deferred-module?astro%3Acontent-layer-deferred-module=&fileName=src%2Fcontent%2Fdocs%2Fguides%2Fmarketplaces.mdx&astroContentModuleFlag=true")],
+["src/content/docs/reference/configuration.mdx", () => import("astro:content-layer-deferred-module?astro%3Acontent-layer-deferred-module=&fileName=src%2Fcontent%2Fdocs%2Freference%2Fconfiguration.mdx&astroContentModuleFlag=true")],
 ["src/content/docs/guides/plugins.mdx", () => import("astro:content-layer-deferred-module?astro%3Acontent-layer-deferred-module=&fileName=src%2Fcontent%2Fdocs%2Fguides%2Fplugins.mdx&astroContentModuleFlag=true")],
 ["src/content/docs/guides/workspaces.mdx", () => import("astro:content-layer-deferred-module?astro%3Acontent-layer-deferred-module=&fileName=src%2Fcontent%2Fdocs%2Fguides%2Fworkspaces.mdx&astroContentModuleFlag=true")],
+["src/content/docs/getting-started/quick-start.mdx", () => import("astro:content-layer-deferred-module?astro%3Acontent-layer-deferred-module=&fileName=src%2Fcontent%2Fdocs%2Fgetting-started%2Fquick-start.mdx&astroContentModuleFlag=true")],
+["src/content/docs/getting-started/installation.mdx", () => import("astro:content-layer-deferred-module?astro%3Acontent-layer-deferred-module=&fileName=src%2Fcontent%2Fdocs%2Fgetting-started%2Finstallation.mdx&astroContentModuleFlag=true")],
+["src/content/docs/guides/marketplaces.mdx", () => import("astro:content-layer-deferred-module?astro%3Acontent-layer-deferred-module=&fileName=src%2Fcontent%2Fdocs%2Fguides%2Fmarketplaces.mdx&astroContentModuleFlag=true")],
+["src/content/docs/getting-started/introduction.mdx", () => import("astro:content-layer-deferred-module?astro%3Acontent-layer-deferred-module=&fileName=src%2Fcontent%2Fdocs%2Fgetting-started%2Fintroduction.mdx&astroContentModuleFlag=true")],
 ["src/content/docs/reference/cli.mdx", () => import("astro:content-layer-deferred-module?astro%3Acontent-layer-deferred-module=&fileName=src%2Fcontent%2Fdocs%2Freference%2Fcli.mdx&astroContentModuleFlag=true")],
-["src/content/docs/reference/clients.mdx", () => import("astro:content-layer-deferred-module?astro%3Acontent-layer-deferred-module=&fileName=src%2Fcontent%2Fdocs%2Freference%2Fclients.mdx&astroContentModuleFlag=true")],
-["src/content/docs/reference/configuration.mdx", () => import("astro:content-layer-deferred-module?astro%3Acontent-layer-deferred-module=&fileName=src%2Fcontent%2Fdocs%2Freference%2Fconfiguration.mdx&astroContentModuleFlag=true")]]);
+["src/content/docs/reference/clients.mdx", () => import("astro:content-layer-deferred-module?astro%3Acontent-layer-deferred-module=&fileName=src%2Fcontent%2Fdocs%2Freference%2Fclients.mdx&astroContentModuleFlag=true")]]);
 		

--- a/docs/src/content/docs/getting-started/introduction.mdx
+++ b/docs/src/content/docs/getting-started/introduction.mdx
@@ -20,62 +20,7 @@ AllAgents solves this by providing:
 | File location | Runtime lookup from cache | Copied to workspace (git-versioned) |
 | Project structure | AI config mixed with code | Separate workspace repo |
 
-## Architecture
-
-```mermaid
-graph TB
-    subgraph Marketplaces
-        M1[claude-plugins-official]
-        M2[obra/superpowers]
-        M3[custom marketplace]
-    end
-
-    subgraph Plugins
-        P1[code-review]
-        P2[superpowers]
-        P3[my-plugin]
-    end
-
-    subgraph "Plugin Contents"
-        S[skills/]
-        H[hooks/]
-        A[agents/]
-        MCP[mcp/]
-        C[commands/]
-    end
-
-    M1 --> P1
-    M2 --> P2
-    M3 --> P3
-
-    P1 & P2 & P3 --> S & H & A & MCP & C
-
-    subgraph "User Scope (~/.allagents/)"
-        UW[workspace.yaml]
-        UC[~/.claude/]
-        UA[~/.agents/]
-    end
-
-    subgraph "Project Scope (.allagents/)"
-        PW[workspace.yaml]
-
-        subgraph Repositories
-            R1[repo-1/]
-            R2[repo-2/]
-            R3[repo-3/]
-        end
-
-        PC[.claude/]
-        PA[.agents/]
-    end
-
-    S & H & A & C --> UC & UA
-    S & H & A & C --> PC & PA
-
-    PW --> R1 & R2 & R3
-```
-
-**Key concepts:**
+## Key Concepts
 
 | Concept | Description |
 |---------|-------------|


### PR DESCRIPTION
## Summary
- Remove mermaid diagram from introduction page (was rendering as raw text)
- Rename "Architecture" section to "Key Concepts" (table already explains the concepts)
- No new dependencies needed - the landing page already has an interactive architecture visualization

## Test plan
- [x] Build succeeds
- [x] Introduction page displays cleanly with tables