### PR TITLE
fix(native): use canonical marketplace name for native plugin specs

### DIFF
--- a/src/core/sync.ts
+++ b/src/core/sync.ts
@@ -43,6 +43,7 @@ import {
   isPluginSpec,
   resolvePluginSpecWithAutoRegister,
   ensureMarketplacesRegistered,
+  parsePluginSpec,
 } from './marketplace.js';
 import {
   loadSyncState,
@@ -210,6 +211,8 @@ export interface ValidatedPlugin {
   error?: string;
   /** Plugin name from marketplace manifest (overrides plugin.json / directory name) */
   pluginName?: string;
+  /** Canonical marketplace name when it differs from the spec (e.g., manifest overrides repo name) */
+  registeredAs?: string;
 }
 
 interface PluginSyncPlan {
@@ -217,6 +220,59 @@ interface PluginSyncPlan {
   clients: ClientType[];
   /** Clients that should use native install for this plugin */
   nativeClients: ClientType[];
+}
+
+/**
+ * Build a native-friendly plugin spec using the canonical marketplace name.
+ * When a marketplace manifest overrides the repo name (e.g., repo "WTG.AI.Prompts"
+ * → manifest name "wtg-ai-prompts"), the native CLI only knows the canonical name.
+ *
+ * Returns the canonical spec and, if applicable, the original owner/repo source
+ * needed to pre-register the marketplace with the native CLI.
+ */
+function resolveNativePluginSource(vp: ValidatedPlugin): {
+  spec: string;
+  marketplaceSource?: string;
+} {
+  if (!vp.registeredAs) return { spec: vp.plugin };
+
+  const parsed = parsePluginSpec(vp.plugin);
+  if (!parsed) return { spec: vp.plugin };
+
+  const canonicalSpec = `${parsed.plugin}@${vp.registeredAs}`;
+  if (parsed.owner && parsed.repo) {
+    return { spec: canonicalSpec, marketplaceSource: `${parsed.owner}/${parsed.repo}` };
+  }
+  return { spec: canonicalSpec };
+}
+
+/**
+ * Collect native plugin specs and marketplace sources from validated plugins.
+ * Resolves canonical marketplace names so native CLI operations use the correct spec.
+ */
+function collectNativePluginSources(validPlugins: ValidatedPlugin[]): {
+  pluginsByClient: Map<ClientType, string[]>;
+  marketplaceSourcesByClient: Map<ClientType, Set<string>>;
+} {
+  const pluginsByClient = new Map<ClientType, string[]>();
+  const marketplaceSourcesByClient = new Map<ClientType, Set<string>>();
+
+  for (const vp of validPlugins) {
+    for (const client of vp.nativeClients) {
+      const existing = pluginsByClient.get(client) ?? [];
+      const { spec, marketplaceSource } = resolveNativePluginSource(vp);
+      existing.push(spec);
+      pluginsByClient.set(client, existing);
+
+      if (marketplaceSource) {
+        const sources = marketplaceSourcesByClient.get(client) ?? new Set();
+        sources.add(marketplaceSource);
+        marketplaceSourcesByClient.set(client, sources);
+      }
+    }
+  }
+
+  return { pluginsByClient, marketplaceSourcesByClient };
 }
 
 function collectSyncClients(
@@ -757,6 +813,7 @@ async function validatePlugin(
       clients: [],
       nativeClients: [],
       ...(resolved.pluginName && { pluginName: resolved.pluginName }),
+      ...(resolved.registeredAs && { registeredAs: resolved.registeredAs }),
     };
   }
 
@@ -1324,15 +1381,10 @@ export async function syncWorkspace(
 
   // Step 4b: Native CLI installations
   let nativeResult: NativeSyncResult | undefined;
-  const nativePluginsByClient = new Map<ClientType, string[]>();
-
-  for (const vp of validPlugins) {
-    for (const client of vp.nativeClients) {
-      const existing = nativePluginsByClient.get(client) ?? [];
-      existing.push(vp.plugin);
-      nativePluginsByClient.set(client, existing);
-    }
-  }
+  const {
+    pluginsByClient: nativePluginsByClient,
+    marketplaceSourcesByClient: nativeMarketplaceSources,
+  } = collectNativePluginSources(validPlugins);
 
   // Detect clients that previously had native plugins but no longer do (mode switch or removal)
   const previousNativeClients = previousState?.nativePlugins
@@ -1363,6 +1415,15 @@ export async function syncWorkspace(
           warnings.push(`Native install: ${clientType} CLI not found, skipping native plugin installation`);
         }
         continue;
+      }
+
+      // Pre-register marketplaces whose canonical name differs from repo name.
+      // syncPlugins won't extract these from canonical specs (no owner/repo).
+      const marketplaceSources = nativeMarketplaceSources.get(clientType);
+      if (marketplaceSources) {
+        for (const source of marketplaceSources) {
+          await nativeClient.addMarketplace(source, { cwd: workspacePath });
+        }
       }
 
       // Uninstall removed plugins
@@ -1716,15 +1777,10 @@ export async function syncUserWorkspace(
 
   // Run native CLI installations for user scope
   let nativeResult: NativeSyncResult | undefined;
-  const nativePluginsByClient = new Map<ClientType, string[]>();
-
-  for (const vp of validPlugins) {
-    for (const client of vp.nativeClients) {
-      const existing = nativePluginsByClient.get(client) ?? [];
-      existing.push(vp.plugin);
-      nativePluginsByClient.set(client, existing);
-    }
-  }
+  const {
+    pluginsByClient: nativePluginsByClient,
+    marketplaceSourcesByClient: nativeMarketplaceSources,
+  } = collectNativePluginSources(validPlugins);
 
   // Detect clients that previously had native plugins but no longer do
   const previousNativeClients = previousState?.nativePlugins
@@ -1755,6 +1811,14 @@ export async function syncUserWorkspace(
           warnings.push(`Native install: ${clientType} CLI not found, skipping native plugin installation`);
         }
         continue;
+      }
+
+      // Pre-register marketplaces whose canonical name differs from repo name
+      const marketplaceSources = nativeMarketplaceSources.get(clientType);
+      if (marketplaceSources) {
+        for (const source of marketplaceSources) {
+          await nativeClient.addMarketplace(source);
+        }
       }
 
       // Uninstall removed plugins

--- a/tests/unit/core/native/canonical-name-mismatch.test.ts
+++ b/tests/unit/core/native/canonical-name-mismatch.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'bun:test';
+import { ClaudeNativeClient } from '../../../../src/core/native/claude.js';
+
+/**
+ * Demonstrates the native uninstall bug when a marketplace manifest
+ * overrides the repo name.
+ *
+ * Example: repo "owner/WTG.AI.Prompts" has a manifest that sets
+ * name: "wtg-ai-prompts". The native CLI registers the marketplace
+ * under the canonical name "wtg-ai-prompts", but allagents stores
+ * the spec using the repo name "WTG.AI.Prompts".
+ *
+ * On uninstall, allagents passes "plugin@WTG.AI.Prompts" to the
+ * native CLI, which doesn't recognize it — it only knows
+ * "plugin@wtg-ai-prompts".
+ */
+describe('native uninstall — canonical name mismatch', () => {
+  const client = new ClaudeNativeClient();
+
+  it('toPluginSpec uses repo name, not the canonical marketplace name', () => {
+    // The plugin source as stored in ValidatedPlugin.plugin
+    const pluginSource = 'code-review@owner/WTG.AI.Prompts';
+
+    // toPluginSpec drops the owner but keeps the repo name verbatim
+    const spec = client.toPluginSpec(pluginSource);
+    expect(spec).toBe('code-review@WTG.AI.Prompts');
+
+    // But the native CLI registered the marketplace under canonical name
+    // from the manifest: "wtg-ai-prompts"
+    const canonicalSpec = 'code-review@wtg-ai-prompts';
+
+    // BUG: The spec we'd use for uninstall doesn't match
+    // what the native CLI actually knows
+    expect(spec).not.toBe(canonicalSpec);
+  });
+
+  it('uninstall flow uses wrong spec when marketplace name differs from repo', () => {
+    // Simulate the sync flow without the fix:
+    //
+    // 1. Install: vp.plugin is pushed to nativePluginsByClient
+    const vpPlugin = 'code-review@owner/WTG.AI.Prompts';
+
+    // 2. toPluginSpec converts for install and state storage
+    const installedSpec = client.toPluginSpec(vpPlugin);
+    expect(installedSpec).toBe('code-review@WTG.AI.Prompts');
+
+    // 3. This spec is saved in sync state as nativePlugins.claude
+    const syncState = [installedSpec!]; // ["code-review@WTG.AI.Prompts"]
+
+    // 4. On next sync, plugin is removed from config
+    const currentSpecs: string[] = []; // no plugins
+
+    // 5. Diff: previousPlugins - currentSpecs = removed
+    const removed = syncState.filter((p) => !currentSpecs.includes(p));
+    expect(removed).toEqual(['code-review@WTG.AI.Prompts']);
+
+    // 6. uninstallPlugin is called with "code-review@WTG.AI.Prompts"
+    //    but native CLI only knows "code-review@wtg-ai-prompts"
+    //    → uninstall fails silently (caught as warning)
+    expect(removed[0]).not.toBe('code-review@wtg-ai-prompts');
+  });
+
+  it('canonical spec works correctly for uninstall', () => {
+    // With the fix: resolveNativePluginSource returns canonical spec
+    // when registeredAs is set
+    const canonicalSource = 'code-review@wtg-ai-prompts';
+
+    // toPluginSpec leaves it unchanged (no owner/repo to strip)
+    const spec = client.toPluginSpec(canonicalSource);
+    expect(spec).toBe('code-review@wtg-ai-prompts');
+
+    // This matches what the native CLI knows → uninstall works
+    const syncState = [spec!];
+    const currentSpecs: string[] = [];
+    const removed = syncState.filter((p) => !currentSpecs.includes(p));
+    expect(removed[0]).toBe('code-review@wtg-ai-prompts');
+  });
+});


### PR DESCRIPTION
## Summary

- When a marketplace manifest overrides the repo name (e.g., repo `WTG.AI.Prompts` → manifest name `wtg-ai-prompts`), native CLI uninstall failed because allagents stored the spec using the repo name while the native CLI registered it under the canonical name
- Propagates `registeredAs` through `ValidatedPlugin` and uses it to build native-friendly specs with the canonical name
- Pre-registers marketplaces whose canonical name differs from repo name before native sync

## Test plan

- [x] Unit test demonstrating the spec mismatch (`canonical-name-mismatch.test.ts`)
- [x] Full test suite passes (767 pass, 0 fail)
- [x] Pre-commit hooks pass (lint, typecheck, test)