### PR TITLE
fix(sync): skip stale skill directories without SKILL.md

### DIFF
--- a/src/core/transform.ts
+++ b/src/core/transform.ts
@@ -331,7 +331,11 @@ export async function collectPluginSkills(
   }
 
   const entries = await readdir(skillsDir, { withFileTypes: true });
-  const skillDirs = entries.filter((e) => e.isDirectory());
+  // Only include directories that contain a SKILL.md file.
+  // Stale directories (e.g., skills removed from marketplace) are skipped.
+  const skillDirs = entries.filter(
+    (e) => e.isDirectory() && existsSync(join(skillsDir, e.name, 'SKILL.md')),
+  );
 
   // Filter out disabled skills if disabledSkills set is provided
   const filteredDirs = disabledSkills && pluginName

--- a/tests/unit/core/skill-resolution.test.ts
+++ b/tests/unit/core/skill-resolution.test.ts
@@ -59,6 +59,25 @@ description: Skill B
     expect(skills).toHaveLength(0);
   });
 
+  it('should skip skill directories without SKILL.md', async () => {
+    const pluginDir = join(testDir, 'plugin-with-stale');
+    await mkdir(join(pluginDir, 'skills', 'valid-skill'), { recursive: true });
+    await mkdir(join(pluginDir, 'skills', 'stale-skill'), { recursive: true });
+    await writeFile(
+      join(pluginDir, 'skills', 'valid-skill', 'SKILL.md'),
+      `---
+name: valid-skill
+description: Valid Skill
+---`,
+    );
+    // stale-skill has no SKILL.md (e.g., removed from marketplace)
+
+    const skills = await collectPluginSkills(pluginDir, 'test-source');
+
+    expect(skills).toHaveLength(1);
+    expect(skills[0]?.folderName).toBe('valid-skill');
+  });
+
   it('should ignore files in skills directory (only dirs)', async () => {
     const pluginDir = join(testDir, 'plugin-with-files');
     await mkdir(join(pluginDir, 'skills', 'real-skill'), { recursive: true });


### PR DESCRIPTION
## Summary

- When a skill is removed from a marketplace plugin, its directory may persist on disk without a `SKILL.md` file (e.g., git doesn't remove empty directories after pull)
- `collectPluginSkills` now checks for `SKILL.md` existence before including a directory, preventing false "SKILL.md not found" errors during `workspace sync`
- Stale directories are silently skipped rather than reported as copy failures

## Test plan

- [x] Added unit test: `should skip skill directories without SKILL.md`
- [x] Full test suite passes (768 tests, 0 failures)