### PR TITLE
fix(sync): warn when no clients configured in workspace.yaml

### DIFF
--- a/src/cli/commands/plugin.ts
+++ b/src/cli/commands/plugin.ts
@@ -125,6 +125,13 @@ async function runSyncAndPrint(options?: { skipAgentFiles?: boolean }): Promise<
       }
     }
 
+    if (result.warnings && result.warnings.length > 0) {
+      console.log('\nWarnings:');
+      for (const warning of result.warnings) {
+        console.log(`  \u26A0 ${warning}`);
+      }
+    }
+
     console.log('');
     for (const line of formatSyncSummary(result)) {
       console.log(line);

--- a/src/core/sync.ts
+++ b/src/core/sync.ts
@@ -1736,6 +1736,21 @@ export async function syncWorkspace(
   const filteredPlans = pluginPlans.filter((plan) => plan.clients.length > 0 || plan.nativeClients.length > 0);
   const syncClients = collectSyncClients(workspaceClients, filteredPlans);
 
+  // Warn when no clients are configured — the sync will succeed but create no artifacts
+  if (syncClients.length === 0) {
+    return {
+      success: true,
+      pluginResults: [],
+      totalCopied: 0,
+      totalFailed: 0,
+      totalSkipped: 0,
+      totalGenerated: 0,
+      warnings: [
+        'No clients configured in workspace.yaml — no artifacts were synced. Add clients to workspace.yaml or run \'allagents workspace init\' to configure.',
+      ],
+    };
+  }
+
   // Step 0: Pre-register unique marketplaces to avoid race conditions during parallel validation
   await ensureMarketplacesRegistered(filteredPlans.map((plan) => plan.source));
 

--- a/tests/unit/core/sync.test.ts
+++ b/tests/unit/core/sync.test.ts
@@ -133,6 +133,25 @@ describe('sync', () => {
       expect(result.error).toContain(`${CONFIG_DIR}/${WORKSPACE_CONFIG_FILE} not found`);
     });
 
+    it('should warn when no clients are configured', async () => {
+      await mkdir(join(testDir, CONFIG_DIR), { recursive: true });
+      await writeFile(
+        join(testDir, CONFIG_DIR, WORKSPACE_CONFIG_FILE),
+        `
+repositories: []
+plugins: []
+clients: []
+`,
+      );
+
+      const result = await syncWorkspace(testDir);
+
+      expect(result.success).toBe(true);
+      expect(result.totalCopied).toBe(0);
+      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings![0]).toContain('No clients configured');
+    });
+
     it('should fail if plugin does not exist and leave workspace unchanged', async () => {
       // Setup: Create .allagents/workspace.yaml with non-existent plugin
       await mkdir(join(testDir, CONFIG_DIR), { recursive: true });


### PR DESCRIPTION
## Summary

- Returns a warning when `clients: []` (or no effective clients after plugin plan filtering) and sync is called — instead of silently doing nothing
- Warning appears in both `workspace sync` and `plugin install/update` output
- Exits with code 0 (success) since the workspace itself is valid

## E2E Test Steps

```bash
mkdir -p /tmp/aa-test/.allagents
cat > /tmp/aa-test/.allagents/workspace.yaml << 'YAML'
repositories: []
plugins: []
clients: []
YAML

# workspace sync
cd /tmp/aa-test && allagents workspace sync
# Expected: Warning: No clients configured in workspace.yaml — no artifacts were synced.

# plugin install
allagents plugin install /some/local/plugin
# Expected: same warning shown after sync step
```

Closes #222