### PR TITLE
fix(format-sync): deduplicate destinations to prevent double-counting artifacts

### DIFF
--- a/src/cli/format-sync.ts
+++ b/src/cli/format-sync.ts
@@ -79,9 +79,12 @@ function classifyDestination(dest: string): { client: string; artifactType: Arti
  */
 export function classifyCopyResults(copyResults: CopyResult[]): Map<string, ArtifactCounts> {
   const clientCounts = new Map<string, ArtifactCounts>();
+  const seenDestinations = new Set<string>();
 
   for (const result of copyResults) {
     if (result.action !== 'copied') continue;
+    if (seenDestinations.has(result.destination)) continue;
+    seenDestinations.add(result.destination);
     const classification = classifyDestination(result.destination);
     if (!classification) continue;
 


### PR DESCRIPTION
## Summary

- When multiple clients resolve to the same destination path (e.g., `vscode` following `copilot`'s paths), each artifact was counted once per client, causing double-counting in sync output
- Fix deduplicates copy results by destination path in `classifyCopyResults` before counting
- Client-agnostic: prevents double-counting for any clients that share paths

## Test plan

- [ ] Run `workspace sync` with both `vscode` and `copilot` configured — skill counts should no longer be doubled
- [ ] Verify counts match the actual number of unique files synced