### PR TITLE
fix(marketplace): don't log auto-register when marketplace already exists

### DIFF
--- a/src/cli/commands/plugin.ts
+++ b/src/cli/commands/plugin.ts
@@ -911,7 +911,7 @@ const pluginInstallCmd = command({
 
       if (!isJsonMode()) {
         if (result.autoRegistered) {
-          console.log(`\u2713 Auto-registered marketplace: ${result.autoRegistered}`);
+          console.log(`  Resolved marketplace: ${result.autoRegistered}`);
         }
         console.log(`\u2713 Installed plugin (${isUser ? 'user' : 'project'} scope): ${displayPlugin}`);
       }

--- a/src/core/marketplace.ts
+++ b/src/core/marketplace.ts
@@ -66,6 +66,8 @@ export interface MarketplaceResult {
   success: boolean;
   marketplace?: MarketplaceEntry;
   error?: string;
+  /** True when addMarketplace returned an already-registered entry (idempotent) */
+  alreadyRegistered?: boolean;
   /** User-level plugins that were removed during marketplace removal cascade */
   removedUserPlugins?: string[];
   /** User-level plugins that still reference the removed marketplace (returned when cascade is off) */
@@ -277,7 +279,7 @@ export async function addMarketplace(
   })();
   const existingBySource = findBySourceLocation(registry, sourceLocation);
   if (existingBySource) {
-    return { success: true, marketplace: existingBySource };
+    return { success: true, marketplace: existingBySource, alreadyRegistered: true };
   }
 
   let marketplacePath: string;
@@ -349,6 +351,7 @@ export async function addMarketplace(
           return {
             success: true,
             marketplace: existing,
+            alreadyRegistered: true,
           };
         }
         name = manifestName;
@@ -1063,12 +1066,14 @@ async function autoRegisterMarketplace(
         return { success: true, name: existing.name };
       }
 
-      console.log(`Auto-registering GitHub marketplace: ${source}`);
       const result = await addMarketplace(source);
       if (!result.success) {
         return { success: false, error: result.error || 'Unknown error' };
       }
       const name = result.marketplace?.name ?? parts[1];
+      if (!result.alreadyRegistered) {
+        console.log(`Auto-registered GitHub marketplace: ${source}`);
+      }
       registeredSourceCache.set(source, name);
       return { success: true, name };
     }

--- a/tests/unit/core/marketplace-dedup.test.ts
+++ b/tests/unit/core/marketplace-dedup.test.ts
@@ -119,11 +119,12 @@ describe('marketplace deduplication', () => {
       expect(results).toHaveLength(2);
       expect(results.every((r) => r.success)).toBe(true);
 
-      // Should only have logged 2 auto-registration messages
+      // Only the first marketplace is truly new — the second finds
+      // the existing entry via manifest name, so no log is emitted.
       const autoRegLogs = logMessages.filter((m) =>
-        m.includes('Auto-registering'),
+        m.includes('Auto-registered'),
       );
-      expect(autoRegLogs).toHaveLength(2);
+      expect(autoRegLogs).toHaveLength(1);
     });
 
     it('should skip already registered marketplaces', async () => {
@@ -141,7 +142,7 @@ describe('marketplace deduplication', () => {
 
       // Should not have logged any auto-registration (already registered)
       const autoRegLogs = logMessages.filter((m) =>
-        m.includes('Auto-registering'),
+        m.includes('Auto-registered'),
       );
       expect(autoRegLogs).toHaveLength(0);
 
@@ -188,7 +189,7 @@ describe('marketplace deduplication', () => {
       // Pre-register marketplaces (like sync.ts does before validateAllPlugins)
       await ensureMarketplacesRegistered(plugins);
       const preRegLogs = logMessages.filter((m) =>
-        m.includes('Auto-registering'),
+        m.includes('Auto-registered'),
       );
       expect(preRegLogs).toHaveLength(1);
 
@@ -202,7 +203,7 @@ describe('marketplace deduplication', () => {
 
       // Should NOT have logged any additional auto-registration messages
       const postRegLogs = logMessages.filter((m) =>
-        m.includes('Auto-registering'),
+        m.includes('Auto-registered'),
       );
       expect(postRegLogs).toHaveLength(0);
     });


### PR DESCRIPTION
## Summary

- `addMarketplace` now returns `alreadyRegistered: true` when it finds an existing entry (via source location or manifest name)
- `autoRegisterMarketplace` only logs "Auto-registered" for genuinely new registrations
- `plugin install` command shows "Resolved marketplace:" instead of "✓ Auto-registered marketplace:" since it fires whenever the canonical name differs from the spec

## Problem

When running `plugin install glow@WiseTechGlobal/WTG.AI.Prompts` with `wtg-ai-prompts` already registered locally, the output showed:

```
Auto-registering GitHub marketplace: WiseTechGlobal/WTG.AI.Prompts
✓ Auto-registered marketplace: wtg-ai-prompts
```

This was misleading — nothing was actually registered, it found the existing marketplace via manifest name.

## Test plan

- [x] Updated dedup test expectations to match new behavior
- [x] All 36 marketplace tests pass
- [x] Pre-commit hooks pass (lint, typecheck, test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)