### PR TITLE
feat(opencode): add commandsPath support for OpenCode client

### DIFF
--- a/src/models/client-mapping.ts
+++ b/src/models/client-mapping.ts
@@ -4,7 +4,7 @@ import type { ClientType } from './workspace-config.js';
  * Client-specific path and file configuration
  */
 export interface ClientMapping {
-  /** Path for commands (Claude-specific feature) */
+  /** Path for commands (Claude, OpenCode) */
   commandsPath?: string;
   skillsPath: string;
   agentsPath?: string;
@@ -45,6 +45,7 @@ export const CLIENT_MAPPINGS: Record<ClientType, ClientMapping> = {
     agentFile: 'AGENTS.md',
   },
   opencode: {
+    commandsPath: '.opencode/commands/',
     skillsPath: '.agents/skills/',
     agentFile: 'AGENTS.md',
   },
@@ -116,6 +117,7 @@ export const USER_CLIENT_MAPPINGS: Record<ClientType, ClientMapping> = {
     agentFile: 'AGENTS.md',
   },
   opencode: {
+    commandsPath: '.opencode/commands/',
     skillsPath: '.agents/skills/',
     agentFile: 'AGENTS.md',
   },


### PR DESCRIPTION
## Summary

- Add `commandsPath: '.opencode/commands/'` to OpenCode client mapping
- Update code comment to reflect that commands support both Claude and OpenCode

## Changes

- **src/models/client-mapping.ts**: Added `commandsPath` to both `CLIENT_MAPPINGS` and `USER_CLIENT_MAPPINGS` for the OpenCode client

## References

- [OpenCode commands docs](https://opencode.ai/docs/commands/)
- Closes #144

## Test plan

- [x] All existing tests pass (666 tests)
- [x] Commands will now sync to `.opencode/commands/` for workspaces with OpenCode as a client