### PR TITLE
fix(sync): remove validation gate from copySkills

### DIFF
--- a/src/core/transform.ts
+++ b/src/core/transform.ts
@@ -5,7 +5,6 @@ import { resolveGlobPatterns, isGlobPattern } from '../utils/glob-patterns.js';
 import { CLIENT_MAPPINGS, isUniversalClient } from '../models/client-mapping.js';
 import type { ClientMapping } from '../models/client-mapping.js';
 import type { ClientType, WorkspaceFile, SyncMode } from '../models/workspace-config.js';
-import { validateSkill } from '../validators/skill.js';
 import { generateWorkspaceRules, type WorkspaceRepository } from '../constants.js';
 import { parseFileSource } from '../utils/plugin-path.js';
 import { createSymlink } from '../utils/symlink.js';
@@ -239,17 +238,6 @@ export async function copySkills(
     // Use resolved name from skillNameMap if available, otherwise use folder name
     const resolvedName = skillNameMap?.get(entry.name) ?? entry.name;
     const skillDestPath = join(destDir, resolvedName);
-
-    // Validate skill before copying
-    const validation = await validateSkill(skillSourcePath);
-    if (!validation.valid) {
-      return {
-        source: skillSourcePath,
-        destination: skillDestPath,
-        action: 'failed',
-        ...(validation.error && { error: validation.error }),
-      };
-    }
 
     if (dryRun) {
       return {


### PR DESCRIPTION
## Summary

- Removes the `validateSkill` check in `copySkills` that caused skill directories without `SKILL.md` to be reported as failures
- After #171 intentionally collects all skill directories (including those without `SKILL.md`), the validation gate was inconsistent and produced spurious error messages during sync
- Skill validation is left to the consuming coding agent, not the copy step

## Test plan

- [x] All 772 existing tests pass
- [ ] Run `allagents workspace sync` with a plugin that has skill directories without `SKILL.md` — verify no error messages appear