### PR TITLE
feat(tui): show marketplace skills in skills screen and plugin picker

### DIFF
--- a/src/cli/tui/actions/plugins.ts
+++ b/src/cli/tui/actions/plugins.ts
@@ -24,7 +24,7 @@ import {
 import { updatePlugin } from '../../../core/plugin.js';
 import { parseMarketplaceManifest } from '../../../utils/marketplace-manifest-parser.js';
 import { getWorkspaceStatus } from '../../../core/status.js';
-import { getAllSkillsFromPlugins } from '../../../core/skills.js';
+import { getAllSkillsFromPlugins, discoverSkillNames } from '../../../core/skills.js';
 import { getHomeDir } from '../../../constants.js';
 import type { TuiContext } from '../context.js';
 import type { TuiCache } from '../cache.js';
@@ -87,7 +87,7 @@ async function getCachedMarketplacePlugins(
  * Shared helper: determine scope, install a plugin, sync, and show success.
  * Returns true if installed successfully, false if cancelled or failed.
  */
-async function installSelectedPlugin(
+export async function installSelectedPlugin(
   pluginRef: string,
   context: TuiContext,
   cache?: TuiCache,
@@ -558,16 +558,18 @@ export async function runInstallPlugin(context: TuiContext, cache?: TuiCache): P
       return;
     }
 
-    // Collect plugins from all marketplaces
+    // Collect plugins from all marketplaces with skill preview
     const allPlugins: Array<{ label: string; value: string }> = [];
     for (const marketplace of marketplaces) {
       const result = await getCachedMarketplacePlugins(marketplace.name, cache);
       for (const plugin of result.plugins) {
-        const label = plugin.description
-          ? `${plugin.name} - ${plugin.description}`
-          : plugin.name;
+        const skillNames = await discoverSkillNames(plugin.path);
+        const desc = plugin.description ? ` - ${plugin.description}` : '';
+        const skillInfo = skillNames.length > 0
+          ? `\n    Skills: ${skillNames.join(', ')}`
+          : '';
         allPlugins.push({
-          label: `${label} (${marketplace.name})`,
+          label: `${plugin.name}${desc} (${marketplace.name})${skillInfo}`,
           value: `${plugin.name}@${marketplace.name}`,
         });
       }

--- a/src/cli/tui/actions/skills.ts
+++ b/src/cli/tui/actions/skills.ts
@@ -1,5 +1,5 @@
 import * as p from '@clack/prompts';
-import { getAllSkillsFromPlugins, type SkillInfo } from '../../../core/skills.js';
+import { getAllSkillsFromPlugins, discoverSkillNames, type SkillInfo } from '../../../core/skills.js';
 import {
   addDisabledSkill,
   removeDisabledSkill,
@@ -10,11 +10,16 @@ import {
   isUserConfigPath,
 } from '../../../core/user-workspace.js';
 import { syncWorkspace, syncUserWorkspace } from '../../../core/sync.js';
+import {
+  listMarketplaces,
+  listMarketplacePlugins,
+} from '../../../core/marketplace.js';
 import { getHomeDir } from '../../../constants.js';
 import type { TuiContext } from '../context.js';
 import type { TuiCache } from '../cache.js';
+import { installSelectedPlugin } from './plugins.js';
 
-const { multiselect } = p;
+const { multiselect, select } = p;
 
 interface ScopedSkill extends SkillInfo {
   scope: 'user' | 'project';
@@ -65,100 +70,246 @@ async function loadAllSkills(context: TuiContext): Promise<ScopedSkill[]> {
 }
 
 /**
+ * Marketplace skill info for display
+ */
+interface MarketplaceSkillPreview {
+  skillName: string;
+  pluginName: string;
+  marketplaceName: string;
+  pluginRef: string;
+  pluginDescription?: string | undefined;
+}
+
+/**
+ * Load skills available from all configured marketplaces.
+ * Scans each marketplace plugin's local directory for skills.
+ */
+async function loadMarketplaceSkills(cache?: TuiCache): Promise<MarketplaceSkillPreview[]> {
+  const previews: MarketplaceSkillPreview[] = [];
+
+  try {
+    const cachedMarketplaces = cache?.getMarketplaces();
+    const marketplaces = cachedMarketplaces ?? await listMarketplaces();
+    if (!cachedMarketplaces) cache?.setMarketplaces(marketplaces);
+
+    for (const marketplace of marketplaces) {
+      const cachedPlugins = cache?.getMarketplacePlugins(marketplace.name);
+      const result = cachedPlugins ?? await listMarketplacePlugins(marketplace.name);
+      if (!cachedPlugins) cache?.setMarketplacePlugins(marketplace.name, result);
+
+      for (const plugin of result.plugins) {
+        const skillNames = await discoverSkillNames(plugin.path);
+        for (const skillName of skillNames) {
+          const preview: MarketplaceSkillPreview = {
+            skillName,
+            pluginName: plugin.name,
+            marketplaceName: marketplace.name,
+            pluginRef: `${plugin.name}@${marketplace.name}`,
+          };
+          if (plugin.description) preview.pluginDescription = plugin.description;
+          previews.push(preview);
+        }
+      }
+    }
+  } catch {
+    // Marketplace unavailable — degrade gracefully
+  }
+
+  return previews;
+}
+
+/**
  * Skills — lets user toggle which skills are enabled/disabled via multiselect.
+ * When no skills are installed, shows marketplace skills for discovery.
  */
 export async function runSkills(context: TuiContext, cache?: TuiCache): Promise<void> {
   try {
     const skills = await loadAllSkills(context);
 
     if (skills.length === 0) {
-      p.note('No skills found. Install a plugin with skills first.', 'Skills');
+      // No skills installed — show marketplace skills for discovery
+      await runBrowseMarketplaceSkills(context, cache);
       return;
     }
 
-    // Build multiselect options grouped by plugin
-    const options = skills.map((s) => ({
-      label: `${s.name} (${s.pluginName}) [${s.scope}]`,
-      value: s.key,
-    }));
+    // Skills exist — show toggle + browse option
+    while (true) {
+      const action = await select({
+        message: 'Skills',
+        options: [
+          { label: 'Toggle installed skills', value: 'toggle' as const },
+          { label: 'Browse marketplace skills...', value: 'browse' as const },
+          { label: 'Back', value: 'back' as const },
+        ],
+      });
 
-    // Pre-select enabled skills (not disabled)
-    const initialValues = skills.filter((s) => !s.disabled).map((s) => s.key);
-
-    const selected = await multiselect({
-      message: 'Toggle skills (selected = enabled)',
-      options,
-      initialValues,
-      required: false,
-    });
-
-    if (p.isCancel(selected)) {
-      return;
-    }
-
-    const selectedSet = new Set(selected);
-
-    // Compute diff
-    const toDisable = skills.filter((s) => !s.disabled && !selectedSet.has(s.key));
-    const toEnable = skills.filter((s) => s.disabled && selectedSet.has(s.key));
-
-    if (toDisable.length === 0 && toEnable.length === 0) {
-      p.note('No changes made.', 'Skills');
-      return;
-    }
-
-    const s = p.spinner();
-    s.start('Updating skills...');
-
-    let changedProject = false;
-    let changedUser = false;
-
-    // Disable newly unchecked skills
-    for (const skill of toDisable) {
-      if (skill.scope === 'user') {
-        await addUserDisabledSkill(skill.skillKey);
-        changedUser = true;
-      } else if (context.workspacePath) {
-        await addDisabledSkill(skill.skillKey, context.workspacePath);
-        changedProject = true;
+      if (p.isCancel(action) || action === 'back') {
+        return;
       }
-    }
 
-    // Enable newly checked skills
-    for (const skill of toEnable) {
-      if (skill.scope === 'user') {
-        await removeUserDisabledSkill(skill.skillKey);
-        changedUser = true;
-      } else if (context.workspacePath) {
-        await removeDisabledSkill(skill.skillKey, context.workspacePath);
-        changedProject = true;
+      if (action === 'browse') {
+        await runBrowseMarketplaceSkills(context, cache);
+        continue;
       }
-    }
 
-    s.stop('Skills updated');
-
-    // Auto-sync affected scopes
-    const syncS = p.spinner();
-    syncS.start('Syncing...');
-    if (changedProject && context.workspacePath) {
-      await syncWorkspace(context.workspacePath);
+      // Toggle skills
+      await runToggleSkills(skills, context, cache);
+      return;
     }
-    if (changedUser) {
-      await syncUserWorkspace();
-    }
-    syncS.stop('Sync complete');
-    cache?.invalidate();
-
-    const changes: string[] = [];
-    for (const skill of toEnable) {
-      changes.push(`✓ Enabled: ${skill.name} (${skill.pluginName}) [${skill.scope}]`);
-    }
-    for (const skill of toDisable) {
-      changes.push(`✗ Disabled: ${skill.name} (${skill.pluginName}) [${skill.scope}]`);
-    }
-    p.note(changes.join('\n'), 'Updated');
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     p.note(message, 'Error');
   }
+}
+
+/**
+ * Toggle installed skills via multiselect.
+ */
+async function runToggleSkills(
+  skills: ScopedSkill[],
+  context: TuiContext,
+  cache?: TuiCache,
+): Promise<void> {
+  // Build multiselect options grouped by plugin
+  const options = skills.map((s) => ({
+    label: `${s.name} (${s.pluginName}) [${s.scope}]`,
+    value: s.key,
+  }));
+
+  // Pre-select enabled skills (not disabled)
+  const initialValues = skills.filter((s) => !s.disabled).map((s) => s.key);
+
+  const selected = await multiselect({
+    message: 'Toggle skills (selected = enabled)',
+    options,
+    initialValues,
+    required: false,
+  });
+
+  if (p.isCancel(selected)) {
+    return;
+  }
+
+  const selectedSet = new Set(selected);
+
+  // Compute diff
+  const toDisable = skills.filter((s) => !s.disabled && !selectedSet.has(s.key));
+  const toEnable = skills.filter((s) => s.disabled && selectedSet.has(s.key));
+
+  if (toDisable.length === 0 && toEnable.length === 0) {
+    p.note('No changes made.', 'Skills');
+    return;
+  }
+
+  const s = p.spinner();
+  s.start('Updating skills...');
+
+  let changedProject = false;
+  let changedUser = false;
+
+  // Disable newly unchecked skills
+  for (const skill of toDisable) {
+    if (skill.scope === 'user') {
+      await addUserDisabledSkill(skill.skillKey);
+      changedUser = true;
+    } else if (context.workspacePath) {
+      await addDisabledSkill(skill.skillKey, context.workspacePath);
+      changedProject = true;
+    }
+  }
+
+  // Enable newly checked skills
+  for (const skill of toEnable) {
+    if (skill.scope === 'user') {
+      await removeUserDisabledSkill(skill.skillKey);
+      changedUser = true;
+    } else if (context.workspacePath) {
+      await removeDisabledSkill(skill.skillKey, context.workspacePath);
+      changedProject = true;
+    }
+  }
+
+  s.stop('Skills updated');
+
+  // Auto-sync affected scopes
+  const syncS = p.spinner();
+  syncS.start('Syncing...');
+  if (changedProject && context.workspacePath) {
+    await syncWorkspace(context.workspacePath);
+  }
+  if (changedUser) {
+    await syncUserWorkspace();
+  }
+  syncS.stop('Sync complete');
+  cache?.invalidate();
+
+  const changes: string[] = [];
+  for (const skill of toEnable) {
+    changes.push(`✓ Enabled: ${skill.name} (${skill.pluginName}) [${skill.scope}]`);
+  }
+  for (const skill of toDisable) {
+    changes.push(`✗ Disabled: ${skill.name} (${skill.pluginName}) [${skill.scope}]`);
+  }
+  p.note(changes.join('\n'), 'Updated');
+}
+
+/**
+ * Browse skills available from configured marketplaces.
+ * Shows a skill-centric view grouped by plugin. Selecting a skill installs its plugin.
+ */
+async function runBrowseMarketplaceSkills(
+  context: TuiContext,
+  cache?: TuiCache,
+): Promise<void> {
+  const s = p.spinner();
+  s.start('Loading marketplace skills...');
+  const marketplaceSkills = await loadMarketplaceSkills(cache);
+  s.stop('Marketplace skills loaded');
+
+  if (marketplaceSkills.length === 0) {
+    p.note(
+      'No skills found in configured marketplaces.\nUse "Manage marketplaces" to add one first.',
+      'Skills',
+    );
+    return;
+  }
+
+  // Group by plugin for display
+  const byPlugin = new Map<string, { ref: string; description?: string | undefined; skills: string[] }>();
+  for (const skill of marketplaceSkills) {
+    const existing = byPlugin.get(skill.pluginRef);
+    if (existing) {
+      existing.skills.push(skill.skillName);
+    } else {
+      const entry: { ref: string; description?: string | undefined; skills: string[] } = {
+        ref: skill.pluginRef,
+        skills: [skill.skillName],
+      };
+      if (skill.pluginDescription) entry.description = skill.pluginDescription;
+      byPlugin.set(skill.pluginRef, entry);
+    }
+  }
+
+  // Build select options — one per plugin, showing its skills
+  const options: Array<{ label: string; value: string }> = [];
+  for (const [pluginRef, data] of byPlugin) {
+    const skillList = data.skills.join(', ');
+    const desc = data.description ? ` - ${data.description}` : '';
+    options.push({
+      label: `${pluginRef}${desc}\n    Skills: ${skillList}`,
+      value: pluginRef,
+    });
+  }
+  options.push({ label: 'Back', value: '__back__' });
+
+  const selected = await select({
+    message: 'Select a plugin to install',
+    options,
+  });
+
+  if (p.isCancel(selected) || selected === '__back__') {
+    return;
+  }
+
+  await installSelectedPlugin(selected, context, cache);
 }

--- a/src/core/skills.ts
+++ b/src/core/skills.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs';
 import { readFile, readdir } from 'node:fs/promises';
-import { join, resolve } from 'node:path';
+import { join, basename, resolve } from 'node:path';
 import { load } from 'js-yaml';
 import { CONFIG_DIR, WORKSPACE_CONFIG_FILE } from '../constants.js';
 import { getPluginSource, type WorkspaceConfig, type PluginSkillsConfig } from '../models/workspace-config.js';
@@ -190,4 +190,46 @@ export async function findSkillByName(
 ): Promise<SkillInfo[]> {
   const allSkills = await getAllSkillsFromPlugins(workspacePath);
   return allSkills.filter((s) => s.name === skillName);
+}
+
+/**
+ * Discover skill names from a plugin directory without workspace config.
+ * Used for marketplace plugin preview — shows what skills a plugin provides.
+ * @param pluginPath - Path to plugin directory
+ * @returns Array of skill names
+ */
+export async function discoverSkillNames(pluginPath: string): Promise<string[]> {
+  if (!existsSync(pluginPath)) return [];
+
+  const skillsDir = join(pluginPath, 'skills');
+  if (existsSync(skillsDir)) {
+    const entries = await readdir(skillsDir, { withFileTypes: true });
+    return entries.filter((e) => e.isDirectory()).map((e) => e.name);
+  }
+
+  // Flat layout: subdirs with SKILL.md
+  const entries = await readdir(pluginPath, { withFileTypes: true });
+  const flatSkills: string[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    if (existsSync(join(pluginPath, entry.name, 'SKILL.md'))) {
+      flatSkills.push(entry.name);
+    }
+  }
+  if (flatSkills.length > 0) return flatSkills;
+
+  // Root-level SKILL.md
+  const rootSkillMd = join(pluginPath, 'SKILL.md');
+  if (existsSync(rootSkillMd)) {
+    try {
+      const content = await readFile(rootSkillMd, 'utf-8');
+      const { parseSkillMetadata } = await import('../validators/skill.js');
+      const metadata = parseSkillMetadata(content);
+      return [metadata?.name ?? basename(pluginPath)];
+    } catch {
+      return [basename(pluginPath)];
+    }
+  }
+
+  return [];
 }


### PR DESCRIPTION
## Summary
- **Skills screen (no skills installed)**: Instead of dead-end "Install a plugin first" message, show skills from configured marketplace plugins grouped by plugin. Selecting one triggers install.
- **Skills screen (skills exist)**: Add "Browse marketplace skills..." menu option alongside the existing toggle, so users can discover and install more skills.
- **Plugin picker**: Show skill names per plugin in the install list so users can see what each plugin provides before installing.
- Add `discoverSkillNames()` helper that scans a plugin directory for skills across all layouts (standard `skills/`, flat subdirs, root-level SKILL.md).

Closes #245

## Test plan
- [x] All existing tests pass (960 pass, 0 fail)
- [x] TypeScript compilation clean

### E2E verification
```bash
bun run build

# Test 1: Skills screen with no skills installed
# Set up a workspace with a marketplace but no installed plugins
mkdir -p /tmp/test-ws/.allagents
cat > /tmp/test-ws/.allagents/workspace.yaml <<YAML
plugins: []
clients: [claude]
YAML
cd /tmp/test-ws && /path/to/dist/index.js
# Navigate to Skills → should show marketplace skills grouped by plugin

# Test 2: Plugin picker skill preview
# Navigate to Plugins → + Add plugin
# Each plugin should show its skills below the name

# Test 3: Skills screen with skills installed
# Install a plugin first, then navigate to Skills
# Should show: "Toggle installed skills" / "Browse marketplace skills..." / "Back"

# Cleanup
rm -rf /tmp/test-ws
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)