### PR TITLE
fix(plugin): use canonical key for plugin list deduplication

### DIFF
--- a/src/cli/commands/plugin.ts
+++ b/src/cli/commands/plugin.ts
@@ -639,6 +639,12 @@ const pluginListCmd = command({
       // key = "spec:scope" → file-sync client types
       const pluginClients = new Map<string, string[]>();
 
+      // Canonical key for deduplication: uses parsed name+marketplace so different
+      // spec formats (e.g., "plugin@owner/repo" vs "plugin@repo") resolve to the same key
+      function canonicalKey(name: string, marketplace: string, scope: string): string {
+        return `${name}:${marketplace}:${scope}`;
+      }
+
       async function loadConfigClients(
         configPath: string,
         scope: 'user' | 'project',
@@ -671,7 +677,7 @@ const pluginListCmd = command({
       const userSyncState = await loadSyncState(getAllagentsDir());
       const projectSyncState = await loadSyncState(process.cwd());
 
-      // Build merged map: key = "spec:scope"
+      // Build merged map: key = "name:marketplace:scope" for format-independent dedup
       interface MergedPlugin {
         spec: string;
         name: string;
@@ -683,25 +689,28 @@ const pluginListCmd = command({
       const merged = new Map<string, MergedPlugin>();
 
       for (const p of allInstalled) {
-        const key = `${p.spec}:${p.scope}`;
+        const key = canonicalKey(p.name, p.marketplace, p.scope);
         merged.set(key, {
           spec: p.spec,
           name: p.name,
           marketplace: p.marketplace,
           scope: p.scope,
-          fileClients: pluginClients.get(key) ?? [],
+          fileClients: pluginClients.get(`${p.spec}:${p.scope}`) ?? [],
           nativeClients: [],
         });
       }
 
-      // Merge native plugins
+      // Merge native plugins using the same canonical key
       for (const [state, scope] of [
         [userSyncState, 'user'],
         [projectSyncState, 'project'],
       ] as const) {
         for (const [client, specs] of Object.entries(state?.nativePlugins ?? {})) {
           for (const spec of specs) {
-            const key = `${spec}:${scope}`;
+            const parsed = parsePluginSpec(spec);
+            const key = parsed
+              ? canonicalKey(parsed.plugin, parsed.marketplaceName, scope)
+              : `${spec}::${scope}`;
             const existing = merged.get(key);
             if (existing) {
               if (!existing.nativeClients.includes(client)) {
@@ -710,8 +719,8 @@ const pluginListCmd = command({
             } else {
               merged.set(key, {
                 spec,
-                name: spec.split('@')[0] ?? spec,
-                marketplace: spec.split('@')[1] ?? '',
+                name: parsed?.plugin ?? spec,
+                marketplace: parsed?.marketplaceName ?? '',
                 scope,
                 fileClients: [],
                 nativeClients: [client],


### PR DESCRIPTION
## Problem

`plugin list` shows duplicate entries for plugins that have both file-sync and native clients:

```
❯ agentv-dev@EntityProcess/agentv
  Scope: project
  Clients: universal, vscode, claude

❯ agentv-dev@agentv
  Scope: project
  Clients: native claude
```

These are the same plugin. The duplication happens because:

1. **Installed plugins** (from workspace.yaml) use the full spec: `agentv-dev@EntityProcess/agentv`
2. **Native plugins** (from sync state) use a shortened spec: `agentv-dev@agentv`
   - This is because `claude.ts:toPluginSpec()` strips `owner/repo` → `repo` for Claude CLI compatibility
3. The merge map in `plugin list` used `${spec}:${scope}` as keys, so these two specs produced different map entries

## Fix

Use `${name}:${marketplace}:${scope}` as the canonical map key instead of `${spec}:${scope}`. Both spec formats parse to the same name (`agentv-dev`) and marketplace (`agentv`) via `parsePluginSpec()`, so they merge correctly.

### Key design decisions

- **Only the `merged` dedup map uses canonical keys.** The `pluginClients` map (file-sync client types) still uses raw `${spec}:${scope}` keys — it's populated and looked up from the same workspace.yaml spec string, so no format mismatch exists there.
- **Non-marketplace plugins** (GitHub URLs, local paths) fall through `parsePluginSpec()` → `null` and use `${spec}::${scope}` as a fallback key. These never have native clients, so format mismatch is not possible.
- **No data format changes.** Sync state, workspace.yaml, and all persisted data are untouched. This is purely display-layer logic.

## After

```
❯ superpowers@superpowers-dev
  Scope: user
  Clients: copilot, codex, vscode

❯ agentv-dev@EntityProcess/agentv
  Scope: project
  Clients: native claude, universal, vscode, claude

Total: 2 installed
```

## Follow-up consideration

The merge logic in the `plugin list` handler is ~60 lines of inline code with multiple maps using different key formats. Extracting the pure merge logic into a standalone function (e.g., `mergePluginList(installed, pluginClients, nativePlugins) → MergedPlugin[]`) would make it unit-testable and reduce regression risk. Not done here to keep the PR focused.

## Test plan

- [x] Build CLI and run `plugin list` in workspace with plugins that have both file-sync and native clients
- [x] Verify only one entry per plugin, with file-sync and native clients merged
- [x] Verify plugins with only file-sync clients (no native) still appear correctly
- [x] Verify JSON output mode shows correct merged structure
- [x] Lint and typecheck pass

### E2E reproduction

```bash
bun run build

# Before (v0.32.2) — shows 3 plugins, agentv-dev listed twice:
cd /path/to/workspace-with-native-plugins
npx allagents plugin list

# After (this PR) — shows 2 plugins, agentv-dev merged:
node /path/to/worktree/dist/index.js plugin list
# ❯ agentv-dev@EntityProcess/agentv
#   Clients: native claude, universal, vscode, claude

# JSON mode also correct:
node /path/to/worktree/dist/index.js plugin list --json
# total: 2, agentv-dev has both clients and nativeClients arrays
```