### PR TITLE
fix(format-sync): deduplicate deleted artifacts in display output

### DIFF
--- a/src/cli/format-sync.ts
+++ b/src/cli/format-sync.ts
@@ -195,7 +195,17 @@ export function formatDeletedArtifacts(artifacts: DeletedArtifact[]): string[] {
   }
 
   return Array.from(byClient.entries()).map(([displayClient, items]) => {
-    const names = items.map((a) => `${a.type} '${a.name}'`).join(', ');
+    // Deduplicate by type:name within each display group.
+    // Multiple internal clients (e.g. vscode + copilot) can map to the same
+    // display name, producing duplicate entries for the same artifact.
+    const seen = new Set<string>();
+    const unique = items.filter((a) => {
+      const key = `${a.type}:${a.name}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+    const names = unique.map((a) => `${a.type} '${a.name}'`).join(', ');
     return `  Deleted (${displayClient}): ${names}`;
   });
 }

--- a/tests/unit/cli/format-sync.test.ts
+++ b/tests/unit/cli/format-sync.test.ts
@@ -334,6 +334,19 @@ describe('formatDeletedArtifacts', () => {
     expect(lines).toContain("  Deleted (claude): skill 'skill-a'");
     expect(lines).toContain("  Deleted (copilot): skill 'skill-b'");
   });
+
+  test('deduplicates artifacts when multiple internal clients map to the same display name', () => {
+    // vscode and copilot both display as "copilot"
+    const artifacts: DeletedArtifact[] = [
+      { client: 'vscode', type: 'skill', name: 'my-skill' },
+      { client: 'copilot', type: 'skill', name: 'my-skill' },
+      { client: 'vscode', type: 'command', name: 'my-cmd' },
+      { client: 'copilot', type: 'command', name: 'my-cmd' },
+    ];
+    const lines = formatDeletedArtifacts(artifacts);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toBe("  Deleted (copilot): skill 'my-skill', command 'my-cmd'");
+  });
 });
 
 describe('formatSyncSummary with deletedArtifacts', () => {


### PR DESCRIPTION
## Summary

- When multiple internal clients map to the same display name (e.g. `vscode` and `copilot` both display as "copilot"), the same deleted artifact appeared multiple times in the "Deleted" output line
- Added deduplication by `type:name` within each display group in `formatDeletedArtifacts`

**Before:**
```
Deleted (copilot): skill 'code-research', skill 'git-log-search', skill 'code-research', skill 'git-log-search'
```

**After:**
```
Deleted (copilot): skill 'code-research', skill 'git-log-search'
```

## Test plan

- [x] Unit test added: verifies deduplication when `vscode` and `copilot` artifacts both map to "copilot" display group
- [x] `bun test tests/unit/cli/format-sync.test.ts` — 28 tests pass
- [x] `bun run build` — builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)