### PR TITLE
docs: require clarification before fixing ambiguous bug reports

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,11 +33,9 @@ When working on a GitHub issue, **ALWAYS** follow this workflow:
 
 1. **Create a worktree with a feature branch** from `main`:
    ```bash
-   # From the repository root
-   cd /path/to/allagents
-   git worktree add ../allagents_<type>-<short-description> <type>/<issue-number>-<short-description>
-   # Example: git worktree add ../allagents_feat-add-new-embedder feat/42-add-new-embedder
-   cd ../allagents_<type>-<short-description>
+   git worktree add .worktrees/<type>-<short-description> -b <type>/<issue-number>-<short-description>
+   # Example: git worktree add .worktrees/feat-add-new-embedder -b feat/42-add-new-embedder
+   cd .worktrees/<type>-<short-description>
    ```
 
 2. **Implement the changes** and commit following the commit convention
@@ -118,23 +116,11 @@ If a mock doesn't match the real interface (e.g., missing a `name` field the rea
 
 ### Git Worktrees
 
-**ALWAYS use git worktrees for feature development.** This allows you to work on multiple branches simultaneously without switching contexts.
-
-Create worktrees in a **sibling folder** using the naming convention `projectname_branchname`:
-
-```bash
-# From the repository root
-git worktree add ../allagents_<branchname> <branchname>
-
-# Examples:
-git worktree add ../allagents_feat-new-feature feat/new-feature
-git worktree add ../allagents_fix-bug-123 fix/123-description
-```
+**ALWAYS use git worktrees for feature development.** Worktrees live in `.worktrees/` (already in `.gitignore`).
 
 When done:
 ```bash
-# Remove worktree after branch is merged
-git worktree remove ../allagents_<branchname>
+git worktree remove .worktrees/<name>
 ```
 
 ## Architecture Notes


### PR DESCRIPTION
## Summary
- Adds a "Bug Reports and Issue Requirements" section to CLAUDE.md instructing the agent to ask clarifying questions before writing code when a bug report is vague or could be user error
- Prevents wasted effort on fixes that solve the wrong problem

## Context
Issue #186 reported "symlinks should use relative paths" but the actual cause was running `workspace sync` from the wrong directory. A code change was made and PR'd unnecessarily because the requirement wasn't clarified first.