### PR TITLE
fix(client): add vscode to default user-scope clients

### DIFF
--- a/src/core/user-workspace.ts
+++ b/src/core/user-workspace.ts
@@ -39,6 +39,7 @@ const DEFAULT_USER_CLIENTS: ClientType[] = [
   'gemini',
   'factory',
   'ampcode',
+  'vscode',
 ];
 
 /**

--- a/tests/unit/core/user-workspace.test.ts
+++ b/tests/unit/core/user-workspace.test.ts
@@ -69,6 +69,7 @@ describe('user-workspace', () => {
       expect(config!.clients).toContain('gemini');
       expect(config!.clients).toContain('factory');
       expect(config!.clients).toContain('ampcode');
+      expect(config!.clients).toContain('vscode');
     });
   });
 


### PR DESCRIPTION
## Summary
- PR #136 added vscode as a full client but missed adding it to `DEFAULT_USER_CLIENTS` in `src/core/user-workspace.ts`
- `allagents plugin install ... --scope user` created `~/.allagents/workspace.yaml` without `vscode` in the clients list
- Adds `vscode` to the default user-scope clients and updates the test assertion

## Test plan
- [x] Existing `user-workspace.test.ts` tests pass (16/16)
- [x] Pre-commit hooks (lint, typecheck, test) pass