### PR TITLE
feat(clients): add universal client type

### DIFF
--- a/src/models/client-mapping.ts
+++ b/src/models/client-mapping.ts
@@ -21,6 +21,9 @@ export interface ClientMapping {
 /**
  * Project-level client path mappings for all supported AI clients.
  * Paths are relative to the project root directory.
+ *
+ * Only the 'universal' client uses .agents/skills/.
+ * All other clients use provider-specific directories.
  */
 export const CLIENT_MAPPINGS: Record<ClientType, ClientMapping> = {
   claude: {
@@ -32,12 +35,12 @@ export const CLIENT_MAPPINGS: Record<ClientType, ClientMapping> = {
     hooksPath: '.claude/hooks/',
   },
   copilot: {
-    skillsPath: '.agents/skills/',
+    skillsPath: '.github/skills/',
     agentFile: 'AGENTS.md',
     githubPath: '.github/',
   },
   codex: {
-    skillsPath: '.agents/skills/',
+    skillsPath: '.codex/skills/',
     agentFile: 'AGENTS.md',
   },
   cursor: {
@@ -46,11 +49,11 @@ export const CLIENT_MAPPINGS: Record<ClientType, ClientMapping> = {
   },
   opencode: {
     commandsPath: '.opencode/commands/',
-    skillsPath: '.agents/skills/',
+    skillsPath: '.opencode/skills/',
     agentFile: 'AGENTS.md',
   },
   gemini: {
-    skillsPath: '.agents/skills/',
+    skillsPath: '.gemini/skills/',
     agentFile: 'GEMINI.md',
     agentFileFallback: 'AGENTS.md',
   },
@@ -60,11 +63,11 @@ export const CLIENT_MAPPINGS: Record<ClientType, ClientMapping> = {
     hooksPath: '.factory/hooks/',
   },
   ampcode: {
-    skillsPath: '.agents/skills/',
+    skillsPath: '.ampcode/skills/',
     agentFile: 'AGENTS.md',
   },
   vscode: {
-    skillsPath: '.agents/skills/',
+    skillsPath: '.github/skills/',
     agentFile: 'AGENTS.md',
     githubPath: '.github/',
   },
@@ -117,32 +120,32 @@ export const CLIENT_MAPPINGS: Record<ClientType, ClientMapping> = {
     agentFile: 'AGENTS.md',
   },
   replit: {
-    skillsPath: '.agents/skills/',
+    skillsPath: '.replit/skills/',
     agentFile: 'AGENTS.md',
   },
   kimi: {
+    skillsPath: '.kimi/skills/',
+    agentFile: 'AGENTS.md',
+  },
+  universal: {
     skillsPath: '.agents/skills/',
     agentFile: 'AGENTS.md',
   },
 };
 
 /**
- * User-level client path mappings for all supported AI clients.
- * Paths are relative to the user's home directory (~/).
- * Used when plugins are installed with --scope user.
- */
-/**
- * The canonical skills path used by universal clients.
- * Skills are copied here first, then symlinked from non-universal client paths.
+ * The canonical skills path used by the universal client.
+ * When universal is in the clients list, skills are copied here first,
+ * then symlinked from non-universal client paths.
  */
 export const CANONICAL_SKILLS_PATH = '.agents/skills/';
 
 /**
- * Check if a client uses the canonical .agents/skills/ path.
- * Universal clients don't need symlinks since they read from canonical directly.
+ * Check if a client is the universal client (uses .agents/skills/).
+ * Only the 'universal' client type returns true.
  */
 export function isUniversalClient(client: ClientType): boolean {
-  return CLIENT_MAPPINGS[client].skillsPath === CANONICAL_SKILLS_PATH;
+  return client === 'universal';
 }
 
 /**
@@ -160,12 +163,12 @@ export const USER_CLIENT_MAPPINGS: Record<ClientType, ClientMapping> = {
     hooksPath: '.claude/hooks/',
   },
   copilot: {
-    skillsPath: '.agents/skills/',
+    skillsPath: '.copilot/skills/',
     agentFile: 'AGENTS.md',
     githubPath: '.copilot/',
   },
   codex: {
-    skillsPath: '.agents/skills/',
+    skillsPath: '.codex/skills/',
     agentFile: 'AGENTS.md',
   },
   cursor: {
@@ -174,11 +177,11 @@ export const USER_CLIENT_MAPPINGS: Record<ClientType, ClientMapping> = {
   },
   opencode: {
     commandsPath: '.opencode/commands/',
-    skillsPath: '.agents/skills/',
+    skillsPath: '.opencode/skills/',
     agentFile: 'AGENTS.md',
   },
   gemini: {
-    skillsPath: '.agents/skills/',
+    skillsPath: '.gemini/skills/',
     agentFile: 'GEMINI.md',
     agentFileFallback: 'AGENTS.md',
   },
@@ -188,11 +191,11 @@ export const USER_CLIENT_MAPPINGS: Record<ClientType, ClientMapping> = {
     hooksPath: '.factory/hooks/',
   },
   ampcode: {
-    skillsPath: '.agents/skills/',
+    skillsPath: '.ampcode/skills/',
     agentFile: 'AGENTS.md',
   },
   vscode: {
-    skillsPath: '.agents/skills/',
+    skillsPath: '.copilot/skills/',
     agentFile: 'AGENTS.md',
     githubPath: '.copilot/',
   },
@@ -245,10 +248,14 @@ export const USER_CLIENT_MAPPINGS: Record<ClientType, ClientMapping> = {
     agentFile: 'AGENTS.md',
   },
   replit: {
-    skillsPath: '.agents/skills/',
+    skillsPath: '.replit/skills/',
     agentFile: 'AGENTS.md',
   },
   kimi: {
+    skillsPath: '.kimi/skills/',
+    agentFile: 'AGENTS.md',
+  },
+  universal: {
     skillsPath: '.agents/skills/',
     agentFile: 'AGENTS.md',
   },

--- a/src/models/workspace-config.ts
+++ b/src/models/workspace-config.ts
@@ -87,6 +87,7 @@ export const ClientTypeSchema = z.enum([
   'kiro',
   'replit',
   'kimi',
+  'universal',
 ]);
 
 export type ClientType = z.infer<typeof ClientTypeSchema>;

--- a/tests/unit/core/github-content.test.ts
+++ b/tests/unit/core/github-content.test.ts
@@ -89,9 +89,9 @@ Also check [API Guide](../../skills/cw-api/README.md).
       'utf-8',
     );
 
-    // Links should be adjusted to workspace skills path (.agents/skills/)
-    expect(copiedContent).toContain('#file:../../.agents/skills/cw-coding/SKILL.md');
-    expect(copiedContent).toContain('[API Guide](../../.agents/skills/cw-api/README.md)');
+    // Links should be adjusted to workspace skills path (.github/skills/)
+    expect(copiedContent).toContain('#file:../../.github/skills/cw-coding/SKILL.md');
+    expect(copiedContent).toContain('[API Guide](../../.github/skills/cw-api/README.md)');
   });
 
   it('adjusts links using skill name map for renamed skills', async () => {
@@ -106,7 +106,7 @@ Also check [API Guide](../../skills/cw-api/README.md).
     expect(results[0].action).toBe('copied');
 
     const copiedContent = await readFile(join(workspaceDir, '.github', 'instructions', 'file.md'), 'utf-8');
-    expect(copiedContent).toContain('#file:../../.agents/skills/plugin-name:my-skill/SKILL.md');
+    expect(copiedContent).toContain('#file:../../.github/skills/plugin-name:my-skill/SKILL.md');
   });
 
   it('preserves non-skill links and external URLs', async () => {

--- a/tests/unit/core/sync-dedup.test.ts
+++ b/tests/unit/core/sync-dedup.test.ts
@@ -10,68 +10,67 @@ import type { CopyResult } from '../../../src/core/transform.js';
 
 describe('deduplicateClientsByPath', () => {
   it('should group clients that share the same skillsPath', () => {
-    // copilot, codex, opencode, gemini, ampcode all use .agents/skills/
-    const clients = ['copilot', 'codex', 'opencode', 'gemini', 'ampcode'] as const;
+    // copilot and vscode both use .github/skills/
+    const clients = ['copilot', 'vscode'] as const;
     const result = deduplicateClientsByPath([...clients], CLIENT_MAPPINGS);
 
     // Should have only one representative client
     expect(result.representativeClients).toHaveLength(1);
-    expect(result.representativeClients[0]).toBe('copilot'); // First in list
+    expect(result.representativeClients[0]).toBe('copilot');
 
-    // The group should contain all 5 clients
+    // The group should contain both clients
     const group = result.clientGroups.get('copilot');
     expect(group).toBeDefined();
-    expect(group).toHaveLength(5);
+    expect(group).toHaveLength(2);
     expect(group).toContain('copilot');
-    expect(group).toContain('codex');
-    expect(group).toContain('opencode');
-    expect(group).toContain('gemini');
-    expect(group).toContain('ampcode');
+    expect(group).toContain('vscode');
   });
 
   it('should keep clients with different skillsPaths separate', () => {
-    const clients = ['claude', 'cursor', 'copilot'] as const;
+    // claude uses .claude/skills/, cursor uses .cursor/skills/, codex uses .codex/skills/
+    const clients = ['claude', 'cursor', 'codex'] as const;
     const result = deduplicateClientsByPath([...clients], CLIENT_MAPPINGS);
 
-    // claude uses .claude/skills/, cursor uses .cursor/skills/, copilot uses .agents/skills/
     expect(result.representativeClients).toHaveLength(3);
     expect(result.representativeClients).toContain('claude');
     expect(result.representativeClients).toContain('cursor');
-    expect(result.representativeClients).toContain('copilot');
+    expect(result.representativeClients).toContain('codex');
 
     // Each group should have only one client
     expect(result.clientGroups.get('claude')).toEqual(['claude']);
     expect(result.clientGroups.get('cursor')).toEqual(['cursor']);
-    expect(result.clientGroups.get('copilot')).toEqual(['copilot']);
+    expect(result.clientGroups.get('codex')).toEqual(['codex']);
   });
 
   it('should handle mixed unique and shared paths', () => {
-    // claude (unique), copilot+codex (shared), cursor (unique)
-    const clients = ['claude', 'copilot', 'codex', 'cursor'] as const;
+    // claude (unique .claude/skills/), copilot+vscode (shared .github/skills/), codex (unique .codex/skills/)
+    const clients = ['claude', 'copilot', 'vscode', 'codex'] as const;
     const result = deduplicateClientsByPath([...clients], CLIENT_MAPPINGS);
 
     // Should have 3 representative clients
     expect(result.representativeClients).toHaveLength(3);
     expect(result.representativeClients).toContain('claude');
-    expect(result.representativeClients).toContain('cursor');
+    expect(result.representativeClients).toContain('codex');
     // copilot should be representative for the shared group
     expect(result.representativeClients).toContain('copilot');
 
-    // copilot group should have both copilot and codex
+    // copilot group should have both copilot and vscode
     const copilotGroup = result.clientGroups.get('copilot');
     expect(copilotGroup).toHaveLength(2);
     expect(copilotGroup).toContain('copilot');
-    expect(copilotGroup).toContain('codex');
+    expect(copilotGroup).toContain('vscode');
   });
 
   it('should work with USER_CLIENT_MAPPINGS', () => {
+    // copilot uses .copilot/skills/, codex uses .codex/skills/, opencode uses .opencode/skills/
     const clients = ['copilot', 'codex', 'opencode'] as const;
     const result = deduplicateClientsByPath([...clients], USER_CLIENT_MAPPINGS);
 
-    // All use .agents/skills/ in user mappings too
-    expect(result.representativeClients).toHaveLength(1);
-    const group = result.clientGroups.get('copilot');
-    expect(group).toHaveLength(3);
+    // All three have different user-level paths, so no grouping
+    expect(result.representativeClients).toHaveLength(3);
+    expect(result.clientGroups.get('copilot')).toEqual(['copilot']);
+    expect(result.clientGroups.get('codex')).toEqual(['codex']);
+    expect(result.clientGroups.get('opencode')).toEqual(['opencode']);
   });
 
   it('should handle empty clients array', () => {
@@ -89,40 +88,43 @@ describe('deduplicateClientsByPath', () => {
     expect(result.clientGroups.get('claude')).toEqual(['claude']);
   });
 
-  it('should group vscode with copilot/codex (all use .agents/skills/)', () => {
+  it('should group vscode with copilot (both use .github/skills/)', () => {
     const clients = ['copilot', 'vscode', 'codex'] as const;
     const result = deduplicateClientsByPath([...clients], CLIENT_MAPPINGS);
 
-    // All three share .agents/skills/ so should be in one group
-    expect(result.representativeClients).toHaveLength(1);
+    // copilot and vscode share .github/skills/, codex uses .codex/skills/
+    expect(result.representativeClients).toHaveLength(2);
     expect(result.representativeClients).toContain('copilot');
+    expect(result.representativeClients).toContain('codex');
 
     const copilotGroup = result.clientGroups.get('copilot');
-    expect(copilotGroup).toHaveLength(3);
+    expect(copilotGroup).toHaveLength(2);
     expect(copilotGroup).toContain('copilot');
     expect(copilotGroup).toContain('vscode');
-    expect(copilotGroup).toContain('codex');
+
+    const codexGroup = result.clientGroups.get('codex');
+    expect(codexGroup).toHaveLength(1);
+    expect(codexGroup).toContain('codex');
   });
 });
 
 describe('collectSyncedPaths with shared paths', () => {
   it('should track file for all clients sharing the same skillsPath', () => {
-    // Simulate a copy result to .agents/skills/my-skill
+    // copilot and vscode both use .github/skills/
     const copyResults: CopyResult[] = [
       {
         source: '/some/plugin/skills/my-skill',
-        destination: '/workspace/.agents/skills/my-skill',
+        destination: '/workspace/.github/skills/my-skill',
         action: 'copied',
       },
     ];
 
-    const clients = ['copilot', 'codex', 'opencode'] as const;
+    const clients = ['copilot', 'vscode'] as const;
     const result = collectSyncedPaths(copyResults, '/workspace', [...clients], CLIENT_MAPPINGS);
 
-    // All three clients should track the same skill
-    expect(result.copilot).toContain('.agents/skills/my-skill/');
-    expect(result.codex).toContain('.agents/skills/my-skill/');
-    expect(result.opencode).toContain('.agents/skills/my-skill/');
+    // Both clients should track the same skill
+    expect(result.copilot).toContain('.github/skills/my-skill/');
+    expect(result.vscode).toContain('.github/skills/my-skill/');
   });
 
   it('should track files correctly when clients have different paths', () => {
@@ -134,7 +136,7 @@ describe('collectSyncedPaths with shared paths', () => {
       },
       {
         source: '/some/plugin/skills/skill2',
-        destination: '/workspace/.agents/skills/skill2',
+        destination: '/workspace/.github/skills/skill2',
         action: 'copied',
       },
     ];
@@ -144,10 +146,10 @@ describe('collectSyncedPaths with shared paths', () => {
 
     // claude should only track .claude/skills/skill1
     expect(result.claude).toContain('.claude/skills/skill1/');
-    expect(result.claude).not.toContain('.agents/skills/skill2/');
+    expect(result.claude).not.toContain('.github/skills/skill2/');
 
-    // copilot should only track .agents/skills/skill2
-    expect(result.copilot).toContain('.agents/skills/skill2/');
+    // copilot should only track .github/skills/skill2
+    expect(result.copilot).toContain('.github/skills/skill2/');
     expect(result.copilot).not.toContain('.claude/skills/skill1/');
   });
 });
@@ -182,11 +184,10 @@ description: A test skill
     return pluginDir;
   }
 
-  it('should copy skill only once when multiple clients share .agents/skills/', async () => {
-    // Create a plugin with a skill
+  it('should copy skill only once when multiple clients share .github/skills/', async () => {
     const pluginDir = await createPluginWithSkill('my-plugin', 'test-skill');
 
-    // Setup workspace config with clients that share .agents/skills/
+    // Setup workspace config with clients that share .github/skills/
     await mkdir(join(testDir, CONFIG_DIR), { recursive: true });
     await writeFile(
       join(testDir, CONFIG_DIR, WORKSPACE_CONFIG_FILE),
@@ -196,31 +197,25 @@ plugins:
   - ${pluginDir}
 clients:
   - copilot
-  - codex
-  - opencode
-  - gemini
-  - ampcode
+  - vscode
 `,
     );
 
     const result = await syncWorkspace(testDir);
 
     expect(result.success).toBe(true);
-    // Should only copy once (not 5 times)
+    // Should only copy once (not 2 times)
     expect(result.totalCopied).toBe(1);
 
-    // Skill should exist in .agents/skills/
-    expect(existsSync(join(testDir, '.agents', 'skills', 'test-skill', 'SKILL.md'))).toBe(true);
+    // Skill should exist in .github/skills/
+    expect(existsSync(join(testDir, '.github', 'skills', 'test-skill', 'SKILL.md'))).toBe(true);
 
-    // Verify sync state tracks the skill for all clients
+    // Verify sync state tracks the skill for both clients
     const statePath = join(testDir, CONFIG_DIR, 'sync-state.json');
     const state = JSON.parse(await readFile(statePath, 'utf-8'));
 
-    expect(state.files.copilot).toContain('.agents/skills/test-skill/');
-    expect(state.files.codex).toContain('.agents/skills/test-skill/');
-    expect(state.files.opencode).toContain('.agents/skills/test-skill/');
-    expect(state.files.gemini).toContain('.agents/skills/test-skill/');
-    expect(state.files.ampcode).toContain('.agents/skills/test-skill/');
+    expect(state.files.copilot).toContain('.github/skills/test-skill/');
+    expect(state.files.vscode).toContain('.github/skills/test-skill/');
   });
 
   it('should copy skill to different paths for clients with unique skillsPaths', async () => {
@@ -250,13 +245,13 @@ clients:
     // Skills should exist in each client's directory
     expect(existsSync(join(testDir, '.claude', 'skills', 'test-skill', 'SKILL.md'))).toBe(true);
     expect(existsSync(join(testDir, '.cursor', 'skills', 'test-skill', 'SKILL.md'))).toBe(true);
-    expect(existsSync(join(testDir, '.agents', 'skills', 'test-skill', 'SKILL.md'))).toBe(true);
+    expect(existsSync(join(testDir, '.github', 'skills', 'test-skill', 'SKILL.md'))).toBe(true);
   });
 
   it('should properly purge when a client sharing path is removed', async () => {
     const pluginDir = await createPluginWithSkill('my-plugin', 'test-skill');
 
-    // First sync with copilot and codex (both share .agents/skills/)
+    // First sync with copilot and vscode (both share .github/skills/)
     await mkdir(join(testDir, CONFIG_DIR), { recursive: true });
     await writeFile(
       join(testDir, CONFIG_DIR, WORKSPACE_CONFIG_FILE),
@@ -266,15 +261,15 @@ plugins:
   - ${pluginDir}
 clients:
   - copilot
-  - codex
+  - vscode
 `,
     );
 
     const result1 = await syncWorkspace(testDir);
     expect(result1.success).toBe(true);
-    expect(existsSync(join(testDir, '.agents', 'skills', 'test-skill', 'SKILL.md'))).toBe(true);
+    expect(existsSync(join(testDir, '.github', 'skills', 'test-skill', 'SKILL.md'))).toBe(true);
 
-    // Now remove codex from clients
+    // Now remove vscode from clients
     await writeFile(
       join(testDir, CONFIG_DIR, WORKSPACE_CONFIG_FILE),
       `
@@ -290,19 +285,19 @@ clients:
     expect(result2.success).toBe(true);
 
     // Skill should still exist (copilot still uses it)
-    expect(existsSync(join(testDir, '.agents', 'skills', 'test-skill', 'SKILL.md'))).toBe(true);
+    expect(existsSync(join(testDir, '.github', 'skills', 'test-skill', 'SKILL.md'))).toBe(true);
 
     // State should only have copilot now
     const statePath = join(testDir, CONFIG_DIR, 'sync-state.json');
     const state = JSON.parse(await readFile(statePath, 'utf-8'));
     expect(state.files.copilot).toBeDefined();
-    expect(state.files.codex).toBeUndefined();
+    expect(state.files.vscode).toBeUndefined();
   });
 
   it('should purge shared path when all clients using it are removed', async () => {
     const pluginDir = await createPluginWithSkill('my-plugin', 'test-skill');
 
-    // First sync with copilot and codex (using copy mode for predictable behavior)
+    // First sync with copilot and vscode (using copy mode for predictable behavior)
     await mkdir(join(testDir, CONFIG_DIR), { recursive: true });
     await writeFile(
       join(testDir, CONFIG_DIR, WORKSPACE_CONFIG_FILE),
@@ -312,13 +307,13 @@ plugins:
   - ${pluginDir}
 clients:
   - copilot
-  - codex
+  - vscode
 syncMode: copy
 `,
     );
 
     await syncWorkspace(testDir);
-    expect(existsSync(join(testDir, '.agents', 'skills', 'test-skill'))).toBe(true);
+    expect(existsSync(join(testDir, '.github', 'skills', 'test-skill'))).toBe(true);
 
     // Remove both clients (replace with claude)
     await writeFile(
@@ -335,8 +330,8 @@ syncMode: copy
 
     await syncWorkspace(testDir);
 
-    // .agents/skills/test-skill should be purged
-    expect(existsSync(join(testDir, '.agents', 'skills', 'test-skill'))).toBe(false);
+    // .github/skills/test-skill should be purged
+    expect(existsSync(join(testDir, '.github', 'skills', 'test-skill'))).toBe(false);
 
     // .claude/skills/test-skill should exist
     expect(existsSync(join(testDir, '.claude', 'skills', 'test-skill', 'SKILL.md'))).toBe(true);

--- a/tests/unit/core/sync.test.ts
+++ b/tests/unit/core/sync.test.ts
@@ -61,9 +61,9 @@ describe('sync', () => {
 
     it('should purge multiple clients', async () => {
       // Setup: Create directories for multiple clients
-      // Note: copilot now uses .agents/skills/ (universal agents folder)
+      // Note: copilot uses .github/skills/ (provider-specific folder)
       await mkdir(join(testDir, '.claude', 'commands'), { recursive: true });
-      await mkdir(join(testDir, '.agents', 'skills'), { recursive: true });
+      await mkdir(join(testDir, '.github', 'skills'), { recursive: true });
       await writeFile(join(testDir, 'CLAUDE.md'), '# Claude');
       await writeFile(join(testDir, 'AGENTS.md'), '# Agents');
 
@@ -72,7 +72,7 @@ describe('sync', () => {
 
       // Verify both are purged
       expect(existsSync(join(testDir, '.claude', 'commands'))).toBe(false);
-      expect(existsSync(join(testDir, '.agents', 'skills'))).toBe(false);
+      expect(existsSync(join(testDir, '.github', 'skills'))).toBe(false);
       expect(existsSync(join(testDir, 'CLAUDE.md'))).toBe(false);
       expect(existsSync(join(testDir, 'AGENTS.md'))).toBe(false);
 
@@ -725,7 +725,7 @@ clients:
     it('should purge files when client is removed from workspace.yaml', async () => {
       // Setup: Create a plugin with a skill
       // Use claude and cursor (different paths) to test removal cleanup
-      // Note: copilot uses .agents/skills/ (universal) while claude uses .claude/skills/
+      // Note: copilot uses .github/skills/ while claude uses .claude/skills/
       const pluginDir = join(testDir, 'my-plugin');
       const skillDir = join(pluginDir, 'skills', 'my-skill');
       await mkdir(skillDir, { recursive: true });
@@ -946,7 +946,7 @@ clients:
       );
 
       // Setup workspace config with two clients (use claude and cursor for different paths)
-      // Note: opencode uses .agents/skills/ (universal), cursor uses .cursor/skills/
+      // Note: opencode uses .opencode/skills/, cursor uses .cursor/skills/
       const configDir = join(testDir, '.allagents');
       await mkdir(configDir, { recursive: true });
       await writeFile(
@@ -974,7 +974,7 @@ clients:
       );
 
       // Setup workspace config with two clients (use claude and cursor for different paths)
-      // Note: opencode uses .agents/skills/ (universal), cursor uses .cursor/skills/
+      // Note: opencode uses .opencode/skills/, cursor uses .cursor/skills/
       const configDir = join(testDir, '.allagents');
       await mkdir(configDir, { recursive: true });
       await writeFile(

--- a/tests/unit/models/client-mapping.test.ts
+++ b/tests/unit/models/client-mapping.test.ts
@@ -6,6 +6,7 @@ describe('CLIENT_MAPPINGS', () => {
     const expectedClients = [
       'claude', 'copilot', 'codex', 'cursor', 'opencode', 'gemini', 'factory', 'ampcode', 'vscode',
       'openclaw', 'windsurf', 'cline', 'continue', 'roo', 'kilo', 'trae', 'augment', 'zencoder', 'junie', 'openhands', 'kiro', 'replit', 'kimi',
+      'universal',
     ];
     for (const client of expectedClients) {
       expect(CLIENT_MAPPINGS).toHaveProperty(client);
@@ -28,28 +29,28 @@ describe('CLIENT_MAPPINGS', () => {
     expect(CLIENT_MAPPINGS.factory.hooksPath).toBe('.factory/hooks/');
   });
 
-  test('copilot uses universal .agents/skills/ path', () => {
-    expect(CLIENT_MAPPINGS.copilot.skillsPath).toBe('.agents/skills/');
+  test('copilot uses provider-specific .github/skills/ path', () => {
+    expect(CLIENT_MAPPINGS.copilot.skillsPath).toBe('.github/skills/');
   });
 
-  test('codex uses universal .agents/skills/ path', () => {
-    expect(CLIENT_MAPPINGS.codex.skillsPath).toBe('.agents/skills/');
+  test('codex uses provider-specific .codex/skills/ path', () => {
+    expect(CLIENT_MAPPINGS.codex.skillsPath).toBe('.codex/skills/');
   });
 
-  test('opencode uses universal .agents/skills/ path', () => {
-    expect(CLIENT_MAPPINGS.opencode.skillsPath).toBe('.agents/skills/');
+  test('opencode uses provider-specific .opencode/skills/ path', () => {
+    expect(CLIENT_MAPPINGS.opencode.skillsPath).toBe('.opencode/skills/');
   });
 
-  test('gemini uses universal .agents/skills/ path', () => {
-    expect(CLIENT_MAPPINGS.gemini.skillsPath).toBe('.agents/skills/');
+  test('gemini uses provider-specific .gemini/skills/ path', () => {
+    expect(CLIENT_MAPPINGS.gemini.skillsPath).toBe('.gemini/skills/');
   });
 
-  test('ampcode uses universal .agents/skills/ path', () => {
-    expect(CLIENT_MAPPINGS.ampcode.skillsPath).toBe('.agents/skills/');
+  test('ampcode uses provider-specific .ampcode/skills/ path', () => {
+    expect(CLIENT_MAPPINGS.ampcode.skillsPath).toBe('.ampcode/skills/');
   });
 
-  test('vscode uses universal .agents/skills/ path', () => {
-    expect(CLIENT_MAPPINGS.vscode.skillsPath).toBe('.agents/skills/');
+  test('vscode uses provider-specific .github/skills/ path', () => {
+    expect(CLIENT_MAPPINGS.vscode.skillsPath).toBe('.github/skills/');
   });
 
   test('openclaw uses root-level skills/ path (no dot prefix)', () => {
@@ -76,12 +77,16 @@ describe('CLIENT_MAPPINGS', () => {
     expect(CLIENT_MAPPINGS.kilo.skillsPath).toBe('.kilocode/skills/');
   });
 
-  test('replit uses universal .agents/skills/ path', () => {
-    expect(CLIENT_MAPPINGS.replit.skillsPath).toBe('.agents/skills/');
+  test('replit uses provider-specific .replit/skills/ path', () => {
+    expect(CLIENT_MAPPINGS.replit.skillsPath).toBe('.replit/skills/');
   });
 
-  test('kimi uses universal .agents/skills/ path', () => {
-    expect(CLIENT_MAPPINGS.kimi.skillsPath).toBe('.agents/skills/');
+  test('kimi uses provider-specific .kimi/skills/ path', () => {
+    expect(CLIENT_MAPPINGS.kimi.skillsPath).toBe('.kimi/skills/');
+  });
+
+  test('universal uses .agents/skills/ path', () => {
+    expect(CLIENT_MAPPINGS.universal.skillsPath).toBe('.agents/skills/');
   });
 
   test('project paths are relative (no leading /)', () => {
@@ -115,28 +120,28 @@ describe('USER_CLIENT_MAPPINGS', () => {
     expect(USER_CLIENT_MAPPINGS.factory.hooksPath).toBe('.factory/hooks/');
   });
 
-  test('copilot uses universal ~/.agents/skills/ path', () => {
-    expect(USER_CLIENT_MAPPINGS.copilot.skillsPath).toBe('.agents/skills/');
+  test('copilot uses provider-specific ~/.copilot/skills/ path', () => {
+    expect(USER_CLIENT_MAPPINGS.copilot.skillsPath).toBe('.copilot/skills/');
   });
 
-  test('codex uses universal ~/.agents/skills/ path', () => {
-    expect(USER_CLIENT_MAPPINGS.codex.skillsPath).toBe('.agents/skills/');
+  test('codex uses provider-specific ~/.codex/skills/ path', () => {
+    expect(USER_CLIENT_MAPPINGS.codex.skillsPath).toBe('.codex/skills/');
   });
 
-  test('opencode uses universal ~/.agents/skills/ path', () => {
-    expect(USER_CLIENT_MAPPINGS.opencode.skillsPath).toBe('.agents/skills/');
+  test('opencode uses provider-specific ~/.opencode/skills/ path', () => {
+    expect(USER_CLIENT_MAPPINGS.opencode.skillsPath).toBe('.opencode/skills/');
   });
 
-  test('gemini uses universal ~/.agents/skills/ path', () => {
-    expect(USER_CLIENT_MAPPINGS.gemini.skillsPath).toBe('.agents/skills/');
+  test('gemini uses provider-specific ~/.gemini/skills/ path', () => {
+    expect(USER_CLIENT_MAPPINGS.gemini.skillsPath).toBe('.gemini/skills/');
   });
 
-  test('ampcode uses universal ~/.agents/skills/ path', () => {
-    expect(USER_CLIENT_MAPPINGS.ampcode.skillsPath).toBe('.agents/skills/');
+  test('ampcode uses provider-specific ~/.ampcode/skills/ path', () => {
+    expect(USER_CLIENT_MAPPINGS.ampcode.skillsPath).toBe('.ampcode/skills/');
   });
 
-  test('vscode uses universal ~/.agents/skills/ path', () => {
-    expect(USER_CLIENT_MAPPINGS.vscode.skillsPath).toBe('.agents/skills/');
+  test('vscode uses provider-specific ~/.copilot/skills/ path', () => {
+    expect(USER_CLIENT_MAPPINGS.vscode.skillsPath).toBe('.copilot/skills/');
   });
 
   test('openclaw uses root-level skills/ path', () => {
@@ -151,12 +156,16 @@ describe('USER_CLIENT_MAPPINGS', () => {
     expect(USER_CLIENT_MAPPINGS.cline.skillsPath).toBe('.cline/skills/');
   });
 
-  test('replit uses universal ~/.agents/skills/ path', () => {
-    expect(USER_CLIENT_MAPPINGS.replit.skillsPath).toBe('.agents/skills/');
+  test('replit uses provider-specific ~/.replit/skills/ path', () => {
+    expect(USER_CLIENT_MAPPINGS.replit.skillsPath).toBe('.replit/skills/');
   });
 
-  test('kimi uses universal ~/.agents/skills/ path', () => {
-    expect(USER_CLIENT_MAPPINGS.kimi.skillsPath).toBe('.agents/skills/');
+  test('kimi uses provider-specific ~/.kimi/skills/ path', () => {
+    expect(USER_CLIENT_MAPPINGS.kimi.skillsPath).toBe('.kimi/skills/');
+  });
+
+  test('universal uses ~/.agents/skills/ path', () => {
+    expect(USER_CLIENT_MAPPINGS.universal.skillsPath).toBe('.agents/skills/');
   });
 
   test('user paths are relative to home directory (no leading /)', () => {


### PR DESCRIPTION
## Summary
- Introduces `universal` as a new client type that explicitly maps to `.agents/skills/`
- All previously-universal clients (copilot, codex, vscode, opencode, gemini, ampcode, replit, kimi) now use provider-specific directories
- Only when `universal` is in the clients list does `.agents/skills/` get populated; without it, each client gets direct copies to its own directory
- Symlinks to canonical `.agents/skills/` are only created when `universal` is present

## Motivation
When multiple clients share `.agents/skills/`, some clients (e.g. copilot) that scan multiple directories (`.agents`, `.claude`, `.github`) load the same skills multiple times. This change lets users explicitly opt into `.agents/` via the `universal` client.

## New client paths (project-level)
| Client | Old | New |
|---|---|---|
| copilot | `.agents/skills/` | `.github/skills/` |
| codex | `.agents/skills/` | `.codex/skills/` |
| vscode | `.agents/skills/` | `.github/skills/` |
| opencode | `.agents/skills/` | `.opencode/skills/` |
| gemini | `.agents/skills/` | `.gemini/skills/` |
| ampcode | `.agents/skills/` | `.ampcode/skills/` |
| replit | `.agents/skills/` | `.replit/skills/` |
| kimi | `.agents/skills/` | `.kimi/skills/` |
| **universal** (new) | — | `.agents/skills/` |

## Test plan
- [x] All 682 existing tests pass
- [x] New test: canonical `.agents/skills/` not created without `universal`
- [x] Pre-push hooks pass (lint, typecheck, test)

Closes #149