### PR TITLE
feat(plugin): show native CLI installs in plugin list

### DIFF
--- a/src/cli/commands/plugin.ts
+++ b/src/cli/commands/plugin.ts
@@ -40,7 +40,18 @@ import {
 } from '../metadata/plugin.js';
 import { skillsCmd } from './plugin-skills.js';
 import { formatMcpResult, formatNativeResult, buildSyncData } from '../format-sync.js';
-import { getPluginSource, type PluginEntry } from '../../models/workspace-config.js';
+import {
+  getPluginSource,
+  getPluginClients,
+  getClientTypes,
+  type PluginEntry,
+  type WorkspaceConfig,
+} from '../../models/workspace-config.js';
+import { CONFIG_DIR, WORKSPACE_CONFIG_FILE } from '../../constants.js';
+import { readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { load } from 'js-yaml';
 
 
 /**
@@ -611,6 +622,34 @@ const pluginListCmd = command({
   args: {},
   handler: async () => {
     try {
+      // Build per-plugin client map from workspace configs
+      // key = "spec:scope" → file-sync client types
+      const pluginClients = new Map<string, string[]>();
+
+      async function loadConfigClients(
+        configPath: string,
+        scope: 'user' | 'project',
+      ): Promise<void> {
+        if (!existsSync(configPath)) return;
+        try {
+          const content = await readFile(configPath, 'utf-8');
+          const config = load(content) as WorkspaceConfig;
+          if (!config?.plugins || !config?.clients) return;
+          const defaultClients = getClientTypes(config.clients);
+          for (const entry of config.plugins) {
+            const spec = getPluginSource(entry);
+            const clients = getPluginClients(entry) ?? defaultClients;
+            pluginClients.set(`${spec}:${scope}`, clients);
+          }
+        } catch { /* ignore read/parse errors */ }
+      }
+
+      const userConfigPath = join(getAllagentsDir(), WORKSPACE_CONFIG_FILE);
+      const projectConfigPath = join(process.cwd(), CONFIG_DIR, WORKSPACE_CONFIG_FILE);
+      await loadConfigClients(userConfigPath, 'user');
+      await loadConfigClients(projectConfigPath, 'project');
+
+      // Get installed marketplace plugins
       const userPlugins = await getInstalledUserPlugins();
       const projectPlugins = await getInstalledProjectPlugins(process.cwd());
       const allInstalled = [...userPlugins, ...projectPlugins];
@@ -619,17 +658,17 @@ const pluginListCmd = command({
       const userSyncState = await loadSyncState(getAllagentsDir());
       const projectSyncState = await loadSyncState(process.cwd());
 
-      // Build merged map: key = "spec:scope" → { spec, scope, nativeClients[] }
+      // Build merged map: key = "spec:scope"
       interface MergedPlugin {
         spec: string;
         name: string;
         marketplace: string;
         scope: 'user' | 'project';
+        fileClients: string[];
         nativeClients: string[];
       }
       const merged = new Map<string, MergedPlugin>();
 
-      // Add marketplace plugins
       for (const p of allInstalled) {
         const key = `${p.spec}:${p.scope}`;
         merged.set(key, {
@@ -637,6 +676,7 @@ const pluginListCmd = command({
           name: p.name,
           marketplace: p.marketplace,
           scope: p.scope,
+          fileClients: pluginClients.get(key) ?? [],
           nativeClients: [],
         });
       }
@@ -660,6 +700,7 @@ const pluginListCmd = command({
                 name: spec.split('@')[0] ?? spec,
                 marketplace: spec.split('@')[1] ?? '',
                 scope,
+                fileClients: [],
                 nativeClients: [client],
               });
             }
@@ -678,6 +719,7 @@ const pluginListCmd = command({
               name: p.name,
               marketplace: p.marketplace,
               scope: p.scope,
+              ...(p.fileClients.length > 0 && { clients: p.fileClients }),
               ...(p.nativeClients.length > 0 && { nativeClients: p.nativeClients }),
             })),
             total: plugins.length,
@@ -697,10 +739,18 @@ const pluginListCmd = command({
 
       console.log('Installed plugins:\n');
       for (const p of plugins) {
-        const tags = p.nativeClients.map((c) => `native: ${c}`);
-        const suffix = tags.length > 0 ? ` (${tags.join(', ')})` : '';
-        console.log(`  ❯ ${p.spec}${suffix}`);
-        console.log(`    Scope: ${p.scope}\n`);
+        console.log(`  ❯ ${p.spec}`);
+        console.log(`    Scope: ${p.scope}`);
+
+        const hasClients = p.fileClients.length > 0 || p.nativeClients.length > 0;
+        if (hasClients) {
+          const parts = [
+            ...p.nativeClients.map((c) => `native ${c}`),
+            ...p.fileClients,
+          ];
+          console.log(`    Clients: ${parts.join(', ')}`);
+        }
+        console.log('');
       }
 
       console.log(`Total: ${plugins.length} installed`);


### PR DESCRIPTION
## Summary

- `plugin list` now loads sync state from both user (`~/.allagents`) and project scopes to display native CLI plugin installs alongside marketplace plugins
- Native plugins are shown with `(native: <client>)` suffix (e.g., `cargowise@wtg-ai-prompts (native: claude)`)
- JSON output includes native plugins with a `native: true` flag
- Total count and empty-state check account for native plugins

## Test plan

- [x] All existing tests pass (764 pass, 0 fail)
- [ ] Manual: run `plugin list` in a project with native CLI installs and verify they appear
- [ ] Manual: run `plugin list --json` and verify native plugins are in the output with `native: true`