### PR TITLE
fix(cli): update stale error message about flat SKILL.md repos

### DIFF
--- a/src/cli/commands/plugin-skills.ts
+++ b/src/cli/commands/plugin-skills.ts
@@ -374,7 +374,7 @@ const addCmd = command({
           if (matches.length === 0) {
             const allSkills = await getAllSkillsFromPlugins(workspacePath);
             const skillNames = [...new Set(allSkills.map((s) => s.name))].join(', ');
-            const error = `Skill '${skill}' not found in plugin '${from}'. The plugin may not use the allagents skills/ directory structure (flat SKILL.md repos from the npx skills ecosystem are not yet supported). (see GitHub for details)\n\nAvailable skills: ${skillNames || 'none'}`;
+            const error = `Skill '${skill}' not found in plugin '${from}'.\n\nAvailable skills: ${skillNames || 'none'}\n\nTip: run \`allagents skills list\` to see all installed skills.`;
             if (isJsonMode()) {
               jsonOutput({ success: false, command: 'plugin skills add', error });
               process.exit(1);


### PR DESCRIPTION
## Summary
- Remove outdated "flat SKILL.md repos from the npx skills ecosystem are not yet supported" message from `plugin skills add --from` error
- Replace with actionable guidance: show available skills and tip to use `allagents skills list`

Closes #241

## E2E Test
```bash
bun run build
# Install a plugin and try adding a non-existent skill
./dist/index.js plugin skills add nonexistent-skill --from github:some/plugin
# Verify: error message no longer says "not yet supported"
# Verify: error message shows available skills and tip
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)