### PR TITLE
fix(vscode): use relative paths in .code-workspace folders

### DIFF
--- a/src/core/vscode-workspace.ts
+++ b/src/core/vscode-workspace.ts
@@ -1,4 +1,4 @@
-import { resolve, basename, isAbsolute } from 'node:path';
+import { resolve, relative, basename, isAbsolute } from 'node:path';
 import type { Repository, VscodeConfig } from '../models/workspace-config.js';
 
 /**
@@ -34,13 +34,16 @@ export type PathPlaceholderMap = Map<string, string>;
 /**
  * Build a placeholder map from repositories using path as the lookup key.
  *
+ * Resolves repository paths relative to workspacePath, producing clean relative paths
+ * (with `..` segments normalized). This keeps .code-workspace files portable.
+ *
  * @param repositories - Repository list from workspace.yaml
  * @param workspacePath - Workspace root for resolving relative paths
- * @returns Map of relative paths to absolute paths
+ * @returns Map of original paths to normalized relative paths
  *
  * @example
  * // Given: { path: "../Glow" } and workspacePath: "/home/user/workspace"
- * // Result: Map { "../Glow" => "/home/user/Glow" }
+ * // Result: Map { "../Glow" => "../Glow" }
  */
 export function buildPathPlaceholderMap(
   repositories: Repository[],
@@ -50,7 +53,8 @@ export function buildPathPlaceholderMap(
 
   for (const repo of repositories) {
     const absolutePath = resolve(workspacePath, repo.path);
-    map.set(repo.path, absolutePath);
+    const relativePath = relative(workspacePath, absolutePath);
+    map.set(repo.path, relativePath);
   }
 
   return map;
@@ -63,7 +67,7 @@ export function buildPathPlaceholderMap(
  *
  * @example
  * // Given repositories: [{ path: "../Glow" }]
- * "{path:../Glow}/src" → "/home/user/Glow/src"
+ * "{path:../Glow}/src" → "../Glow/src"
  * "D:\\GitHub\\Glow" → "D:/GitHub/Glow"
  */
 export function substitutePathPlaceholders<T>(
@@ -121,28 +125,33 @@ export function generateVscodeWorkspace(
 
   // 0. Current workspace folder
   folders.push({ path: '.' });
-  // Track absolute path for deduplication
-  seenPaths.add(resolve(workspacePath, '.'));
+  // Track absolute path for deduplication (normalized for cross-platform)
+  seenPaths.add(resolve(workspacePath, '.').replace(/\\/g, '/'));
 
   // 1. Repository folders (from workspace.yaml)
+  // Use relative paths so the .code-workspace file stays portable when the workspace moves.
   for (const repo of repositories) {
-    const absolutePath = resolve(workspacePath, repo.path).replace(/\\/g, '/');
-    folders.push({ path: absolutePath });
-    seenPaths.add(absolutePath);
+    const absolutePath = resolve(workspacePath, repo.path);
+    const relPath = relative(workspacePath, absolutePath).replace(/\\/g, '/');
+    folders.push({ path: relPath });
+    seenPaths.add(absolutePath.replace(/\\/g, '/'));
   }
 
   // 2. Template folders (deduplicated against repo folders, preserve optional name)
   if (resolvedTemplate && Array.isArray(resolvedTemplate.folders)) {
     for (const folder of resolvedTemplate.folders as WorkspaceFolder[]) {
       const rawPath = folder.path as string;
-      const normalizedPath = (typeof rawPath === 'string' && !isAbsolute(rawPath)
+      // Resolve to absolute for deduplication only
+      const absoluteForDedup = (typeof rawPath === 'string' && !isAbsolute(rawPath)
         ? resolve(workspacePath, rawPath)
         : rawPath).replace(/\\/g, '/');
-      if (!seenPaths.has(normalizedPath)) {
+      if (!seenPaths.has(absoluteForDedup)) {
+        // Keep the path as-is (just normalize backslashes)
+        const normalizedPath = rawPath.replace(/\\/g, '/');
         const entry: WorkspaceFolder = { path: normalizedPath };
         if (folder.name) entry.name = folder.name;
         folders.push(entry);
-        seenPaths.add(normalizedPath);
+        seenPaths.add(absoluteForDedup);
       }
     }
   }

--- a/tests/unit/cli/workspace-setup.test.ts
+++ b/tests/unit/cli/workspace-setup.test.ts
@@ -39,11 +39,9 @@ clients:
 
     const folders = result.folders as Array<{ path: string }>;
     expect(folders[0].path).toBe('.');
-    // On Windows paths are absolute (C:\...) not starting with /
-    // Just verify they are not relative (don't start with . or ..)
-    for (const folder of folders.slice(1)) {
-      expect(folder.path.startsWith('.')).toBe(false);
-    }
+    // Paths should be relative for portability (e.g., ../backend, ../frontend)
+    expect(folders[1].path).toBe('../backend');
+    expect(folders[2].path).toBe('../frontend');
 
     expect(result.settings).toEqual({ 'chat.agent.maxRequests': 999 });
   });

--- a/tests/unit/core/vscode-workspace.test.ts
+++ b/tests/unit/core/vscode-workspace.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { resolve, join } from 'node:path';
+import { resolve, relative, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
   buildPathPlaceholderMap,
@@ -12,7 +12,7 @@ import {
 const testBase = join(tmpdir(), 'allagents-test');
 
 describe('generateVscodeWorkspace', () => {
-  test('generates workspace with repository folders resolved to absolute paths', () => {
+  test('generates workspace with repository folders as relative paths', () => {
     const workspacePath = join(testBase, 'myapp');
     const result = generateVscodeWorkspace({
       workspacePath,
@@ -25,8 +25,8 @@ describe('generateVscodeWorkspace', () => {
 
     expect(result.folders).toEqual([
       { path: '.' },
-      { path: resolve(workspacePath, '../backend').replace(/\\/g, '/') },
-      { path: resolve(workspacePath, '../frontend').replace(/\\/g, '/') },
+      { path: '../backend' },
+      { path: '../frontend' },
     ]);
   });
 
@@ -44,8 +44,8 @@ describe('generateVscodeWorkspace', () => {
 
   test('merges template folders after repo folders, deduplicating by path', () => {
     const workspacePath = join(testBase, 'myapp');
-    const sharedPath = resolve(workspacePath, '../shared').replace(/\\/g, '/');
-    const extraPath = join(testBase, 'extra').replace(/\\/g, '/');
+    const sharedAbsPath = resolve(workspacePath, '../shared').replace(/\\/g, '/');
+    const extraAbsPath = join(testBase, 'extra').replace(/\\/g, '/');
 
     const result = generateVscodeWorkspace({
       workspacePath,
@@ -55,19 +55,19 @@ describe('generateVscodeWorkspace', () => {
       ],
       template: {
         folders: [
-          { path: sharedPath, name: 'SharedLib' }, // duplicate of ../shared
-          { path: extraPath, name: 'ExtraLib' },
+          { path: sharedAbsPath, name: 'SharedLib' }, // duplicate of ../shared (absolute)
+          { path: extraAbsPath, name: 'ExtraLib' },
         ],
       },
     });
 
-    // ../shared resolves to sharedPath — template duplicate removed
-    // extra is not a duplicate, so it's kept with its name
+    // ../shared deduplicates against template's absolute sharedAbsPath
+    // extra is not a duplicate, so it's kept with its name (absolute, from template)
     expect(result.folders).toEqual([
       { path: '.' },
-      { path: resolve(workspacePath, '../backend').replace(/\\/g, '/') },
-      { path: sharedPath },
-      { path: extraPath, name: 'ExtraLib' },
+      { path: '../backend' },
+      { path: '../shared' },
+      { path: extraAbsPath, name: 'ExtraLib' },
     ]);
   });
 
@@ -114,18 +114,16 @@ describe('generateVscodeWorkspace', () => {
 });
 
 describe('substitutePathPlaceholders', () => {
-  // Use resolved paths for the map values (with forward slashes for consistency)
-  const glowPath = resolve(testBase, 'Glow').replace(/\\/g, '/');
-  const glowSharedPath = resolve(testBase, 'Glow.Shared').replace(/\\/g, '/');
+  // Path map now contains relative paths (matching buildPathPlaceholderMap behavior)
   const pathMap = new Map<string, string>([
-    ['../Glow', glowPath],
-    ['../Glow.Shared', glowSharedPath],
+    ['../Glow', '../Glow'],
+    ['../Glow.Shared', '../Glow.Shared'],
   ]);
 
   test('substitutes {path:..} in string values', () => {
     const input = { cwd: '{path:../Glow}/DotNet/Client' };
     const result = substitutePathPlaceholders(input, pathMap);
-    expect(result.cwd).toBe(`${glowPath}/DotNet/Client`);
+    expect(result.cwd).toBe('../Glow/DotNet/Client');
   });
 
   test('substitutes in nested objects', () => {
@@ -137,7 +135,7 @@ describe('substitutePathPlaceholders', () => {
       },
     };
     const result = substitutePathPlaceholders(input, pathMap);
-    expect(result.launch.configurations[0].cwd).toBe(`${glowPath}/src`);
+    expect(result.launch.configurations[0].cwd).toBe('../Glow/src');
     expect(result.launch.configurations[0].name).toBe('dev');
   });
 
@@ -148,7 +146,7 @@ describe('substitutePathPlaceholders', () => {
       ],
     };
     const result = substitutePathPlaceholders(input, pathMap);
-    expect(result.folders[0].path).toBe(glowSharedPath);
+    expect(result.folders[0].path).toBe('../Glow.Shared');
   });
 
   test('leaves strings without placeholders unchanged', () => {
@@ -165,28 +163,30 @@ describe('substitutePathPlaceholders', () => {
 });
 
 describe('buildPathPlaceholderMap', () => {
-  test('registers repositories by relative path', () => {
+  test('registers repositories with normalized relative paths', () => {
     const workspacePath = join(testBase, 'workspace');
     const map = buildPathPlaceholderMap(
       [{ path: '../Glow' }, { path: '../Glow.Shared' }],
       workspacePath,
     );
 
-    expect(map.get('../Glow')).toBe(resolve(workspacePath, '../Glow'));
-    expect(map.get('../Glow.Shared')).toBe(resolve(workspacePath, '../Glow.Shared'));
+    expect(map.get('../Glow')).toBe(relative(workspacePath, resolve(workspacePath, '../Glow')));
+    expect(map.get('../Glow.Shared')).toBe(relative(workspacePath, resolve(workspacePath, '../Glow.Shared')));
   });
 
-  test('resolves paths to absolute paths', () => {
+  test('produces relative paths for portability', () => {
     const workspacePath = join(testBase, 'workspace');
     const map = buildPathPlaceholderMap(
       [{ path: '../Glow', repo: 'WiseTechGlobal/Glow' }],
       workspacePath,
     );
 
-    // Path should be absolute (not relative)
     const resolved = map.get('../Glow');
     expect(resolved).toBeDefined();
-    expect(resolved).not.toContain('..');
+    // Path should be relative (contains ..) for portability
+    expect(resolved).toContain('..');
+    // Path should not be absolute
+    expect(resolved!.startsWith('/')).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- Repository folder paths in `.code-workspace` files are now relative instead of absolute, making the workspace portable when moved to a different directory
- `{path:...}` template placeholders also resolve to relative paths for consistency
- Template folder deduplication still works correctly using absolute paths internally for comparison

Closes #186

## Test plan
- [x] All 796 unit tests pass
- [x] `buildPathPlaceholderMap` produces relative paths (`../Glow` stays `../Glow`)
- [x] `generateVscodeWorkspace` emits relative folder paths (`../backend` instead of `/home/user/backend`)
- [x] Template folder deduplication still works (absolute paths used only for comparison)
- [x] Template folders with absolute paths preserved as-is