### PR TITLE
fix(cli): move update notice to top of output and highlight in yellow

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -30,15 +30,11 @@ setJsonMode(json);
 
 // Kick off update check for non-json, non-agent-help invocations.
 // Reads from local cache (fast), spawns a detached child to refresh if stale.
-// The notice is printed on process exit so it appears after command output,
-// even if the command calls process.exit() directly.
+// The notice is printed before command output so it's immediately visible.
 const isWizard = finalArgs.length === 0 && process.stdout.isTTY && !json;
-let updateNotice: string | null = null;
 if (!agentHelp && !json && !isWizard) {
-  process.on('exit', () => {
-    if (updateNotice) process.stderr.write(`\n${updateNotice}\n`);
-  });
-  getUpdateNotice(packageJson.version).then((n) => { updateNotice = n; });
+  const notice = await getUpdateNotice(packageJson.version);
+  if (notice) process.stderr.write(`${notice}\n\n`);
 }
 
 if (agentHelp) {

--- a/src/cli/update-check.ts
+++ b/src/cli/update-check.ts
@@ -1,6 +1,7 @@
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { spawn } from 'node:child_process';
+import chalk from 'chalk';
 import { getHomeDir, CONFIG_DIR } from '../constants.js';
 
 const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
@@ -68,7 +69,7 @@ export function buildNotice(
 ): string | null {
   if (!latestVersion) return null;
   if (!isNewer(latestVersion, currentVersion)) return null;
-  return `  Update available: ${currentVersion} → ${latestVersion}\n  Run \`allagents self update\` to upgrade.`;
+  return chalk.yellow(`Update available: ${currentVersion} → ${latestVersion}\nRun \`allagents self update\` to upgrade.`);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Move the update notice from bottom (process exit) to top (before command output)
- Highlight the notice in yellow using chalk
- Remove leading indent from notice text

## Test plan
- [x] Build and run `allagents workspace sync` with a stale version cache to verify notice appears at top in yellow
- [x] Verify `--json` and `--agent-help` modes still suppress the notice