### PR TITLE
fix(cli): skip interactive client prompt when --from is used

### DIFF
--- a/src/cli/commands/workspace.ts
+++ b/src/cli/commands/workspace.ts
@@ -67,8 +67,9 @@ const initCmd = command({
       const targetPath = path ?? '.';
       let clients = client ? parseClientEntries(client) : undefined;
 
-      // If no --client flag, prompt interactively
-      if (!clients) {
+      // If no --client flag and no --from, prompt interactively.
+      // When --from is used, the remote workspace.yaml defines the clients.
+      if (!clients && !from) {
         const { promptForClients } = await import('../tui/prompt-clients.js');
         const prompted = await promptForClients();
         if (prompted === null) {

--- a/src/cli/tui/actions/init.ts
+++ b/src/cli/tui/actions/init.ts
@@ -1,5 +1,6 @@
 import * as p from '@clack/prompts';
 import { initWorkspace } from '../../../core/workspace.js';
+import type { ClientEntry } from '../../../models/workspace-config.js';
 import { promptForClients } from '../prompt-clients.js';
 
 const { text } = p;
@@ -30,10 +31,15 @@ export async function runInit(): Promise<void> {
       return;
     }
 
-    const selectedClients = await promptForClients();
-
-    if (selectedClients === null) {
-      return;
+    // Skip client prompt when a template source is provided — the remote
+    // workspace.yaml already defines the desired client configuration.
+    let selectedClients: ClientEntry[] | undefined;
+    if (!fromSource) {
+      const prompted = await promptForClients();
+      if (prompted === null) {
+        return;
+      }
+      selectedClients = prompted;
     }
 
     const s = p.spinner();
@@ -41,14 +47,14 @@ export async function runInit(): Promise<void> {
 
     const options: Parameters<typeof initWorkspace>[1] = {
       ...(fromSource ? { from: fromSource } : {}),
-      ...(selectedClients.length > 0 ? { clients: selectedClients } : {}),
+      ...(selectedClients && selectedClients.length > 0 ? { clients: selectedClients } : {}),
     };
     const result = await initWorkspace(targetPath, options);
 
     s.stop('Workspace initialized');
 
     const lines = [`Path: ${result.path}`];
-    if (selectedClients.length > 0) {
+    if (selectedClients && selectedClients.length > 0) {
       lines.push(`Clients: ${selectedClients.join(', ')}`);
     }
     if (result.syncResult) {


### PR DESCRIPTION
## Summary

- When `workspace init --from <url>` is used, skip the interactive "Which AI clients do you use?" prompt
- The remote `workspace.yaml` already defines the client configuration — prompting is redundant and breaks the non-interactive use case
- Fix applied to both CLI command handler and TUI guided init flow

## E2E verification

```bash
# Build
bun run build

# With --from: no prompt, uses remote workspace.yaml clients
./dist/index.js workspace init /tmp/test-from --from https://github.com/WiseTechGlobal/WTG.AI.Prompts/tree/main/scripts/allagents-setup/cargowise
# ✓ No interactive prompt, clients from remote template (universal, copilot, vscode)

# Without --from: prompt still appears as expected
./dist/index.js workspace init /tmp/test-no-from
# ✓ Interactive client selection prompt shown
```