### PR TITLE
feat(sync): add plugin-level client targeting

### DIFF
--- a/src/cli/commands/plugin.ts
+++ b/src/cli/commands/plugin.ts
@@ -38,6 +38,7 @@ import {
 } from '../metadata/plugin.js';
 import { skillsCmd } from './plugin-skills.js';
 import { formatMcpResult, buildSyncData } from '../format-sync.js';
+import { getPluginSource, type PluginEntry } from '../../models/workspace-config.js';
 
 
 /**
@@ -956,8 +957,9 @@ const pluginUpdateCmd = command({
         const configPath = join(process.cwd(), CONFIG_DIR, WORKSPACE_CONFIG_FILE);
         if (existsSync(configPath)) {
           const content = await readFile(configPath, 'utf-8');
-          const config = load(content) as { plugins?: string[] };
-          for (const p of config.plugins ?? []) {
+          const config = load(content) as { plugins?: PluginEntry[] };
+          for (const entry of config.plugins ?? []) {
+            const p = getPluginSource(entry);
             if (!pluginsToUpdate.includes(p)) {
               pluginsToUpdate.push(p);
             }
@@ -968,7 +970,8 @@ const pluginUpdateCmd = command({
       if (updateUser) {
         const userConfig = await getUserWorkspaceConfig();
         if (userConfig) {
-          for (const p of userConfig.plugins ?? []) {
+          for (const entry of userConfig.plugins ?? []) {
+            const p = getPluginSource(entry);
             if (!pluginsToUpdate.includes(p)) {
               pluginsToUpdate.push(p);
             }

--- a/src/core/skills.ts
+++ b/src/core/skills.ts
@@ -3,7 +3,7 @@ import { readFile, readdir } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { load } from 'js-yaml';
 import { CONFIG_DIR, WORKSPACE_CONFIG_FILE } from '../constants.js';
-import type { WorkspaceConfig } from '../models/workspace-config.js';
+import { getPluginSource, type WorkspaceConfig } from '../models/workspace-config.js';
 import { fetchPlugin, getPluginName } from './plugin.js';
 import { isGitHubUrl, parseGitHubUrl } from '../utils/plugin-path.js';
 import { isPluginSpec, resolvePluginSpecWithAutoRegister } from './marketplace.js';
@@ -74,7 +74,8 @@ export async function getAllSkillsFromPlugins(
   const disabledSkills = new Set(config.disabledSkills ?? []);
   const skills: SkillInfo[] = [];
 
-  for (const pluginSource of config.plugins) {
+  for (const pluginEntry of config.plugins) {
+    const pluginSource = getPluginSource(pluginEntry);
     const pluginPath = await resolvePluginPath(pluginSource, workspacePath);
     if (!pluginPath) continue;
 

--- a/src/core/status.ts
+++ b/src/core/status.ts
@@ -2,6 +2,7 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { CONFIG_DIR, WORKSPACE_CONFIG_FILE, getHomeDir } from '../constants.js';
 import { parseWorkspaceConfig } from '../utils/workspace-parser.js';
+import { getPluginSource } from '../models/workspace-config.js';
 import {
   parsePluginSource,
   getPluginCachePath,
@@ -63,7 +64,8 @@ export async function getWorkspaceStatus(
     const config = await parseWorkspaceConfig(configPath);
     const plugins: PluginStatus[] = [];
 
-    for (const pluginSource of config.plugins) {
+    for (const pluginEntry of config.plugins) {
+      const pluginSource = getPluginSource(pluginEntry);
       if (isPluginSpec(pluginSource)) {
         const status = await getMarketplacePluginStatus(pluginSource);
         plugins.push(status);
@@ -133,7 +135,8 @@ async function getUserPluginStatuses(): Promise<PluginStatus[]> {
   if (!config) return [];
 
   const statuses: PluginStatus[] = [];
-  for (const pluginSource of config.plugins) {
+  for (const pluginEntry of config.plugins) {
+    const pluginSource = getPluginSource(pluginEntry);
     if (isPluginSpec(pluginSource)) {
       statuses.push(await getMarketplacePluginStatus(pluginSource));
     } else {

--- a/src/models/workspace-config.ts
+++ b/src/models/workspace-config.ts
@@ -93,6 +93,34 @@ export const ClientTypeSchema = z.enum([
 export type ClientType = z.infer<typeof ClientTypeSchema>;
 
 /**
+ * Plugin entry in workspace.yaml
+ * Supports string shorthand and object form with optional client override.
+ */
+export const PluginEntrySchema = z.union([
+  PluginSourceSchema,
+  z.object({
+    source: PluginSourceSchema,
+    clients: z.array(ClientTypeSchema).optional(),
+  }),
+]);
+
+export type PluginEntry = z.infer<typeof PluginEntrySchema>;
+
+/**
+ * Resolve plugin source from plugin entry (string or object form)
+ */
+export function getPluginSource(plugin: PluginEntry): string {
+  return typeof plugin === 'string' ? plugin : plugin.source;
+}
+
+/**
+ * Resolve optional plugin-level clients from plugin entry
+ */
+export function getPluginClients(plugin: PluginEntry): ClientType[] | undefined {
+  return typeof plugin === 'string' ? undefined : plugin.clients;
+}
+
+/**
  * VSCode workspace generation configuration
  */
 export const VscodeConfigSchema = z.object({
@@ -116,7 +144,7 @@ export type SyncMode = z.infer<typeof SyncModeSchema>;
 export const WorkspaceConfigSchema = z.object({
   workspace: WorkspaceSchema.optional(),
   repositories: z.array(RepositorySchema),
-  plugins: z.array(PluginSourceSchema),
+  plugins: z.array(PluginEntrySchema),
   clients: z.array(ClientTypeSchema),
   vscode: VscodeConfigSchema.optional(),
   syncMode: SyncModeSchema.optional(),

--- a/tests/unit/core/sync-plugin-clients.test.ts
+++ b/tests/unit/core/sync-plugin-clients.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtemp, rm, mkdir, writeFile, readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { syncWorkspace } from '../../../src/core/sync.js';
+import { CONFIG_DIR, WORKSPACE_CONFIG_FILE } from '../../../src/constants.js';
+
+async function createPlugin(baseDir: string, name: string, skillName: string): Promise<string> {
+  const pluginDir = join(baseDir, name);
+  const skillDir = join(pluginDir, 'skills', skillName);
+  await mkdir(skillDir, { recursive: true });
+  await writeFile(
+    join(skillDir, 'SKILL.md'),
+    `---
+name: ${skillName}
+description: ${skillName} description
+---
+`,
+    'utf-8',
+  );
+  return pluginDir;
+}
+
+describe('syncWorkspace - plugin-level clients', () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'allagents-sync-plugin-clients-'));
+    await mkdir(join(testDir, CONFIG_DIR), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  it('uses plugin-level clients override instead of workspace clients', async () => {
+    await createPlugin(testDir, 'override-plugin', 'override-skill');
+
+    await writeFile(
+      join(testDir, CONFIG_DIR, WORKSPACE_CONFIG_FILE),
+      `
+repositories: []
+plugins:
+  - source: ./override-plugin
+    clients:
+      - claude
+clients:
+  - claude
+  - copilot
+`,
+      'utf-8',
+    );
+
+    const result = await syncWorkspace(testDir);
+    expect(result.success).toBe(true);
+    expect(existsSync(join(testDir, '.claude', 'skills', 'override-skill'))).toBe(true);
+    expect(existsSync(join(testDir, '.github', 'skills', 'override-skill'))).toBe(false);
+  });
+
+  it('falls back to workspace clients when plugin-level clients are not set', async () => {
+    await createPlugin(testDir, 'fallback-plugin', 'fallback-skill');
+
+    await writeFile(
+      join(testDir, CONFIG_DIR, WORKSPACE_CONFIG_FILE),
+      `
+repositories: []
+plugins:
+  - ./fallback-plugin
+clients:
+  - claude
+  - copilot
+`,
+      'utf-8',
+    );
+
+    const result = await syncWorkspace(testDir);
+    expect(result.success).toBe(true);
+    expect(existsSync(join(testDir, '.claude', 'skills', 'fallback-skill'))).toBe(true);
+    expect(existsSync(join(testDir, '.github', 'skills', 'fallback-skill'))).toBe(true);
+  });
+
+  it('partial sync ignores plugins that do not target the selected client', async () => {
+    await createPlugin(testDir, 'copilot-plugin', 'copilot-skill');
+
+    await writeFile(
+      join(testDir, CONFIG_DIR, WORKSPACE_CONFIG_FILE),
+      `
+repositories: []
+plugins:
+  - source: ./missing-claude-plugin
+    clients:
+      - claude
+  - source: ./copilot-plugin
+    clients:
+      - copilot
+clients:
+  - claude
+  - copilot
+`,
+      'utf-8',
+    );
+
+    const result = await syncWorkspace(testDir, { clients: ['copilot'] });
+    expect(result.success).toBe(true);
+    expect(result.totalFailed).toBe(0);
+    expect(existsSync(join(testDir, '.github', 'skills', 'copilot-skill'))).toBe(true);
+  });
+
+  it('tracks plugin-level-only client in sync state and allows partial sync for it', async () => {
+    await createPlugin(testDir, 'codex-plugin', 'codex-skill');
+
+    await writeFile(
+      join(testDir, CONFIG_DIR, WORKSPACE_CONFIG_FILE),
+      `
+repositories: []
+plugins:
+  - source: ./codex-plugin
+    clients:
+      - codex
+clients:
+  - claude
+syncMode: copy
+`,
+      'utf-8',
+    );
+
+    const result = await syncWorkspace(testDir);
+    expect(result.success).toBe(true);
+    expect(existsSync(join(testDir, '.codex', 'skills', 'codex-skill'))).toBe(true);
+
+    const stateContent = await readFile(
+      join(testDir, CONFIG_DIR, 'sync-state.json'),
+      'utf-8',
+    );
+    const state = JSON.parse(stateContent) as { files: Record<string, string[]> };
+    expect(state.files.codex).toBeDefined();
+    expect(state.files.codex?.length).toBeGreaterThan(0);
+
+    const partial = await syncWorkspace(testDir, { clients: ['codex'] });
+    expect(partial.success).toBe(true);
+    expect(partial.totalFailed).toBe(0);
+  });
+});

--- a/tests/unit/models/workspace-config.test.ts
+++ b/tests/unit/models/workspace-config.test.ts
@@ -34,6 +34,21 @@ describe('WorkspaceConfigSchema', () => {
     const result = WorkspaceConfigSchema.safeParse(invalidConfig);
     expect(result.success).toBe(false);
   });
+
+  it('should accept plugin object with optional clients', () => {
+    const config = {
+      repositories: [],
+      plugins: [
+        { source: 'code-review@claude-plugins-official', clients: ['claude', 'codex'] },
+        './plugins/example',
+      ],
+      clients: ['claude'],
+    };
+
+    const result = WorkspaceConfigSchema.safeParse(config);
+    expect(result.success).toBe(true);
+  });
+
 });
 
 describe('ClientTypeSchema', () => {


### PR DESCRIPTION
Closes #151

## Summary
- Add plugin entry object form with optional per-plugin client overrides.
- Compute effective clients per plugin during sync, with workspace clients as fallback.
- Fix partial sync and sync-state tracking for plugin-level-only clients.
- Keep behavior client-driven and remove redundant `skillsLayout` config.
- Update workspace/user/status/skills/prune/plugin-update paths to support plugin entry object form.
- Add unit coverage for override, fallback, partial sync, and parser behavior.

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm test -- tests/unit/core/sync-plugin-clients.test.ts tests/unit/core/sync.test.ts tests/unit/core/user-workspace.test.ts tests/unit/models/workspace-config.test.ts tests/unit/utils/workspace-parser.test.ts`
- Manual CLI e2e with built binary: `node dist/index.js workspace sync`
