### PR TITLE
feat: show skills and other artifacts deleted by workspace sync

### DIFF
--- a/src/cli/format-sync.ts
+++ b/src/cli/format-sync.ts
@@ -1,5 +1,5 @@
 import type { NativeSyncResult } from '../core/native/types.js';
-import type { SyncResult } from '../core/sync.js';
+import type { SyncResult, DeletedArtifact } from '../core/sync.js';
 import type { CopyResult } from '../core/transform.js';
 import type { McpMergeResult } from '../core/vscode-mcp.js';
 import { CLIENT_MAPPINGS, USER_CLIENT_MAPPINGS, getDisplayName } from '../models/client-mapping.js';
@@ -171,7 +171,33 @@ export function formatSyncSummary(
   if (result.totalFailed > 0) lines.push(`  Total failed: ${result.totalFailed}`);
   if (result.totalSkipped > 0) lines.push(`  Total skipped: ${result.totalSkipped}`);
 
+  if (result.deletedArtifacts && result.deletedArtifacts.length > 0) {
+    lines.push(...formatDeletedArtifacts(result.deletedArtifacts));
+  }
+
   return lines;
+}
+
+/**
+ * Format deleted artifacts as display lines grouped by client.
+ * Example: "  Deleted (Claude): skill 'old-skill', command 'deprecated-cmd'"
+ */
+export function formatDeletedArtifacts(artifacts: DeletedArtifact[]): string[] {
+  const byClient = new Map<string, DeletedArtifact[]>();
+  for (const artifact of artifacts) {
+    const displayName = getDisplayName(artifact.client);
+    let list = byClient.get(displayName);
+    if (!list) {
+      list = [];
+      byClient.set(displayName, list);
+    }
+    list.push(artifact);
+  }
+
+  return Array.from(byClient.entries()).map(([displayClient, items]) => {
+    const names = items.map((a) => `${a.type} '${a.name}'`).join(', ');
+    return `  Deleted (${displayClient}): ${names}`;
+  });
 }
 
 /**
@@ -261,6 +287,7 @@ export function buildSyncData(result: SyncResult) {
       copyResults: pr.copyResults,
     })),
     purgedPaths: result.purgedPaths ?? [],
+    deletedArtifacts: result.deletedArtifacts ?? [],
     ...(result.mcpResults && {
       mcpServers: Object.fromEntries(
         Object.entries(result.mcpResults)

--- a/src/core/sync.ts
+++ b/src/core/sync.ts
@@ -126,6 +126,16 @@ export function deduplicateClientsByPath(
 /**
  * Result of a sync operation
  */
