### PR TITLE
fix(sync): copy skill directories even without SKILL.md

### DIFF
--- a/src/core/transform.ts
+++ b/src/core/transform.ts
@@ -331,11 +331,7 @@ export async function collectPluginSkills(
   }
 
   const entries = await readdir(skillsDir, { withFileTypes: true });
-  // Only include directories that contain a SKILL.md file.
-  // Stale directories (e.g., skills removed from marketplace) are skipped.
-  const skillDirs = entries.filter(
-    (e) => e.isDirectory() && existsSync(join(skillsDir, e.name, 'SKILL.md')),
-  );
+  const skillDirs = entries.filter((e) => e.isDirectory());
 
   // Filter out disabled skills if disabledSkills set is provided
   const filteredDirs = disabledSkills && pluginName

--- a/tests/unit/core/skill-resolution.test.ts
+++ b/tests/unit/core/skill-resolution.test.ts
@@ -59,10 +59,10 @@ description: Skill B
     expect(skills).toHaveLength(0);
   });
 
-  it('should skip skill directories without SKILL.md', async () => {
+  it('should include skill directories without SKILL.md', async () => {
     const pluginDir = join(testDir, 'plugin-with-stale');
     await mkdir(join(pluginDir, 'skills', 'valid-skill'), { recursive: true });
-    await mkdir(join(pluginDir, 'skills', 'stale-skill'), { recursive: true });
+    await mkdir(join(pluginDir, 'skills', 'no-skillmd'), { recursive: true });
     await writeFile(
       join(pluginDir, 'skills', 'valid-skill', 'SKILL.md'),
       `---
@@ -70,12 +70,12 @@ name: valid-skill
 description: Valid Skill
 ---`,
     );
-    // stale-skill has no SKILL.md (e.g., removed from marketplace)
 
     const skills = await collectPluginSkills(pluginDir, 'test-source');
 
-    expect(skills).toHaveLength(1);
-    expect(skills[0]?.folderName).toBe('valid-skill');
+    expect(skills).toHaveLength(2);
+    const names = skills.map((s) => s.folderName).sort();
+    expect(names).toEqual(['no-skillmd', 'valid-skill']);
   });
 
   it('should ignore files in skills directory (only dirs)', async () => {


### PR DESCRIPTION
## Summary
- Reverts the SKILL.md existence check added in #170
- `collectPluginSkills` now copies all skill subdirectories, leaving validation to the consuming coding agent
- Updated test to assert directories without SKILL.md are included