### PR TITLE
fix(tui): move universal client to top of selection list

### DIFF
--- a/src/models/workspace-config.ts
+++ b/src/models/workspace-config.ts
@@ -64,6 +64,7 @@ export type PluginSource = z.infer<typeof PluginSourceSchema>;
  * Supported AI client types
  */
 export const ClientTypeSchema = z.enum([
+  'universal',
   'claude',
   'copilot',
   'codex',
@@ -87,7 +88,6 @@ export const ClientTypeSchema = z.enum([
   'kiro',
   'replit',
   'kimi',
-  'universal',
 ]);
 
 export type ClientType = z.infer<typeof ClientTypeSchema>;


### PR DESCRIPTION
## Summary
- Moves `universal` from last position (24/24) to first in the `ClientTypeSchema` enum
- This makes it immediately visible in both the TUI client management and workspace init screens, instead of being buried at the bottom of a long scrollable list

Closes #158

## Test plan
- [x] All 729 unit tests pass
- [x] Pre-push hooks pass (lint, typecheck, test)
- [x] Manual E2E: verified `universal` appears first in "Clients" management screen
- [x] Manual E2E: verified `universal` appears first in "Workspace > Init" client selection