### PR TITLE
feat!: inline plugin skills config, workspace schema v2 (#233)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+## [1.0.0] - 2026-03-13
+
+### Breaking Changes
+
+- **Workspace schema v2**: Skill selection is now configured inline on each plugin entry rather than via top-level `disabledSkills`/`enabledSkills` arrays.
+
+  **Before (v1):**
+  ```yaml
+  plugins:
+    - superpowers@marketplace
+  enabledSkills:
+    - superpowers:brainstorming
+  disabledSkills:
+    - my-tools:verbose-logging
+  ```
+
+  **After (v2):**
+  ```yaml
+  version: 2
+  plugins:
+    - source: superpowers@marketplace
+      skills: [brainstorming]
+    - source: my-tools@marketplace
+      skills:
+        exclude: [verbose-logging]
+  ```
+
+  **Migration**: Automatic — existing `workspace.yaml` files are migrated to v2 format on the next `allagents workspace sync`. No manual action required.
+
+### Added
+- Top-level `allagents skills` command as shorthand for `allagents plugin skills`
+- `allagents skills add --from <source>` to install a plugin and enable a skill in one step
+- Auto-wrap support for flat SKILL.md repos (npx skills ecosystem compatibility)
+- `allagents plugin install --skill` now works even when plugin is already installed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "allagents",
-  "version": "0.34.1",
+  "version": "1.0.0",
   "description": "CLI tool for managing multi-repo AI agent workspaces with plugin synchronization",
   "type": "module",
   "bin": {

--- a/src/cli/commands/plugin-skills.ts
+++ b/src/cli/commands/plugin-skills.ts
@@ -6,7 +6,6 @@ import { syncWorkspace, syncUserWorkspace } from '../../core/sync.js';
 import {
   addDisabledSkill,
   removeDisabledSkill,
-  getEnabledSkills,
   removeEnabledSkill,
   addEnabledSkill,
   addPlugin,
@@ -14,7 +13,6 @@ import {
 import {
   addUserDisabledSkill,
   removeUserDisabledSkill,
-  getUserEnabledSkills,
   removeUserEnabledSkill,
   addUserEnabledSkill,
   isUserConfigPath,
@@ -252,22 +250,11 @@ const removeCmd = command({
         return;
       }
 
-      // Detect mode: does this plugin have enabledSkills entries?
-      const enabledSkills = isUser
-        ? await getUserEnabledSkills()
-        : await getEnabledSkills(workspacePath);
-      const pluginPrefix = `${targetSkill.pluginName}:`;
-      const inAllowlistMode = enabledSkills.some((s) => s.startsWith(pluginPrefix));
-
       const skillKey = `${targetSkill.pluginName}:${skill}`;
 
-      const result = inAllowlistMode
-        ? isUser
-          ? await removeUserEnabledSkill(skillKey)
-          : await removeEnabledSkill(skillKey, workspacePath)
-        : isUser
-          ? await addUserDisabledSkill(skillKey)
-          : await addDisabledSkill(skillKey, workspacePath);
+      const result = targetSkill.pluginSkillsMode === 'allowlist'
+        ? isUser ? await removeUserEnabledSkill(skillKey) : await removeEnabledSkill(skillKey, workspacePath)
+        : isUser ? await addUserDisabledSkill(skillKey) : await addDisabledSkill(skillKey, workspacePath);
 
       if (!result.success) {
         if (isJsonMode()) {
@@ -449,22 +436,11 @@ const addCmd = command({
         return;
       }
 
-      // Detect mode: does this plugin have enabledSkills entries?
-      const enabledSkills = isUser
-        ? await getUserEnabledSkills()
-        : await getEnabledSkills(workspacePath);
-      const pluginPrefix = `${targetSkill.pluginName}:`;
-      const inAllowlistMode = enabledSkills.some((s) => s.startsWith(pluginPrefix));
-
       const skillKey = `${targetSkill.pluginName}:${skill}`;
 
-      const result = inAllowlistMode
-        ? isUser
-          ? await addUserEnabledSkill(skillKey)
-          : await addEnabledSkill(skillKey, workspacePath)
-        : isUser
-          ? await removeUserDisabledSkill(skillKey)
-          : await removeDisabledSkill(skillKey, workspacePath);
+      const result = targetSkill.pluginSkillsMode === 'blocklist'
+        ? isUser ? await removeUserDisabledSkill(skillKey) : await removeDisabledSkill(skillKey, workspacePath)
+        : isUser ? await addUserEnabledSkill(skillKey) : await addEnabledSkill(skillKey, workspacePath);
 
       if (!result.success) {
         if (isJsonMode()) {

--- a/src/core/skills.ts
+++ b/src/core/skills.ts
@@ -3,7 +3,7 @@ import { readFile, readdir } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { load } from 'js-yaml';
 import { CONFIG_DIR, WORKSPACE_CONFIG_FILE } from '../constants.js';
-import { getPluginSource, type WorkspaceConfig } from '../models/workspace-config.js';
+import { getPluginSource, type WorkspaceConfig, type PluginSkillsConfig } from '../models/workspace-config.js';
 import { fetchPlugin, getPluginName } from './plugin.js';
 import { isGitHubUrl, parseGitHubUrl } from '../utils/plugin-path.js';
 import { isPluginSpec, resolvePluginSpecWithAutoRegister } from './marketplace.js';
@@ -22,6 +22,12 @@ export interface SkillInfo {
   path: string;
   /** Whether the skill is disabled */
   disabled: boolean;
+  /**
+   * The inline skills mode for the plugin this skill belongs to.
+   * 'allowlist' = plugin has `skills: [...]`, 'blocklist' = plugin has `skills: { exclude: [...] }`,
+   * 'none' = no inline skills field (all skills enabled by default).
+   */
+  pluginSkillsMode: 'allowlist' | 'blocklist' | 'none';
 }
 
 /**
@@ -85,8 +91,12 @@ export async function getAllSkillsFromPlugins(
 
   const content = await readFile(configPath, 'utf-8');
   const config = load(content) as WorkspaceConfig;
-  const disabledSkills = new Set(config.disabledSkills ?? []);
-  const enabledSkills = config.enabledSkills ? new Set(config.enabledSkills) : null;
+
+  // v1 fallback: use top-level disabledSkills/enabledSkills only for configs that haven't migrated
+  const isV1Fallback = config.version === undefined || config.version < 2;
+  const disabledSkills = isV1Fallback ? new Set(config.disabledSkills ?? []) : new Set<string>();
+  const enabledSkills = isV1Fallback && config.enabledSkills ? new Set(config.enabledSkills) : null;
+
   const skills: SkillInfo[] = [];
 
   for (const pluginEntry of config.plugins) {
@@ -98,12 +108,15 @@ export async function getAllSkillsFromPlugins(
     const pluginName = resolved.pluginName ?? getPluginName(pluginPath);
     const skillsDir = join(pluginPath, 'skills');
 
-    // Only apply enabledSkills to plugins that actually have entries in the set
-    const hasEnabledEntries = enabledSkills &&
-      [...enabledSkills].some((s) => s.startsWith(`${pluginName}:`));
+    // Inline plugin-level skills config (v2+); undefined = all enabled (or use v1 fallback below)
+    const pluginSkillsConfig: PluginSkillsConfig | undefined =
+      typeof pluginEntry === 'string' ? undefined : pluginEntry.skills;
+
+    // v1 fallback: only apply enabledSkills to plugins with entries in the set
+    const hasEnabledEntries = !pluginSkillsConfig && enabledSkills &&
+      [...enabledSkills].some((s) => s.startsWith(`${pluginName}`));
 
     let skillEntries: { name: string; skillPath: string }[];
-
     if (existsSync(skillsDir)) {
       // Standard layout: plugin/skills/<skill-name>/
       const entries = await readdir(skillsDir, { withFileTypes: true });
@@ -124,11 +137,32 @@ export async function getAllSkillsFromPlugins(
       skillEntries = flatSkills;
     }
 
+    const pluginSkillsMode: SkillInfo['pluginSkillsMode'] =
+      pluginSkillsConfig === undefined ? 'none'
+      : Array.isArray(pluginSkillsConfig) ? 'allowlist'
+      : 'blocklist';
+
     for (const { name, skillPath } of skillEntries) {
       const skillKey = `${pluginName}:${name}`;
-      const isDisabled = hasEnabledEntries
-        ? !enabledSkills?.has(skillKey)
-        : disabledSkills.has(skillKey);
+      let isDisabled: boolean;
+
+      if (pluginSkillsConfig !== undefined) {
+        // Inline skills config takes priority (v2+)
+        if (Array.isArray(pluginSkillsConfig)) {
+          // allowlist: disabled if NOT in array
+          isDisabled = !pluginSkillsConfig.includes(name);
+        } else {
+          // blocklist: disabled if IS in exclude array
+          isDisabled = pluginSkillsConfig.exclude.includes(name);
+        }
+      } else if (isV1Fallback) {
+        // v1 fallback: top-level disabledSkills/enabledSkills
+        isDisabled = hasEnabledEntries
+          ? !enabledSkills?.has(skillKey)
+          : disabledSkills.has(skillKey);
+      } else {
+        isDisabled = false;
+      }
 
       skills.push({
         name,
@@ -136,6 +170,7 @@ export async function getAllSkillsFromPlugins(
         pluginSource,
         path: skillPath,
         disabled: isDisabled,
+        pluginSkillsMode,
       });
     }
   }

--- a/src/core/sync.ts
+++ b/src/core/sync.ts
@@ -10,6 +10,7 @@ import type {
   PluginEntry,
   WorkspaceFile,
   SyncMode,
+  PluginSkillsConfig,
 } from '../models/workspace-config.js';
 import {
   getPluginClients,
@@ -57,14 +58,14 @@ import {
   getPreviouslySyncedNativePlugins,
 } from './sync-state.js';
 import type { SyncState } from '../models/sync-state.js';
-import { getUserWorkspaceConfig } from './user-workspace.js';
+import { getUserWorkspaceConfig, migrateUserWorkspaceSkillsV1toV2 } from './user-workspace.js';
 import {
   generateVscodeWorkspace,
   getWorkspaceOutputPath,
   computeWorkspaceHash,
   reconcileVscodeWorkspaceFolders,
 } from './vscode-workspace.js';
-import { updateRepositories } from './workspace-modify.js';
+import { updateRepositories, migrateWorkspaceSkillsV1toV2 } from './workspace-modify.js';
 import { syncVscodeMcpConfig } from './vscode-mcp.js';
 import type { McpMergeResult } from './vscode-mcp.js';
 import { syncCodexMcpServers } from './codex-mcp.js';
@@ -244,6 +245,8 @@ export interface ValidatedPlugin {
   marketplaceSource?: string;
   /** Glob patterns of files to exclude when syncing (from workspace.yaml) */
   exclude?: string[];
+  /** Inline skill selection config from plugin entry (v2+) */
+  pluginSkillsConfig?: PluginSkillsConfig;
 }
 
 interface PluginSyncPlan {
@@ -253,6 +256,8 @@ interface PluginSyncPlan {
   nativeClients: ClientType[];
   /** Glob patterns of files to exclude when syncing (from workspace.yaml) */
   exclude?: string[];
+  /** Inline skill selection config from plugin entry (v2+) */
+  pluginSkillsConfig?: PluginSkillsConfig;
 }
 
 /**
@@ -1058,7 +1063,14 @@ function buildPluginSyncPlans(
     }
 
     const exclude = getPluginExclude(plugin);
-    return { source, clients: fileClients, nativeClients, ...(exclude && { exclude }) };
+    const pluginSkillsConfig = typeof plugin === 'string' ? undefined : plugin.skills;
+    return {
+      source,
+      clients: fileClients,
+      nativeClients,
+      ...(exclude && { exclude }),
+      ...(pluginSkillsConfig !== undefined && { pluginSkillsConfig }),
+    };
   });
 
   return { plans, warnings };
@@ -1077,10 +1089,11 @@ async function validateAllPlugins(
   offline: boolean,
 ): Promise<ValidatedPlugin[]> {
   return Promise.all(
-    plans.map(async ({ source, clients, nativeClients, exclude }) => {
+    plans.map(async ({ source, clients, nativeClients, exclude, pluginSkillsConfig }) => {
       const validated = await validatePlugin(source, workspacePath, offline);
       const result: ValidatedPlugin = { ...validated, clients, nativeClients };
       if (exclude) result.exclude = exclude;
+      if (pluginSkillsConfig !== undefined) result.pluginSkillsConfig = pluginSkillsConfig;
       return result;
     }),
   );
@@ -1214,7 +1227,8 @@ interface CollectedSkillEntry {
  * Collect all skills from all validated plugins
  * This is the first pass of two-pass name resolution
  * @param validatedPlugins - Array of validated plugins with resolved paths
- * @param disabledSkills - Optional set of disabled skill keys
+ * @param disabledSkills - Optional set of disabled skill keys (v1 fallback)
+ * @param enabledSkills - Optional set of enabled skill keys (v1 fallback)
  * @returns Array of collected skill entries
  */
 async function collectAllSkills(
@@ -1232,6 +1246,7 @@ async function collectAllSkills(
       disabledSkills,
       pluginName,
       enabledSkills,
+      plugin.pluginSkillsConfig,
     );
 
     for (const skill of skills) {
@@ -1653,6 +1668,9 @@ export async function syncWorkspace(
   workspacePath: string = process.cwd(),
   options: SyncOptions = {},
 ): Promise<SyncResult> {
+  // MIGRATION: v1→v2 - remove after v3 release
+  await migrateWorkspaceSkillsV1toV2(workspacePath);
+
   const { offline = false, dryRun = false, workspaceSourceBase, skipAgentFiles = false } = options;
   const configDir = join(workspacePath, CONFIG_DIR);
   const configPath = join(configDir, WORKSPACE_CONFIG_FILE);
@@ -1787,8 +1805,10 @@ export async function syncWorkspace(
 
   // Step 3b: Two-pass skill name resolution
   // Pass 1: Collect all skills from all plugins (excluding disabled/non-enabled skills)
-  const disabledSkillsSet = new Set(config.disabledSkills ?? []);
-  const enabledSkillsSet = config.enabledSkills ? new Set(config.enabledSkills) : undefined;
+  // v1 fallback: only use top-level disabledSkills/enabledSkills for configs that haven't migrated
+  const isV1Fallback = config.version === undefined || config.version < 2;
+  const disabledSkillsSet = isV1Fallback ? new Set(config.disabledSkills ?? []) : undefined;
+  const enabledSkillsSet = isV1Fallback && config.enabledSkills ? new Set(config.enabledSkills) : undefined;
   const allSkills = await collectAllSkills(validPlugins, disabledSkillsSet, enabledSkillsSet);
 
   // Build per-plugin skill name maps (handles conflicts automatically)
@@ -1947,6 +1967,9 @@ export async function syncWorkspace(
 export async function syncUserWorkspace(
   options: { offline?: boolean; dryRun?: boolean; force?: boolean } = {},
 ): Promise<SyncResult> {
+  // MIGRATION: v1→v2 - remove after v3 release
+  await migrateUserWorkspaceSkillsV1toV2();
+
   const homeDir = resolve(getHomeDir());
   const config = await getUserWorkspaceConfig();
 
@@ -2000,8 +2023,10 @@ export async function syncUserWorkspace(
   }
 
   // Two-pass skill name resolution (excluding disabled/non-enabled skills)
-  const disabledSkillsSet = new Set(config.disabledSkills ?? []);
-  const enabledSkillsSet = config.enabledSkills ? new Set(config.enabledSkills) : undefined;
+  // v1 fallback: only use top-level disabledSkills/enabledSkills for configs that haven't migrated
+  const isV1FallbackUser = config.version === undefined || config.version < 2;
+  const disabledSkillsSet = isV1FallbackUser ? new Set(config.disabledSkills ?? []) : undefined;
+  const enabledSkillsSet = isV1FallbackUser && config.enabledSkills ? new Set(config.enabledSkills) : undefined;
   const allSkills = await collectAllSkills(validPlugins, disabledSkillsSet, enabledSkillsSet);
   const pluginSkillMaps = buildPluginSkillNameMaps(allSkills);
 

--- a/src/core/transform.ts
+++ b/src/core/transform.ts
@@ -5,7 +5,7 @@ import micromatch from 'micromatch';
 import { resolveGlobPatterns, isGlobPattern } from '../utils/glob-patterns.js';
 import { CLIENT_MAPPINGS, isUniversalClient } from '../models/client-mapping.js';
 import type { ClientMapping } from '../models/client-mapping.js';
-import type { ClientType, WorkspaceFile, SyncMode } from '../models/workspace-config.js';
+import type { ClientType, WorkspaceFile, SyncMode, PluginSkillsConfig } from '../models/workspace-config.js';
 import { generateWorkspaceRules, type WorkspaceRepository } from '../constants.js';
 import { parseFileSource } from '../utils/plugin-path.js';
 import { createSymlink } from '../utils/symlink.js';
@@ -353,9 +353,10 @@ export interface CollectedSkill {
  * Used for the first pass of two-pass name resolution
  * @param pluginPath - Resolved path to plugin directory
  * @param pluginSource - Original plugin source reference
- * @param disabledSkills - Optional set of disabled skill keys (plugin:skill format)
+ * @param disabledSkills - Optional set of disabled skill keys (plugin:skill format); used as v1 fallback
  * @param pluginName - Optional plugin name for building skill keys
- * @param enabledSkills - Optional set of enabled skill keys (allowlist mode, takes priority over disabledSkills)
+ * @param enabledSkills - Optional set of enabled skill keys (allowlist mode); used as v1 fallback
+ * @param pluginSkillsConfig - Optional inline plugin-level skills config (v2+); takes priority over disabledSkills/enabledSkills
  * @returns Array of collected skill information
  */
 export async function collectPluginSkills(
@@ -364,12 +365,12 @@ export async function collectPluginSkills(
   disabledSkills?: Set<string>,
   pluginName?: string,
   enabledSkills?: Set<string>,
+  pluginSkillsConfig?: PluginSkillsConfig,
 ): Promise<CollectedSkill[]> {
   const skillsDir = join(pluginPath, 'skills');
 
-  // Filter skills: enabledSkills (allowlist) takes priority over disabledSkills (blocklist)
-  // Only apply enabledSkills to plugins that actually have entries in the set
-  const hasEnabledEntries = enabledSkills && pluginName &&
+  // v1 fallback: only apply enabledSkills to plugins that actually have entries in the set
+  const hasEnabledEntries = !pluginSkillsConfig && enabledSkills && pluginName &&
     [...enabledSkills].some((s) => s.startsWith(`${pluginName}:`));
 
   let candidateDirs: { name: string; path: string }[];
@@ -394,13 +395,28 @@ export async function collectPluginSkills(
     candidateDirs = flatDirs;
   }
 
-  const filteredDirs = pluginName
-    ? hasEnabledEntries
-      ? candidateDirs.filter((e) => enabledSkills?.has(`${pluginName}:${e.name}`))
-      : disabledSkills
-        ? candidateDirs.filter((e) => !disabledSkills.has(`${pluginName}:${e.name}`))
-        : candidateDirs
-    : candidateDirs;
+  let filteredDirs: typeof candidateDirs;
+  if (pluginSkillsConfig !== undefined) {
+    // Inline config takes priority (v2+)
+    if (Array.isArray(pluginSkillsConfig)) {
+      // allowlist: keep only skills in the array
+      filteredDirs = candidateDirs.filter((e) => pluginSkillsConfig.includes(e.name));
+    } else {
+      // blocklist: exclude skills in the exclude array
+      filteredDirs = candidateDirs.filter((e) => !pluginSkillsConfig.exclude.includes(e.name));
+    }
+  } else if (pluginName) {
+    // v1 fallback: use disabledSkills/enabledSkills
+    if (hasEnabledEntries) {
+      filteredDirs = candidateDirs.filter((e) => enabledSkills?.has(`${pluginName}:${e.name}`));
+    } else if (disabledSkills) {
+      filteredDirs = candidateDirs.filter((e) => !disabledSkills.has(`${pluginName}:${e.name}`));
+    } else {
+      filteredDirs = candidateDirs;
+    }
+  } else {
+    filteredDirs = candidateDirs;
+  }
 
   return filteredDirs.map((entry) => ({
     folderName: entry.name,

--- a/src/core/user-workspace.ts
+++ b/src/core/user-workspace.ts
@@ -23,6 +23,9 @@ import {
 } from './marketplace.js';
 import {
   type ModifyResult,
+  ensureObjectPluginEntry,
+  extractPluginNames,
+  findPluginEntryByName,
   pruneDisabledSkillsForPlugin,
   pruneEnabledSkillsForPlugin,
   resolveGitHubIdentity,
@@ -110,7 +113,10 @@ export async function getUserWorkspaceConfig(): Promise<WorkspaceConfig | null> 
  * 2. GitHub URL (e.g., "https://github.com/owner/repo")
  * 3. Local path (e.g., "/home/user/my-plugin")
  */
-export async function addUserPlugin(plugin: string, force?: boolean): Promise<ModifyResult> {
+export async function addUserPlugin(
+  plugin: string,
+  force?: boolean,
+): Promise<ModifyResult> {
   await ensureUserWorkspace();
   const configPath = getUserWorkspaceConfigPath();
 
@@ -170,7 +176,8 @@ export async function hasUserPlugin(plugin: string): Promise<boolean> {
   if (!config) return false;
 
   // Exact match first
-  if (config.plugins.some((entry) => getPluginSource(entry) === plugin)) return true;
+  if (config.plugins.some((entry) => getPluginSource(entry) === plugin))
+    return true;
 
   // Partial match
   return config.plugins.some((entry) => {
@@ -197,12 +204,10 @@ export async function removeUserPlugin(plugin: string): Promise<ModifyResult> {
 
     // Partial match: plugin name without marketplace suffix
     if (index === -1) {
-      index = config.plugins.findIndex(
-        (entry) => {
-          const source = getPluginSource(entry);
-          return source.startsWith(`${plugin}@`) || source === plugin;
-        },
-      );
+      index = config.plugins.findIndex((entry) => {
+        const source = getPluginSource(entry);
+        return source.startsWith(`${plugin}@`) || source === plugin;
+      });
     }
 
     // Semantic match: same GitHub repo under a different format
@@ -296,7 +301,9 @@ async function addPluginToUserConfig(
     const config = load(content) as WorkspaceConfig;
 
     // Check for exact match
-    const exactIndex = config.plugins.findIndex((entry) => getPluginSource(entry) === plugin);
+    const exactIndex = config.plugins.findIndex(
+      (entry) => getPluginSource(entry) === plugin,
+    );
     if (exactIndex !== -1) {
       if (!force) {
         return {
@@ -324,7 +331,9 @@ async function addPluginToUserConfig(
       }
       if (semanticIndex !== -1) {
         if (!force) {
-          const existingSource = getPluginSource(config.plugins[semanticIndex] as PluginEntry);
+          const existingSource = getPluginSource(
+            config.plugins[semanticIndex] as PluginEntry,
+          );
           return {
             success: false,
             error: `Plugin duplicates existing entry '${existingSource}': both resolve to ${newIdentity}`,
@@ -375,17 +384,54 @@ export async function setUserClients(
   }
 }
 
+/** Parse "pluginName:skillName" into its two parts, or return null on bad format. */
+function parseSkillKey(
+  skillKey: string,
+): { pluginName: string; skillName: string } | null {
+  const colonIdx = skillKey.indexOf(':');
+  if (colonIdx === -1) return null;
+  return {
+    pluginName: skillKey.slice(0, colonIdx),
+    skillName: skillKey.slice(colonIdx + 1),
+  };
+}
+
 /**
- * Get disabled skills from user workspace config
+ * Get disabled skills from user workspace config.
+ * Reads from inline plugin entry `skills.exclude` arrays (blocklist mode).
+ * Also includes legacy top-level `disabledSkills` for backward compatibility.
  * @returns Array of disabled skill keys (plugin:skill format)
  */
 export async function getUserDisabledSkills(): Promise<string[]> {
   const config = await getUserWorkspaceConfig();
-  return config?.disabledSkills ?? [];
+  if (!config) return [];
+
+  const result: string[] = [];
+  for (const entry of config.plugins) {
+    if (
+      typeof entry === 'string' ||
+      !entry.skills ||
+      Array.isArray(entry.skills)
+    )
+      continue;
+    const pluginName = extractPluginNames(getPluginSource(entry))[0];
+    if (!pluginName) continue;
+    for (const skillName of entry.skills.exclude) {
+      result.push(`${pluginName}:${skillName}`);
+    }
+  }
+
+  // Include legacy top-level disabledSkills
+  for (const s of config.disabledSkills ?? []) {
+    if (!result.includes(s)) result.push(s);
+  }
+
+  return result;
 }
 
 /**
- * Add a skill to disabledSkills in user workspace config
+ * Add a skill to the plugin entry's `skills.exclude` list (blocklist mode) in user workspace config.
+ * Converts a string shorthand plugin entry to object form if needed.
  * @param skillKey - Skill key in plugin:skill format
  */
 export async function addUserDisabledSkill(
@@ -394,19 +440,45 @@ export async function addUserDisabledSkill(
   await ensureUserWorkspace();
   const configPath = getUserWorkspaceConfigPath();
 
+  const parsed = parseSkillKey(skillKey);
+  if (!parsed) {
+    return {
+      success: false,
+      error: `Invalid skill key format: '${skillKey}' (expected pluginName:skillName)`,
+    };
+  }
+  const { pluginName, skillName } = parsed;
+
   try {
     const content = await readFile(configPath, 'utf-8');
     const config = load(content) as WorkspaceConfig;
-    const disabledSkills = config.disabledSkills ?? [];
 
-    if (disabledSkills.includes(skillKey)) {
+    const index = findPluginEntryByName(config, pluginName);
+    if (index === -1) {
+      return {
+        success: false,
+        error: `Plugin '${pluginName}' not found in user workspace config`,
+      };
+    }
+
+    const entry = ensureObjectPluginEntry(config, index);
+
+    if (Array.isArray(entry.skills)) {
+      return {
+        success: false,
+        error: `Plugin '${pluginName}' is in allowlist mode; use removeUserEnabledSkill to disable a skill`,
+      };
+    }
+
+    const existing = entry.skills?.exclude ?? [];
+    if (existing.includes(skillName)) {
       return {
         success: false,
         error: `Skill '${skillKey}' is already disabled`,
       };
     }
 
-    config.disabledSkills = [...disabledSkills, skillKey];
+    entry.skills = { exclude: [...existing, skillName] };
     await writeFile(configPath, dump(config, { lineWidth: -1 }), 'utf-8');
     return { success: true };
   } catch (error) {
@@ -418,7 +490,7 @@ export async function addUserDisabledSkill(
 }
 
 /**
- * Remove a skill from disabledSkills in user workspace config
+ * Remove a skill from the plugin entry's `skills.exclude` list (blocklist mode) in user workspace config.
  * @param skillKey - Skill key in plugin:skill format
  */
 export async function removeUserDisabledSkill(
@@ -427,22 +499,52 @@ export async function removeUserDisabledSkill(
   await ensureUserWorkspace();
   const configPath = getUserWorkspaceConfigPath();
 
+  const parsed = parseSkillKey(skillKey);
+  if (!parsed) {
+    return {
+      success: false,
+      error: `Invalid skill key format: '${skillKey}' (expected pluginName:skillName)`,
+    };
+  }
+  const { pluginName, skillName } = parsed;
+
   try {
     const content = await readFile(configPath, 'utf-8');
     const config = load(content) as WorkspaceConfig;
-    const disabledSkills = config.disabledSkills ?? [];
 
-    if (!disabledSkills.includes(skillKey)) {
+    const index = findPluginEntryByName(config, pluginName);
+    if (index === -1) {
+      return {
+        success: false,
+        error: `Plugin '${pluginName}' not found in user workspace config`,
+      };
+    }
+
+    const entry = config.plugins[index];
+    if (!entry) {
+      return { success: false, error: `Plugin '${pluginName}' not found in user workspace config` };
+    }
+    if (
+      typeof entry === 'string' ||
+      !entry.skills ||
+      Array.isArray(entry.skills)
+    ) {
       return {
         success: false,
         error: `Skill '${skillKey}' is already enabled`,
       };
     }
 
-    config.disabledSkills = disabledSkills.filter((s) => s !== skillKey);
-    if (config.disabledSkills.length === 0) {
-      config.disabledSkills = undefined;
+    if (!entry.skills.exclude.includes(skillName)) {
+      return {
+        success: false,
+        error: `Skill '${skillKey}' is already enabled`,
+      };
     }
+
+    const newExclude = entry.skills.exclude.filter((s) => s !== skillName);
+    entry.skills = newExclude.length > 0 ? { exclude: newExclude } : undefined;
+
     await writeFile(configPath, dump(config, { lineWidth: -1 }), 'utf-8');
     return { success: true };
   } catch (error) {
@@ -454,16 +556,36 @@ export async function removeUserDisabledSkill(
 }
 
 /**
- * Get enabled skills from user workspace config
+ * Get enabled skills from user workspace config.
+ * Reads from inline plugin entry `skills` arrays (allowlist mode).
+ * Also includes legacy top-level `enabledSkills` for backward compatibility.
  * @returns Array of enabled skill keys (plugin:skill format)
  */
 export async function getUserEnabledSkills(): Promise<string[]> {
   const config = await getUserWorkspaceConfig();
-  return config?.enabledSkills ?? [];
+  if (!config) return [];
+
+  const result: string[] = [];
+  for (const entry of config.plugins) {
+    if (typeof entry === 'string' || !Array.isArray(entry.skills)) continue;
+    const pluginName = extractPluginNames(getPluginSource(entry))[0];
+    if (!pluginName) continue;
+    for (const skillName of entry.skills) {
+      result.push(`${pluginName}:${skillName}`);
+    }
+  }
+
+  // Include legacy top-level enabledSkills
+  for (const s of config.enabledSkills ?? []) {
+    if (!result.includes(s)) result.push(s);
+  }
+
+  return result;
 }
 
 /**
- * Add a skill to enabledSkills in user workspace config
+ * Add a skill to the plugin entry's `skills` allowlist in user workspace config.
+ * Converts a string shorthand plugin entry to object form if needed.
  * @param skillKey - Skill key in plugin:skill format
  */
 export async function addUserEnabledSkill(
@@ -472,19 +594,45 @@ export async function addUserEnabledSkill(
   await ensureUserWorkspace();
   const configPath = getUserWorkspaceConfigPath();
 
+  const parsed = parseSkillKey(skillKey);
+  if (!parsed) {
+    return {
+      success: false,
+      error: `Invalid skill key format: '${skillKey}' (expected pluginName:skillName)`,
+    };
+  }
+  const { pluginName, skillName } = parsed;
+
   try {
     const content = await readFile(configPath, 'utf-8');
     const config = load(content) as WorkspaceConfig;
-    const enabledSkills = config.enabledSkills ?? [];
 
-    if (enabledSkills.includes(skillKey)) {
+    const index = findPluginEntryByName(config, pluginName);
+    if (index === -1) {
+      return {
+        success: false,
+        error: `Plugin '${pluginName}' not found in user workspace config`,
+      };
+    }
+
+    const entry = ensureObjectPluginEntry(config, index);
+
+    if (entry.skills && !Array.isArray(entry.skills)) {
+      return {
+        success: false,
+        error: `Plugin '${pluginName}' is in blocklist mode; use removeUserDisabledSkill to enable a skill`,
+      };
+    }
+
+    const existing = (entry.skills as string[] | undefined) ?? [];
+    if (existing.includes(skillName)) {
       return {
         success: false,
         error: `Skill '${skillKey}' is already enabled`,
       };
     }
 
-    config.enabledSkills = [...enabledSkills, skillKey];
+    entry.skills = [...existing, skillName];
     await writeFile(configPath, dump(config, { lineWidth: -1 }), 'utf-8');
     return { success: true };
   } catch (error) {
@@ -496,7 +644,7 @@ export async function addUserEnabledSkill(
 }
 
 /**
- * Remove a skill from enabledSkills in user workspace config
+ * Remove a skill from the plugin entry's `skills` allowlist in user workspace config.
  * @param skillKey - Skill key in plugin:skill format
  */
 export async function removeUserEnabledSkill(
@@ -505,22 +653,52 @@ export async function removeUserEnabledSkill(
   await ensureUserWorkspace();
   const configPath = getUserWorkspaceConfigPath();
 
+  const parsed = parseSkillKey(skillKey);
+  if (!parsed) {
+    return {
+      success: false,
+      error: `Invalid skill key format: '${skillKey}' (expected pluginName:skillName)`,
+    };
+  }
+  const { pluginName, skillName } = parsed;
+
   try {
     const content = await readFile(configPath, 'utf-8');
     const config = load(content) as WorkspaceConfig;
-    const enabledSkills = config.enabledSkills ?? [];
 
-    if (!enabledSkills.includes(skillKey)) {
+    const index = findPluginEntryByName(config, pluginName);
+    if (index === -1) {
+      return {
+        success: false,
+        error: `Plugin '${pluginName}' not found in user workspace config`,
+      };
+    }
+
+    const entry = config.plugins[index];
+    if (!entry) {
+      return { success: false, error: `Plugin '${pluginName}' not found in user workspace config` };
+    }
+    if (
+      typeof entry === 'string' ||
+      !entry.skills ||
+      !Array.isArray(entry.skills)
+    ) {
       return {
         success: false,
         error: `Skill '${skillKey}' is already disabled`,
       };
     }
 
-    config.enabledSkills = enabledSkills.filter((s) => s !== skillKey);
-    if (config.enabledSkills.length === 0) {
-      config.enabledSkills = undefined;
+    if (!entry.skills.includes(skillName)) {
+      return {
+        success: false,
+        error: `Skill '${skillKey}' is already disabled`,
+      };
     }
+
+    const newSkills = entry.skills.filter((s) => s !== skillName);
+    entry.skills = newSkills.length > 0 ? newSkills : undefined;
+
     await writeFile(configPath, dump(config, { lineWidth: -1 }), 'utf-8');
     return { success: true };
   } catch (error) {
@@ -628,5 +806,94 @@ export async function getInstalledProjectPlugins(
     return result;
   } catch {
     return [];
+  }
+}
+
+// MIGRATION: v1→v2 skill schema. Remove this block after v3 is released.
+/**
+ * Migrate the user workspace config (~/.allagents/workspace.yaml) from v1 skill
+ * schema to v2.
+ *
+ * v1: top-level `enabledSkills`/`disabledSkills` arrays of "pluginName:skillName" strings.
+ * v2: per-plugin `skills` field (allowlist array or `{ exclude: [...] }` blocklist).
+ *
+ * Idempotent: if `version >= 2`, returns immediately without touching the file.
+ * Also upgrades configs that have neither field (first-time users) by setting version:2.
+ */
+export async function migrateUserWorkspaceSkillsV1toV2(): Promise<void> {
+  const configPath = getUserWorkspaceConfigPath();
+  if (!existsSync(configPath)) return;
+
+  let config: WorkspaceConfig;
+  try {
+    const content = await readFile(configPath, 'utf-8');
+    config = load(content) as WorkspaceConfig;
+  } catch {
+    return;
+  }
+
+  if (!config || (config.version !== undefined && config.version >= 2)) return;
+
+  const enabledSkills: string[] = config.enabledSkills ?? [];
+  const disabledSkills: string[] = config.disabledSkills ?? [];
+
+  const enabledByPlugin = new Map<string, string[]>();
+  for (const skillKey of enabledSkills) {
+    const colonIdx = skillKey.indexOf(':');
+    if (colonIdx === -1) continue;
+    const pluginName = skillKey.slice(0, colonIdx);
+    const skillName = skillKey.slice(colonIdx + 1);
+    const list = enabledByPlugin.get(pluginName) ?? [];
+    list.push(skillName);
+    enabledByPlugin.set(pluginName, list);
+  }
+
+  const disabledByPlugin = new Map<string, string[]>();
+  for (const skillKey of disabledSkills) {
+    const colonIdx = skillKey.indexOf(':');
+    if (colonIdx === -1) continue;
+    const pluginName = skillKey.slice(0, colonIdx);
+    const skillName = skillKey.slice(colonIdx + 1);
+    const list = disabledByPlugin.get(pluginName) ?? [];
+    list.push(skillName);
+    disabledByPlugin.set(pluginName, list);
+  }
+
+  for (const [pluginName, skillNames] of enabledByPlugin) {
+    const index = findPluginEntryByName(config, pluginName);
+    if (index === -1) {
+      console.warn(
+        `[migrate v1→v2] No user plugin found for '${pluginName}', skipping`,
+      );
+      continue;
+    }
+    const entry = ensureObjectPluginEntry(config, index);
+    entry.skills = skillNames;
+  }
+
+  for (const [pluginName, skillNames] of disabledByPlugin) {
+    const index = findPluginEntryByName(config, pluginName);
+    if (index === -1) {
+      console.warn(
+        `[migrate v1→v2] No user plugin found for '${pluginName}', skipping`,
+      );
+      continue;
+    }
+    const entry = ensureObjectPluginEntry(config, index);
+    if (!Array.isArray(entry.skills)) {
+      entry.skills = { exclude: skillNames };
+    }
+  }
+
+  config.enabledSkills = undefined;
+  config.disabledSkills = undefined;
+  config.version = 2;
+
+  try {
+    await writeFile(configPath, dump(config, { lineWidth: -1 }), 'utf-8');
+  } catch (error) {
+    console.warn(
+      `[migrate v1→v2] Failed to write migrated user config: ${error instanceof Error ? error.message : String(error)}`,
+    );
   }
 }

--- a/src/core/workspace-modify.ts
+++ b/src/core/workspace-modify.ts
@@ -10,13 +10,13 @@ import type {
   WorkspaceConfig,
 } from '../models/workspace-config.js';
 import { getPluginSource } from '../models/workspace-config.js';
+import { parseMarketplaceManifest } from '../utils/marketplace-manifest-parser.js';
 import {
   isGitHubUrl,
   parseGitHubUrl,
   validatePluginSource,
   verifyGitHubUrlExists,
 } from '../utils/plugin-path.js';
-import { parseMarketplaceManifest } from '../utils/marketplace-manifest-parser.js';
 import {
   getMarketplace,
   isPluginSpec,
@@ -183,7 +183,9 @@ async function addPluginToConfig(
     const config = load(content) as WorkspaceConfig;
 
     // Check if plugin already exists (exact match)
-    const existingExactIndex = config.plugins.findIndex((entry) => getPluginSource(entry) === plugin);
+    const existingExactIndex = config.plugins.findIndex(
+      (entry) => getPluginSource(entry) === plugin,
+    );
     if (existingExactIndex !== -1) {
       if (!force) {
         return {
@@ -261,16 +263,15 @@ export async function hasPlugin(
     const config = load(content) as WorkspaceConfig;
 
     // Exact match first
-    if (config.plugins.some((entry) => getPluginSource(entry) === plugin)) return true;
+    if (config.plugins.some((entry) => getPluginSource(entry) === plugin))
+      return true;
 
     // Partial match
     if (!isPluginSpec(plugin)) {
-      return config.plugins.some(
-        (entry) => {
-          const source = getPluginSource(entry);
-          return source.startsWith(`${plugin}@`) || source === plugin;
-        },
-      );
+      return config.plugins.some((entry) => {
+        const source = getPluginSource(entry);
+        return source.startsWith(`${plugin}@`) || source === plugin;
+      });
     }
 
     return false;
@@ -311,12 +312,10 @@ export async function removePlugin(
 
     // If not found, try partial match (e.g., "code-review" matches "code-review@claude-plugins-official")
     if (index === -1 && isPluginSpec(plugin) === false) {
-      index = config.plugins.findIndex(
-        (entry) => {
-          const source = getPluginSource(entry);
-          return source.startsWith(`${plugin}@`) || source === plugin;
-        },
-      );
+      index = config.plugins.findIndex((entry) => {
+        const source = getPluginSource(entry);
+        return source.startsWith(`${plugin}@`) || source === plugin;
+      });
     }
 
     // Semantic match: same GitHub repo under a different format
@@ -391,8 +390,10 @@ export function pruneDisabledSkillsForPlugin(
  * For plugin specs (plugin@marketplace), skill keys may use either the
  * plugin component or the marketplace name (when the marketplace root
  * IS the plugin directory).
+ *
+ * Exported for reuse by user-workspace.ts.
  */
-function extractPluginNames(pluginSource: string): string[] {
+export function extractPluginNames(pluginSource: string): string[] {
   if (isPluginSpec(pluginSource)) {
     const parsed = parsePluginSpec(pluginSource);
     if (!parsed) return [];
@@ -410,7 +411,53 @@ function extractPluginNames(pluginSource: string): string[] {
 }
 
 /**
- * Get disabled skills from workspace config
+ * Find the index of a plugin entry whose candidate names include pluginName.
+ * Exported for reuse by user-workspace.ts.
+ */
+export function findPluginEntryByName(
+  config: WorkspaceConfig,
+  pluginName: string,
+): number {
+  return config.plugins.findIndex((entry) =>
+    extractPluginNames(getPluginSource(entry)).includes(pluginName),
+  );
+}
+
+/**
+ * Ensure the plugin entry at config.plugins[index] is in object form.
+ * Converts a string shorthand to { source } if needed and returns the mutable object.
+ * Exported for reuse by user-workspace.ts.
+ */
+export function ensureObjectPluginEntry(
+  config: WorkspaceConfig,
+  index: number,
+): Exclude<PluginEntry, string> {
+  const entry = config.plugins[index];
+  if (entry === undefined) throw new Error(`Plugin entry at index ${index} not found`);
+  if (typeof entry === 'string') {
+    const objectEntry: Exclude<PluginEntry, string> = { source: entry };
+    config.plugins[index] = objectEntry;
+    return objectEntry;
+  }
+  return entry;
+}
+
+/** Parse "pluginName:skillName" into its two parts, or return null on bad format. */
+function parseSkillKey(
+  skillKey: string,
+): { pluginName: string; skillName: string } | null {
+  const colonIdx = skillKey.indexOf(':');
+  if (colonIdx === -1) return null;
+  return {
+    pluginName: skillKey.slice(0, colonIdx),
+    skillName: skillKey.slice(colonIdx + 1),
+  };
+}
+
+/**
+ * Get disabled skills from workspace config.
+ * Reads from inline plugin entry `skills.exclude` arrays (blocklist mode).
+ * Also includes legacy top-level `disabledSkills` for backward compatibility.
  * @param workspacePath - Path to workspace directory (default: cwd)
  * @returns Array of disabled skill keys (plugin:skill format)
  */
@@ -423,14 +470,36 @@ export async function getDisabledSkills(
   try {
     const content = await readFile(configPath, 'utf-8');
     const config = load(content) as WorkspaceConfig;
-    return config.disabledSkills ?? [];
+    const result: string[] = [];
+
+    for (const entry of config.plugins) {
+      if (
+        typeof entry === 'string' ||
+        !entry.skills ||
+        Array.isArray(entry.skills)
+      )
+        continue;
+      const pluginName = extractPluginNames(getPluginSource(entry))[0];
+      if (!pluginName) continue;
+      for (const skillName of entry.skills.exclude) {
+        result.push(`${pluginName}:${skillName}`);
+      }
+    }
+
+    // Include legacy top-level disabledSkills
+    for (const s of config.disabledSkills ?? []) {
+      if (!result.includes(s)) result.push(s);
+    }
+
+    return result;
   } catch {
     return [];
   }
 }
 
 /**
- * Add a skill to disabledSkills in workspace config
+ * Add a skill to the plugin entry's `skills.exclude` list (blocklist mode).
+ * Converts a string shorthand plugin entry to object form if needed.
  * @param skillKey - Skill key in plugin:skill format
  * @param workspacePath - Path to workspace directory (default: cwd)
  */
@@ -447,19 +516,45 @@ export async function addDisabledSkill(
     };
   }
 
+  const parsed = parseSkillKey(skillKey);
+  if (!parsed) {
+    return {
+      success: false,
+      error: `Invalid skill key format: '${skillKey}' (expected pluginName:skillName)`,
+    };
+  }
+  const { pluginName, skillName } = parsed;
+
   try {
     const content = await readFile(configPath, 'utf-8');
     const config = load(content) as WorkspaceConfig;
-    const disabledSkills = config.disabledSkills ?? [];
 
-    if (disabledSkills.includes(skillKey)) {
+    const index = findPluginEntryByName(config, pluginName);
+    if (index === -1) {
+      return {
+        success: false,
+        error: `Plugin '${pluginName}' not found in workspace config`,
+      };
+    }
+
+    const entry = ensureObjectPluginEntry(config, index);
+
+    if (Array.isArray(entry.skills)) {
+      return {
+        success: false,
+        error: `Plugin '${pluginName}' is in allowlist mode; use removeEnabledSkill to disable a skill`,
+      };
+    }
+
+    const existing = entry.skills?.exclude ?? [];
+    if (existing.includes(skillName)) {
       return {
         success: false,
         error: `Skill '${skillKey}' is already disabled`,
       };
     }
 
-    config.disabledSkills = [...disabledSkills, skillKey];
+    entry.skills = { exclude: [...existing, skillName] };
     await writeFile(configPath, dump(config, { lineWidth: -1 }), 'utf-8');
     return { success: true };
   } catch (error) {
@@ -471,7 +566,7 @@ export async function addDisabledSkill(
 }
 
 /**
- * Remove a skill from disabledSkills in workspace config
+ * Remove a skill from the plugin entry's `skills.exclude` list (blocklist mode).
  * @param skillKey - Skill key in plugin:skill format
  * @param workspacePath - Path to workspace directory (default: cwd)
  */
@@ -488,23 +583,52 @@ export async function removeDisabledSkill(
     };
   }
 
+  const parsed = parseSkillKey(skillKey);
+  if (!parsed) {
+    return {
+      success: false,
+      error: `Invalid skill key format: '${skillKey}' (expected pluginName:skillName)`,
+    };
+  }
+  const { pluginName, skillName } = parsed;
+
   try {
     const content = await readFile(configPath, 'utf-8');
     const config = load(content) as WorkspaceConfig;
-    const disabledSkills = config.disabledSkills ?? [];
 
-    if (!disabledSkills.includes(skillKey)) {
+    const index = findPluginEntryByName(config, pluginName);
+    if (index === -1) {
+      return {
+        success: false,
+        error: `Plugin '${pluginName}' not found in workspace config`,
+      };
+    }
+
+    const entry = config.plugins[index];
+    if (!entry) {
+      return { success: false, error: `Plugin '${pluginName}' not found in workspace config` };
+    }
+    if (
+      typeof entry === 'string' ||
+      !entry.skills ||
+      Array.isArray(entry.skills)
+    ) {
       return {
         success: false,
         error: `Skill '${skillKey}' is already enabled`,
       };
     }
 
-    config.disabledSkills = disabledSkills.filter((s) => s !== skillKey);
-    // Remove empty array from config
-    if (config.disabledSkills.length === 0) {
-      config.disabledSkills = undefined;
+    if (!entry.skills.exclude.includes(skillName)) {
+      return {
+        success: false,
+        error: `Skill '${skillKey}' is already enabled`,
+      };
     }
+
+    const newExclude = entry.skills.exclude.filter((s) => s !== skillName);
+    entry.skills = newExclude.length > 0 ? { exclude: newExclude } : undefined;
+
     await writeFile(configPath, dump(config, { lineWidth: -1 }), 'utf-8');
     return { success: true };
   } catch (error) {
@@ -516,7 +640,10 @@ export async function removeDisabledSkill(
 }
 
 /**
- * Get the list of enabled skills from workspace config
+ * Get enabled skills from workspace config.
+ * Reads from inline plugin entry `skills` arrays (allowlist mode).
+ * Also includes legacy top-level `enabledSkills` for backward compatibility.
+ * @param workspacePath - Path to workspace directory (default: cwd)
  */
 export async function getEnabledSkills(
   workspacePath: string = process.cwd(),
@@ -526,14 +653,33 @@ export async function getEnabledSkills(
   try {
     const content = await readFile(configPath, 'utf-8');
     const config = load(content) as WorkspaceConfig;
-    return config.enabledSkills ?? [];
+    const result: string[] = [];
+
+    for (const entry of config.plugins) {
+      if (typeof entry === 'string' || !Array.isArray(entry.skills)) continue;
+      const pluginName = extractPluginNames(getPluginSource(entry))[0];
+      if (!pluginName) continue;
+      for (const skillName of entry.skills) {
+        result.push(`${pluginName}:${skillName}`);
+      }
+    }
+
+    // Include legacy top-level enabledSkills
+    for (const s of config.enabledSkills ?? []) {
+      if (!result.includes(s)) result.push(s);
+    }
+
+    return result;
   } catch {
     return [];
   }
 }
 
 /**
- * Add a skill to enabledSkills list (allowlist mode)
+ * Add a skill to the plugin entry's `skills` allowlist.
+ * Converts a string shorthand plugin entry to object form if needed.
+ * @param skillKey - Skill key in plugin:skill format
+ * @param workspacePath - Path to workspace directory (default: cwd)
  */
 export async function addEnabledSkill(
   skillKey: string,
@@ -546,14 +692,46 @@ export async function addEnabledSkill(
       error: `${CONFIG_DIR}/${WORKSPACE_CONFIG_FILE} not found in ${workspacePath}`,
     };
   }
+
+  const parsed = parseSkillKey(skillKey);
+  if (!parsed) {
+    return {
+      success: false,
+      error: `Invalid skill key format: '${skillKey}' (expected pluginName:skillName)`,
+    };
+  }
+  const { pluginName, skillName } = parsed;
+
   try {
     const content = await readFile(configPath, 'utf-8');
     const config = load(content) as WorkspaceConfig;
-    const enabledSkills = config.enabledSkills ?? [];
-    if (enabledSkills.includes(skillKey)) {
-      return { success: false, error: `Skill '${skillKey}' is already enabled` };
+
+    const index = findPluginEntryByName(config, pluginName);
+    if (index === -1) {
+      return {
+        success: false,
+        error: `Plugin '${pluginName}' not found in workspace config`,
+      };
     }
-    config.enabledSkills = [...enabledSkills, skillKey];
+
+    const entry = ensureObjectPluginEntry(config, index);
+
+    if (entry.skills && !Array.isArray(entry.skills)) {
+      return {
+        success: false,
+        error: `Plugin '${pluginName}' is in blocklist mode; use removeDisabledSkill to enable a skill`,
+      };
+    }
+
+    const existing = (entry.skills as string[] | undefined) ?? [];
+    if (existing.includes(skillName)) {
+      return {
+        success: false,
+        error: `Skill '${skillKey}' is already enabled`,
+      };
+    }
+
+    entry.skills = [...existing, skillName];
     await writeFile(configPath, dump(config, { lineWidth: -1 }), 'utf-8');
     return { success: true };
   } catch (error) {
@@ -565,7 +743,9 @@ export async function addEnabledSkill(
 }
 
 /**
- * Remove a skill from enabledSkills list (allowlist mode)
+ * Remove a skill from the plugin entry's `skills` allowlist.
+ * @param skillKey - Skill key in plugin:skill format
+ * @param workspacePath - Path to workspace directory (default: cwd)
  */
 export async function removeEnabledSkill(
   skillKey: string,
@@ -578,17 +758,53 @@ export async function removeEnabledSkill(
       error: `${CONFIG_DIR}/${WORKSPACE_CONFIG_FILE} not found in ${workspacePath}`,
     };
   }
+
+  const parsed = parseSkillKey(skillKey);
+  if (!parsed) {
+    return {
+      success: false,
+      error: `Invalid skill key format: '${skillKey}' (expected pluginName:skillName)`,
+    };
+  }
+  const { pluginName, skillName } = parsed;
+
   try {
     const content = await readFile(configPath, 'utf-8');
     const config = load(content) as WorkspaceConfig;
-    const enabledSkills = config.enabledSkills ?? [];
-    if (!enabledSkills.includes(skillKey)) {
-      return { success: false, error: `Skill '${skillKey}' is already disabled` };
+
+    const index = findPluginEntryByName(config, pluginName);
+    if (index === -1) {
+      return {
+        success: false,
+        error: `Plugin '${pluginName}' not found in workspace config`,
+      };
     }
-    config.enabledSkills = enabledSkills.filter((s) => s !== skillKey);
-    if (config.enabledSkills.length === 0) {
-      config.enabledSkills = undefined;
+
+    const entry = config.plugins[index];
+    if (!entry) {
+      return { success: false, error: `Plugin '${pluginName}' not found in workspace config` };
     }
+    if (
+      typeof entry === 'string' ||
+      !entry.skills ||
+      !Array.isArray(entry.skills)
+    ) {
+      return {
+        success: false,
+        error: `Skill '${skillKey}' is already disabled`,
+      };
+    }
+
+    if (!entry.skills.includes(skillName)) {
+      return {
+        success: false,
+        error: `Skill '${skillKey}' is already disabled`,
+      };
+    }
+
+    const newSkills = entry.skills.filter((s) => s !== skillName);
+    entry.skills = newSkills.length > 0 ? newSkills : undefined;
+
     await writeFile(configPath, dump(config, { lineWidth: -1 }), 'utf-8');
     return { success: true };
   } catch (error) {
@@ -654,6 +870,97 @@ export async function resolveGitHubIdentity(
   }
 
   return null;
+}
+
+// MIGRATION: v1→v2 skill schema. Remove this block after v3 is released.
+/**
+ * Migrate a project workspace config from v1 skill schema to v2.
+ *
+ * v1: top-level `enabledSkills`/`disabledSkills` arrays of "pluginName:skillName" strings.
+ * v2: per-plugin `skills` field (allowlist array or `{ exclude: [...] }` blocklist).
+ *
+ * Idempotent: if `version >= 2`, returns immediately without touching the file.
+ * Also upgrades configs that have neither field (first-time users) by setting version:2.
+ */
+export async function migrateWorkspaceSkillsV1toV2(
+  workspacePath: string,
+): Promise<void> {
+  const configPath = join(workspacePath, CONFIG_DIR, WORKSPACE_CONFIG_FILE);
+  if (!existsSync(configPath)) return;
+
+  let config: WorkspaceConfig;
+  try {
+    const content = await readFile(configPath, 'utf-8');
+    config = load(content) as WorkspaceConfig;
+  } catch {
+    return;
+  }
+
+  if (!config || (config.version !== undefined && config.version >= 2)) return;
+
+  const enabledSkills: string[] = config.enabledSkills ?? [];
+  const disabledSkills: string[] = config.disabledSkills ?? [];
+
+  // Group enabledSkills by pluginName
+  const enabledByPlugin = new Map<string, string[]>();
+  for (const skillKey of enabledSkills) {
+    const parsed = parseSkillKey(skillKey);
+    if (!parsed) continue;
+    const list = enabledByPlugin.get(parsed.pluginName) ?? [];
+    list.push(parsed.skillName);
+    enabledByPlugin.set(parsed.pluginName, list);
+  }
+
+  // Group disabledSkills by pluginName
+  const disabledByPlugin = new Map<string, string[]>();
+  for (const skillKey of disabledSkills) {
+    const parsed = parseSkillKey(skillKey);
+    if (!parsed) continue;
+    const list = disabledByPlugin.get(parsed.pluginName) ?? [];
+    list.push(parsed.skillName);
+    disabledByPlugin.set(parsed.pluginName, list);
+  }
+
+  // Apply enabledSkills → plugin entry allowlist
+  for (const [pluginName, skillNames] of enabledByPlugin) {
+    const index = findPluginEntryByName(config, pluginName);
+    if (index === -1) {
+      console.warn(
+        `[migrate v1→v2] No plugin found for '${pluginName}', skipping`,
+      );
+      continue;
+    }
+    const entry = ensureObjectPluginEntry(config, index);
+    entry.skills = skillNames;
+  }
+
+  // Apply disabledSkills → plugin entry blocklist
+  for (const [pluginName, skillNames] of disabledByPlugin) {
+    const index = findPluginEntryByName(config, pluginName);
+    if (index === -1) {
+      console.warn(
+        `[migrate v1→v2] No plugin found for '${pluginName}', skipping`,
+      );
+      continue;
+    }
+    const entry = ensureObjectPluginEntry(config, index);
+    // If an allowlist was already set from enabledSkills, prefer it (ignore disabled for same plugin)
+    if (!Array.isArray(entry.skills)) {
+      entry.skills = { exclude: skillNames };
+    }
+  }
+
+  config.enabledSkills = undefined;
+  config.disabledSkills = undefined;
+  config.version = 2;
+
+  try {
+    await writeFile(configPath, dump(config, { lineWidth: -1 }), 'utf-8');
+  } catch (error) {
+    console.warn(
+      `[migrate v1→v2] Failed to write migrated config: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
 }
 
 /**

--- a/src/models/workspace-config.ts
+++ b/src/models/workspace-config.ts
@@ -114,6 +114,18 @@ export const ClientEntrySchema = z.union([
 export type ClientEntry = z.infer<typeof ClientEntrySchema>;
 
 /**
+ * Skill selection config for a plugin entry.
+ * - Array: allowlist — only these skills are enabled.
+ * - Object with `exclude`: blocklist — all skills except these are enabled.
+ */
+export const PluginSkillsConfigSchema = z.union([
+  z.array(z.string()),
+  z.object({ exclude: z.array(z.string()) }),
+]);
+
+export type PluginSkillsConfig = z.infer<typeof PluginSkillsConfigSchema>;
+
+/**
  * Plugin entry in workspace.yaml
  * Supports string shorthand and object form with optional client override.
  */
@@ -124,6 +136,7 @@ export const PluginEntrySchema = z.union([
     clients: z.array(ClientTypeSchema).optional(),
     install: InstallModeSchema.optional(),
     exclude: z.array(z.string()).optional(),
+    skills: PluginSkillsConfigSchema.optional(),
   }),
 ]);
 
@@ -222,13 +235,16 @@ export type SyncMode = z.infer<typeof SyncModeSchema>;
  * Complete workspace configuration (workspace.yaml)
  */
 export const WorkspaceConfigSchema = z.object({
+  version: z.number().optional(),
   workspace: WorkspaceSchema.optional(),
   repositories: z.array(RepositorySchema),
   plugins: z.array(PluginEntrySchema),
   clients: z.array(ClientEntrySchema),
   vscode: VscodeConfigSchema.optional(),
   syncMode: SyncModeSchema.optional(),
+  /** @deprecated Use inline skills field on plugin entry instead. Will be removed in v3. */
   disabledSkills: z.array(z.string()).optional(),
+  /** @deprecated Use inline skills field on plugin entry instead. Will be removed in v3. */
   enabledSkills: z.array(z.string()).optional(),
 });
 

--- a/tests/unit/core/user-workspace-skills.test.ts
+++ b/tests/unit/core/user-workspace-skills.test.ts
@@ -22,7 +22,7 @@ describe('user-scope disabledSkills helpers', () => {
   });
 
   it('adds and removes disabled skills in user config', async () => {
-    const config = { repositories: [], plugins: [], clients: ['copilot'] };
+    const config = { repositories: [], plugins: ['superpowers'], clients: ['copilot'] };
     await writeFile(join(tmpDir, '.allagents/workspace.yaml'), dump(config));
 
     // Import after setting HOME
@@ -42,7 +42,7 @@ describe('user-scope disabledSkills helpers', () => {
   });
 
   it('adds and removes enabled skills in user config', async () => {
-    const config = { repositories: [], plugins: [], clients: ['copilot'] };
+    const config = { repositories: [], plugins: ['superpowers'], clients: ['copilot'] };
     await writeFile(join(tmpDir, '.allagents/workspace.yaml'), dump(config));
 
     // Import after setting HOME

--- a/tests/unit/core/workspace-modify-skills.test.ts
+++ b/tests/unit/core/workspace-modify-skills.test.ts
@@ -27,7 +27,7 @@ describe('disabledSkills helpers', () => {
 
   describe('addDisabledSkill', () => {
     it('adds skill to empty disabledSkills', async () => {
-      const config = { repositories: [], plugins: [], clients: ['claude'] };
+      const config = { repositories: [], plugins: ['superpowers'], clients: ['claude'] };
       await writeFile(join(tmpDir, '.allagents/workspace.yaml'), dump(config));
 
       const result = await addDisabledSkill('superpowers:brainstorming', tmpDir);
@@ -40,9 +40,8 @@ describe('disabledSkills helpers', () => {
     it('returns error if skill already disabled', async () => {
       const config = {
         repositories: [],
-        plugins: [],
+        plugins: [{ source: 'superpowers', skills: { exclude: ['brainstorming'] } }],
         clients: ['claude'],
-        disabledSkills: ['superpowers:brainstorming'],
       };
       await writeFile(join(tmpDir, '.allagents/workspace.yaml'), dump(config));
 
@@ -56,9 +55,11 @@ describe('disabledSkills helpers', () => {
     it('removes skill from disabledSkills', async () => {
       const config = {
         repositories: [],
-        plugins: [],
+        plugins: [
+          { source: 'superpowers', skills: { exclude: ['brainstorming'] } },
+          { source: 'other', skills: { exclude: ['skill'] } },
+        ],
         clients: ['claude'],
-        disabledSkills: ['superpowers:brainstorming', 'other:skill'],
       };
       await writeFile(join(tmpDir, '.allagents/workspace.yaml'), dump(config));
 
@@ -71,7 +72,7 @@ describe('disabledSkills helpers', () => {
     });
 
     it('returns error if skill not in disabledSkills', async () => {
-      const config = { repositories: [], plugins: [], clients: ['claude'] };
+      const config = { repositories: [], plugins: ['superpowers'], clients: ['claude'] };
       await writeFile(join(tmpDir, '.allagents/workspace.yaml'), dump(config));
 
       const result = await removeDisabledSkill('superpowers:brainstorming', tmpDir);
@@ -192,7 +193,7 @@ describe('enabledSkills helpers', () => {
 
   describe('addEnabledSkill', () => {
     it('adds skill to empty enabledSkills', async () => {
-      const config = { repositories: [], plugins: [], clients: ['claude'] };
+      const config = { repositories: [], plugins: ['superpowers'], clients: ['claude'] };
       await writeFile(join(tmpDir, '.allagents/workspace.yaml'), dump(config));
       const result = await addEnabledSkill('superpowers:brainstorming', tmpDir);
       expect(result.success).toBe(true);
@@ -202,8 +203,9 @@ describe('enabledSkills helpers', () => {
 
     it('returns error if skill already enabled', async () => {
       const config = {
-        repositories: [], plugins: [], clients: ['claude'],
-        enabledSkills: ['superpowers:brainstorming'],
+        repositories: [],
+        plugins: [{ source: 'superpowers', skills: ['brainstorming'] }],
+        clients: ['claude'],
       };
       await writeFile(join(tmpDir, '.allagents/workspace.yaml'), dump(config));
       const result = await addEnabledSkill('superpowers:brainstorming', tmpDir);
@@ -215,8 +217,12 @@ describe('enabledSkills helpers', () => {
   describe('removeEnabledSkill', () => {
     it('removes skill from enabledSkills', async () => {
       const config = {
-        repositories: [], plugins: [], clients: ['claude'],
-        enabledSkills: ['superpowers:brainstorming', 'other:skill'],
+        repositories: [],
+        plugins: [
+          { source: 'superpowers', skills: ['brainstorming'] },
+          { source: 'other', skills: ['skill'] },
+        ],
+        clients: ['claude'],
       };
       await writeFile(join(tmpDir, '.allagents/workspace.yaml'), dump(config));
       const result = await removeEnabledSkill('superpowers:brainstorming', tmpDir);
@@ -227,7 +233,7 @@ describe('enabledSkills helpers', () => {
     });
 
     it('returns error if skill not in enabledSkills', async () => {
-      const config = { repositories: [], plugins: [], clients: ['claude'] };
+      const config = { repositories: [], plugins: ['superpowers'], clients: ['claude'] };
       await writeFile(join(tmpDir, '.allagents/workspace.yaml'), dump(config));
       const result = await removeEnabledSkill('superpowers:brainstorming', tmpDir);
       expect(result.success).toBe(false);


### PR DESCRIPTION
## Summary

Closes #233.

Implements the inline per-plugin skill selection schema (v2), replacing the implicit dual-array `disabledSkills`/`enabledSkills` design.

## Breaking Change

Skill selection moves from top-level arrays to inline plugin entries.

**Before (v1):**
```yaml
plugins:
  - superpowers@marketplace
enabledSkills:
  - superpowers:brainstorming
disabledSkills:
  - my-tools:verbose-logging
```

**After (v2):**
```yaml
version: 2
plugins:
  - source: superpowers@marketplace
    skills: [brainstorming]
  - source: my-tools@marketplace
    skills:
      exclude: [verbose-logging]
```

## Migration

**Automatic** — existing `workspace.yaml` files are migrated to v2 format on the next `allagents workspace sync`. The migration code is self-contained with a removal comment for v3.

## What Changed

| File | Change |
|------|--------|
| `workspace-config.ts` | Added `PluginSkillsConfig` type, `skills` field on `PluginEntry`, `version` field |
| `skills.ts` | Reads inline `skills` field; v1 fallback; exposes `pluginSkillsMode` on `SkillInfo` |
| `transform.ts` | Same inline-first logic |
| `sync.ts` | Propagates `pluginSkillsConfig`; calls migration on startup |
| `workspace-modify.ts` | Write functions write inline; added migration function |
| `user-workspace.ts` | Same for user scope |
| `plugin-skills.ts` | Removed `inAllowlistMode` detection; uses `targetSkill.pluginSkillsMode` |
| `package.json` | Bumped to v1.0.0 |
| `CHANGELOG.md` | Created with migration guide |