### PR TITLE
fix(codex): skip unnecessary codex CLI call and fix Windows ENOENT

### DIFF
--- a/src/core/codex-mcp.ts
+++ b/src/core/codex-mcp.ts
@@ -87,6 +87,11 @@ export async function syncCodexMcpServers(
     trackedServers: [],
   };
 
+  // Skip calling codex CLI entirely when there are no MCP servers to sync and nothing to remove
+  if (pluginServers.size === 0 && previouslyTracked.size === 0) {
+    return result;
+  }
+
   // List existing Codex MCP servers
   const listResult = await exec('codex', ['mcp', 'list', '--json']);
   if (!listResult.success) {

--- a/src/core/native/types.ts
+++ b/src/core/native/types.ts
@@ -58,6 +58,7 @@ export function executeCommand(
     const proc = spawn(binary, args, {
       cwd: options.cwd,
       stdio: ['ignore', 'pipe', 'pipe'],
+      shell: process.platform === 'win32',
       env: { ...process.env },
     });
 

--- a/tests/unit/core/codex-mcp.test.ts
+++ b/tests/unit/core/codex-mcp.test.ts
@@ -178,6 +178,24 @@ describe('syncCodexMcpServers', () => {
     expect(result.warnings.some((w) => w.toLowerCase().includes('codex'))).toBe(true);
   });
 
+  test('skips codex CLI call when no plugins have MCP servers and nothing previously tracked', async () => {
+    // Plugin has no .mcp.json
+    let execCalled = false;
+    const mockExecute = (_binary: string, _args: string[]): NativeCommandResult => {
+      execCalled = true;
+      return { success: true, output: '[]' };
+    };
+
+    const result = await syncCodexMcpServers([makePlugin(pluginDir)], {
+      _mockExecute: mockExecute,
+    });
+
+    expect(execCalled).toBe(false);
+    expect(result.added).toBe(0);
+    expect(result.removed).toBe(0);
+    expect(result.warnings).toHaveLength(0);
+  });
+
   test('dryRun does not call add or remove', async () => {
     writeFileSync(
       join(pluginDir, '.mcp.json'),


### PR DESCRIPTION
## Summary

- **Skip codex CLI call when no MCP servers to sync**: `syncCodexMcpServers` was calling `codex mcp list` unconditionally even when no plugins had MCP servers and nothing was previously tracked. This produced a spurious warning on every sync. Now early-returns when there's nothing to do.
- **Fix Windows spawn ENOENT**: `executeCommand` uses `spawn()` without `shell: true`, which fails on Windows because npm-installed CLIs (like `codex`) use `.cmd` wrappers that require shell resolution. Added `shell: true` on Windows.

## Test plan

- [x] Unit tests pass (`bun test tests/unit/core/codex-mcp.test.ts` — 11 tests)
- [x] New test: verifies codex CLI is never called when no plugins have MCP servers
- [x] E2E: Created temp workspace with codex client + plugin without MCP servers → no codex warning
- [x] E2E: Ran `workspace sync` from user's original project directory → no codex warning
- [x] Pre-push hooks pass (lint, typecheck, test)

```bash
# E2E steps to reproduce
mkdir -p /tmp/allagents-e2e-test/test-plugin
echo 'name: test-no-mcp
version: 0.1.0
description: Test plugin
skills:
  - name: hello
    path: hello.md' > /tmp/allagents-e2e-test/test-plugin/plugin.yaml
echo "Hello" > /tmp/allagents-e2e-test/test-plugin/hello.md
echo 'clients:
  - codex
plugins:
  - source: ./test-plugin' > /tmp/allagents-e2e-test/workspace.yaml

cd /tmp/allagents-e2e-test
bun run build  # from repo root
./dist/index.js workspace sync
# Verify: no "Codex CLI not available" warning
rm -rf /tmp/allagents-e2e-test
```