+/**
+ * A named artifact (skill, command, hook, or agent) that was deleted during sync
+ * because it was no longer provided by any plugin.
+ */
+export interface DeletedArtifact {
+  client: ClientType;
+  type: 'skill' | 'command' | 'agent' | 'hook';
+  name: string;
+}
+
 export interface SyncResult {
   success: boolean;
   pluginResults: PluginSyncResult[];
@@ -135,6 +145,8 @@ export interface SyncResult {
   totalGenerated: number;
   /** Paths that were/would be purged per client */
   purgedPaths?: PurgePaths[];
+  /** Named artifacts that were deleted and not re-synced by any plugin */
+  deletedArtifacts?: DeletedArtifact[];
   error?: string;
   /** Warnings for plugins that were skipped during sync */
   warnings?: string[];
@@ -153,6 +165,7 @@ export function mergeSyncResults(a: SyncResult, b: SyncResult): SyncResult {
   const warnings = [...(a.warnings || []), ...(b.warnings || [])];
   const messages = [...(a.messages || []), ...(b.messages || [])];
   const purgedPaths = [...(a.purgedPaths || []), ...(b.purgedPaths || [])];
+  const deletedArtifacts = [...(a.deletedArtifacts || []), ...(b.deletedArtifacts || [])];
   const mcpResults = (a.mcpResults || b.mcpResults)
     ? { ...a.mcpResults, ...b.mcpResults }
     : undefined;
@@ -175,6 +188,7 @@ export function mergeSyncResults(a: SyncResult, b: SyncResult): SyncResult {
     ...(warnings.length > 0 && { warnings }),
     ...(messages.length > 0 && { messages }),
     ...(purgedPaths.length > 0 && { purgedPaths }),
+    ...(deletedArtifacts.length > 0 && { deletedArtifacts }),
     ...(mcpResults && { mcpResults }),
     ...(nativeResult && { nativeResult }),
   };
@@ -817,8 +831,94 @@ export function collectSyncedPaths(
 }
 
 /**
+ * Classify a single sync-state path into a named artifact for a given client.
+ * Returns null for paths that are not top-level artifacts or not part of the
+ * managed artifact directories (e.g. files nested inside a skill directory are
+ * skipped – the skill directory entry itself is sufficient).
+ */
+function classifyDeletedPath(
+  path: string,
+  client: ClientType,
+  mapping: ClientMapping,
+): DeletedArtifact | null {
+  // Skills are tracked as "<skillsPath><name>/" (trailing slash) by collectSyncedPaths.
+  // Files inside a skill directory are also stored, but we skip them to avoid duplicates.
+  if (mapping.skillsPath && path.startsWith(mapping.skillsPath)) {
+    const rest = path.slice(mapping.skillsPath.length);
+    if (rest.endsWith('/') && !rest.slice(0, -1).includes('/')) {
+      return { client, type: 'skill', name: rest.slice(0, -1) };
+    }
+    return null;
+  }
+
+  if (mapping.commandsPath && path.startsWith(mapping.commandsPath)) {
+    const rest = path.slice(mapping.commandsPath.length);
+    const topLevel = rest.split('/')[0];
+    if (!topLevel) return null;
+    return { client, type: 'command', name: topLevel.replace(/\.md$/i, '') };
+  }
+
+  if (mapping.hooksPath && path.startsWith(mapping.hooksPath)) {
+    const rest = path.slice(mapping.hooksPath.length);
+    const topLevel = rest.split('/')[0];
+    if (!topLevel) return null;
+    return { client, type: 'hook', name: topLevel.replace(/\.md$/i, '') };
+  }
+
+  if (mapping.agentsPath && path.startsWith(mapping.agentsPath)) {
+    const rest = path.slice(mapping.agentsPath.length);
+    const topLevel = rest.split('/')[0];
+    if (!topLevel) return null;
+    return { client, type: 'agent', name: topLevel.replace(/\.md$/i, '') };
+  }
+
+  return null;
+}
+
+/**
+ * Compute which named artifacts were deleted during sync by comparing the
+ * previous sync state with the paths that were re-synced in this run.
+ *
+ * An artifact is considered deleted when it existed in the previous state but
+ * is not present in the new state (i.e. no plugin re-provided it).
+ */
+export function computeDeletedArtifacts(
+  previousState: SyncState | null,
+  newStatePaths: Partial<Record<ClientType, string[]>>,
+  clients: ClientType[],
+  clientMappings: Record<string, ClientMapping>,
+): DeletedArtifact[] {
+  if (!previousState) return [];
+
+  const deleted: DeletedArtifact[] = [];
+  const seen = new Set<string>();
+
+  for (const client of clients) {
+    const oldPaths = previousState.files[client] ?? [];
+    const newPaths = new Set(newStatePaths[client] ?? []);
+    const mapping = clientMappings[client];
+    if (!mapping) continue;
+
+    for (const path of oldPaths) {
+      if (newPaths.has(path)) continue;
+
+      const artifact = classifyDeletedPath(path, client, mapping);
+      if (!artifact) continue;
+
+      const key = `${client}:${artifact.type}:${artifact.name}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        deleted.push(artifact);
+      }
+    }
+  }
+
+  return deleted;
+}
+
+
+/**
  * Validate a single plugin by resolving its path without copying
- * @param pluginSource - Plugin source
  * @param workspacePath - Path to workspace directory
  * @param offline - Skip fetching from remote and use cached version
  * @returns Validation result with resolved path
@@ -1806,6 +1906,12 @@ export async function syncWorkspace(
   const { totalCopied, totalFailed, totalSkipped, totalGenerated } = countCopyResults(pluginResults, workspaceFileResults);
   const hasFailures = pluginResults.some((r) => !r.success) || totalFailed > 0;
 
+  // Compute deleted artifacts: compare previous state vs what was just synced
+  const allCopyResultsForState = [...pluginResults.flatMap((r) => r.copyResults), ...workspaceFileResults];
+  const resolvedMappings = resolveClientMappings(syncClients, CLIENT_MAPPINGS);
+  const newStatePaths = collectSyncedPaths(allCopyResultsForState, workspacePath, syncClients, resolvedMappings);
+  const deletedArtifacts = computeDeletedArtifacts(previousState, newStatePaths, syncClients, resolvedMappings);
+
   // Persist sync state (skip in dry-run mode)
   const { pluginsByClient: nativePluginsByClient } = collectNativePluginSources(validPlugins);
   if (!dryRun) {
@@ -1824,6 +1930,7 @@ export async function syncWorkspace(
     totalSkipped,
     totalGenerated,
     purgedPaths,
+    ...(deletedArtifacts.length > 0 && { deletedArtifacts }),
     ...(warnings.length > 0 && { warnings }),
     ...(messages.length > 0 && { messages }),
     ...(nativeResult && { nativeResult }),
@@ -1938,6 +2045,12 @@ export async function syncUserWorkspace(
     validPlugins, previousState, 'user', homeDir, dryRun, warnings, messages,
   );
 
+  // Compute deleted artifacts: compare previous state vs what was just synced
+  const allCopyResultsForState = pluginResults.flatMap((r) => r.copyResults);
+  const resolvedUserMappings = resolveClientMappings(syncClients, USER_CLIENT_MAPPINGS);
+  const newStatePaths = collectSyncedPaths(allCopyResultsForState, homeDir, syncClients, resolvedUserMappings);
+  const deletedArtifacts = computeDeletedArtifacts(previousState, newStatePaths, syncClients, resolvedUserMappings);
+
   // Save sync state (including MCP servers and native plugins)
   if (!dryRun) {
     const { pluginsByClient: nativePluginsByClient } = collectNativePluginSources(validPlugins);
@@ -1962,6 +2075,7 @@ export async function syncUserWorkspace(
     totalFailed,
     totalSkipped,
     totalGenerated,
+    ...(deletedArtifacts.length > 0 && { deletedArtifacts }),
     ...(warnings.length > 0 && { warnings }),
     ...(messages.length > 0 && { messages }),
     ...(Object.keys(mcpResults).length > 0 && { mcpResults }),

--- a/tests/unit/cli/format-sync.test.ts
+++ b/tests/unit/cli/format-sync.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test';
-import { formatMcpResult, formatNativeResult, classifyCopyResults, formatArtifactLines, formatPluginArtifacts, formatSyncSummary } from '../../../src/cli/format-sync.js';
+import { formatMcpResult, formatNativeResult, classifyCopyResults, formatArtifactLines, formatPluginArtifacts, formatSyncSummary, formatDeletedArtifacts } from '../../../src/cli/format-sync.js';
 import type { CopyResult } from '../../../src/core/transform.js';
-import type { SyncResult } from '../../../src/core/sync.js';
+import type { SyncResult, DeletedArtifact } from '../../../src/core/sync.js';
 import type { McpMergeResult } from '../../../src/core/vscode-mcp.js';
 import type { NativeSyncResult } from '../../../src/core/native/types.js';
 
@@ -297,5 +297,89 @@ describe('formatNativeResult', () => {
     expect(formatNativeResult(result)).toEqual([
       '  ✗ [copilot] glow@wtg-ai-prompts: boom',
     ]);
+  });
+});
+
+describe('formatDeletedArtifacts', () => {
+  test('returns empty array when no artifacts deleted', () => {
+    expect(formatDeletedArtifacts([])).toEqual([]);
+  });
+
+  test('formats a single deleted skill', () => {
+    const artifacts: DeletedArtifact[] = [
+      { client: 'claude', type: 'skill', name: 'browser-automation' },
+    ];
+    expect(formatDeletedArtifacts(artifacts)).toEqual([
+      "  Deleted (claude): skill 'browser-automation'",
+    ]);
+  });
+
+  test('formats multiple deleted artifacts for same client', () => {
+    const artifacts: DeletedArtifact[] = [
+      { client: 'claude', type: 'skill', name: 'old-skill' },
+      { client: 'claude', type: 'command', name: 'deprecated-cmd' },
+    ];
+    const lines = formatDeletedArtifacts(artifacts);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toBe("  Deleted (claude): skill 'old-skill', command 'deprecated-cmd'");
+  });
+
+  test('formats deleted artifacts for multiple clients', () => {
+    const artifacts: DeletedArtifact[] = [
+      { client: 'claude', type: 'skill', name: 'skill-a' },
+      { client: 'copilot', type: 'skill', name: 'skill-b' },
+    ];
+    const lines = formatDeletedArtifacts(artifacts);
+    expect(lines).toHaveLength(2);
+    expect(lines).toContain("  Deleted (claude): skill 'skill-a'");
+    expect(lines).toContain("  Deleted (copilot): skill 'skill-b'");
+  });
+});
+
+describe('formatSyncSummary with deletedArtifacts', () => {
+  test('shows deleted artifacts when present', () => {
+    const result: SyncResult = {
+      success: true,
+      pluginResults: [],
+      totalCopied: 0,
+      totalFailed: 0,
+      totalSkipped: 0,
+      totalGenerated: 0,
+      deletedArtifacts: [
+        { client: 'claude', type: 'skill', name: 'removed-skill' },
+      ],
+    };
+
+    const lines = formatSyncSummary(result);
+    expect(lines).toContain("  Deleted (claude): skill 'removed-skill'");
+  });
+
+  test('does not show deleted section when deletedArtifacts is empty', () => {
+    const result: SyncResult = {
+      success: true,
+      pluginResults: [],
+      totalCopied: 0,
+      totalFailed: 0,
+      totalSkipped: 0,
+      totalGenerated: 0,
+      deletedArtifacts: [],
+    };
+
+    const lines = formatSyncSummary(result);
+    expect(lines.some((l) => l.includes('Deleted'))).toBe(false);
+  });
+
+  test('does not show deleted section when deletedArtifacts is undefined', () => {
+    const result: SyncResult = {
+      success: true,
+      pluginResults: [],
+      totalCopied: 0,
+      totalFailed: 0,
+      totalSkipped: 0,
+      totalGenerated: 0,
+    };
+
+    const lines = formatSyncSummary(result);
+    expect(lines.some((l) => l.includes('Deleted'))).toBe(false);
   });
 });

--- a/tests/unit/core/sync-deleted-artifacts.test.ts
+++ b/tests/unit/core/sync-deleted-artifacts.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'bun:test';
+import { computeDeletedArtifacts } from '../../../src/core/sync.js';
+import { CLIENT_MAPPINGS } from '../../../src/models/client-mapping.js';
+import type { SyncState } from '../../../src/models/sync-state.js';
+
+function makeState(files: Partial<SyncState['files']>): SyncState {
+  return {
+    version: 1,
+    lastSync: new Date().toISOString(),
+    files: files as SyncState['files'],
+  };
+}
+
+describe('computeDeletedArtifacts', () => {
+  it('returns empty array when there is no previous state', () => {
+    const result = computeDeletedArtifacts(null, {}, ['claude'], CLIENT_MAPPINGS);
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array when no artifacts were deleted', () => {
+    const previousState = makeState({
+      claude: ['.claude/skills/my-skill/'],
+    });
+    const newStatePaths = { claude: ['.claude/skills/my-skill/'] };
+    const result = computeDeletedArtifacts(previousState, newStatePaths, ['claude'], CLIENT_MAPPINGS);
+    expect(result).toEqual([]);
+  });
+
+  it('detects a deleted skill', () => {
+    const previousState = makeState({
+      claude: ['.claude/skills/old-skill/', '.claude/skills/old-skill/skill.md'],
+    });
+    const newStatePaths = { claude: [] };
+    const result = computeDeletedArtifacts(previousState, newStatePaths, ['claude'], CLIENT_MAPPINGS);
+    expect(result).toEqual([{ client: 'claude', type: 'skill', name: 'old-skill' }]);
+  });
+
+  it('deduplicates: only one deleted artifact per skill (directory + files inside)', () => {
+    const previousState = makeState({
+      claude: [
+        '.claude/skills/my-skill/',
+        '.claude/skills/my-skill/README.md',
+        '.claude/skills/my-skill/script.js',
+      ],
+    });
+    const newStatePaths = { claude: [] };
+    const result = computeDeletedArtifacts(previousState, newStatePaths, ['claude'], CLIENT_MAPPINGS);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ client: 'claude', type: 'skill', name: 'my-skill' });
+  });
+
+  it('detects a deleted command', () => {
+    const previousState = makeState({
+      claude: ['.claude/commands/old-cmd.md'],
+    });
+    const newStatePaths = { claude: [] };
+    const result = computeDeletedArtifacts(previousState, newStatePaths, ['claude'], CLIENT_MAPPINGS);
+    expect(result).toEqual([{ client: 'claude', type: 'command', name: 'old-cmd' }]);
+  });
+
+  it('detects a deleted hook', () => {
+    const previousState = makeState({
+      claude: ['.claude/hooks/my-hook/hook.json'],
+    });
+    const newStatePaths = { claude: [] };
+    const result = computeDeletedArtifacts(previousState, newStatePaths, ['claude'], CLIENT_MAPPINGS);
+    expect(result).toEqual([{ client: 'claude', type: 'hook', name: 'my-hook' }]);
+  });
+
+  it('detects a deleted agent', () => {
+    const previousState = makeState({
+      copilot: ['.github/agents/reviewer.md'],
+    });
+    const newStatePaths = { copilot: [] };
+    const result = computeDeletedArtifacts(previousState, newStatePaths, ['copilot'], CLIENT_MAPPINGS);
+    expect(result).toEqual([{ client: 'copilot', type: 'agent', name: 'reviewer' }]);
+  });
+
+  it('only reports artifacts not re-provided by new sync', () => {
+    const previousState = makeState({
+      claude: [
+        '.claude/skills/kept-skill/',
+        '.claude/skills/removed-skill/',
+        '.claude/commands/old-cmd.md',
+      ],
+    });
+    const newStatePaths = {
+      claude: ['.claude/skills/kept-skill/'],
+    };
+    const result = computeDeletedArtifacts(previousState, newStatePaths, ['claude'], CLIENT_MAPPINGS);
+    expect(result).toHaveLength(2);
+    expect(result).toContainEqual({ client: 'claude', type: 'skill', name: 'removed-skill' });
+    expect(result).toContainEqual({ client: 'claude', type: 'command', name: 'old-cmd' });
+  });
+
+  it('handles multiple clients independently', () => {
+    const previousState = makeState({
+      claude: ['.claude/skills/old-claude-skill/'],
+      copilot: ['.github/skills/old-copilot-skill/'],
+    });
+    const newStatePaths = {
+      claude: [],
+      copilot: ['.github/skills/old-copilot-skill/'],
+    };
+    const result = computeDeletedArtifacts(
+      previousState, newStatePaths, ['claude', 'copilot'], CLIENT_MAPPINGS,
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ client: 'claude', type: 'skill', name: 'old-claude-skill' });
+  });
+
+  it('ignores agentFile paths (CLAUDE.md, AGENTS.md) as they are generated files', () => {
+    const previousState = makeState({
+      claude: ['CLAUDE.md'],
+    });
+    const newStatePaths = { claude: [] };
+    const result = computeDeletedArtifacts(previousState, newStatePaths, ['claude'], CLIENT_MAPPINGS);
+    expect(result).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #229

## Summary

When workspace sync purges artifacts (skills, commands, hooks, agents) that are no longer provided by any plugin, users are now notified in the sync output so they can be aware of potentially breaking changes.

## Changes

### `src/core/sync.ts`
- Added `DeletedArtifact` interface `{ client, type, name }`
- Added `deletedArtifacts?: DeletedArtifact[]` field to `SyncResult`
- Added `classifyDeletedPath()` — maps a sync-state file path to a named artifact, skipping files nested inside skill directories to avoid duplicates
- Added `computeDeletedArtifacts()` — compares old sync state vs newly synced paths to find artifacts that were not re-provided by any plugin
- Called `computeDeletedArtifacts` in both `syncWorkspace` and `syncUserWorkspace`
- Updated `mergeSyncResults` to merge `deletedArtifacts` from both results

### `src/cli/format-sync.ts`
- Added `formatDeletedArtifacts()` helper — groups deleted artifacts by client display name
- Updated `formatSyncSummary` to append deleted artifact lines when present
- Updated `buildSyncData` to include `deletedArtifacts` in JSON output

## Example Output

```
Sync complete:
  claude: 3 skills, 1 command
  copilot: 2 skills
  Total generated: 2
  Deleted (claude): skill 'browser-automation', command 'deprecated-cmd'
  Deleted (copilot): skill 'old-skill'
```

## Tests

- `tests/unit/core/sync-deleted-artifacts.test.ts` (new) — 10 tests for `computeDeletedArtifacts`
- `tests/unit/cli/format-sync.test.ts` — added tests for `formatDeletedArtifacts` and `formatSyncSummary` with deleted artifacts