### PR TITLE
fix(skills): preserve empty allowlist when removing last skill

### DIFF
--- a/src/core/user-workspace.ts
+++ b/src/core/user-workspace.ts
@@ -697,7 +697,7 @@ export async function removeUserEnabledSkill(
     }
 
     const newSkills = entry.skills.filter((s) => s !== skillName);
-    entry.skills = newSkills.length > 0 ? newSkills : undefined;
+    entry.skills = newSkills;
 
     await writeFile(configPath, dump(config, { lineWidth: -1 }), 'utf-8');
     return { success: true };

--- a/src/core/workspace-modify.ts
+++ b/src/core/workspace-modify.ts
@@ -813,7 +813,7 @@ export async function removeEnabledSkill(
     }
 
     const newSkills = entry.skills.filter((s) => s !== skillName);
-    entry.skills = newSkills.length > 0 ? newSkills : undefined;
+    entry.skills = newSkills;
 
     await writeFile(configPath, dump(config, { lineWidth: -1 }), 'utf-8');
     return { success: true };


### PR DESCRIPTION
## Summary

- When the last skill is removed from an allowlist, the `skills` field was set to `undefined`, reverting to "no config" = all skills enabled
- Now preserves the empty array (`skills: []`) so the plugin stays in allowlist mode with all skills disabled
- Fixed in both `workspace-modify.ts` (project scope) and `user-workspace.ts` (user scope)

## Before

```yaml
# After removing last skill:
plugins:
  - source: document-skills@anthropic-agent-skills
# skills field gone → all 17 skills enabled
```

## After

```yaml
# After removing last skill:
plugins:
  - source: document-skills@anthropic-agent-skills
    skills: []
# Empty allowlist → all skills disabled
```

## E2E Test

```bash
bun run build
cd /tmp && mkdir test && cd test && git init
mkdir -p .allagents
cat > .allagents/workspace.yaml << 'YAML'
repositories: []
plugins:
  - source: document-skills@anthropic-agent-skills
    skills: [pdf]
clients: [copilot]
version: 2
YAML

# Remove the only skill
./dist/index.js plugin skills remove pdf
cat .allagents/workspace.yaml  # Should show skills: []
./dist/index.js plugin skills list  # All should be disabled
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)