### PR TITLE
chore(workspace): replace scope logs with concise plugin update summary

### DIFF
--- a/src/cli/commands/plugin.ts
+++ b/src/cli/commands/plugin.ts
@@ -145,9 +145,6 @@ async function runSyncAndPrint(options?: { skipAgentFiles?: boolean }): Promise<
  * Run user-scope sync and print results. Returns true if sync succeeded.
  */
 async function runUserSyncAndPrint(): Promise<{ ok: boolean; syncData: ReturnType<typeof buildSyncData> | null }> {
-  if (!isJsonMode()) {
-    console.log('\nSyncing user workspace...\n');
-  }
   const result = await syncUserWorkspace();
 
   if (!result.success && result.error) {

--- a/src/cli/commands/workspace.ts
+++ b/src/cli/commands/workspace.ts
@@ -13,7 +13,7 @@ import { buildDescription, conciseSubcommands } from '../help.js';
 import { initMeta, syncMeta, statusMeta, pruneMeta } from '../metadata/workspace.js';
 import { ClientTypeSchema, InstallModeSchema, type ClientEntry, type ClientType, type InstallMode } from '../../models/workspace-config.js';
 import { repoAddMeta, repoRemoveMeta, repoListMeta } from '../metadata/workspace-repo.js';
-import { formatMcpResult, formatNativeResult, buildSyncData, formatPluginArtifacts, formatSyncSummary } from '../format-sync.js';
+import { formatMcpResult, formatNativeResult, buildSyncData, formatPluginArtifacts, formatSyncSummary, formatSyncHeader } from '../format-sync.js';
 
 
 // =============================================================================
@@ -170,18 +170,12 @@ const syncCmd = command({
 
       // Sync user workspace if config exists
       if (userConfigExists) {
-        if (!isJsonMode()) {
-          console.log('Syncing user workspace...\n');
-        }
         const userResult = await syncUserWorkspace({ offline, dryRun, force });
         combined = userResult;
       }
 
       // Sync project workspace if config exists
       if (projectConfigExists) {
-        if (!isJsonMode()) {
-          console.log('Syncing project workspace...\n');
-        }
         const projectResult = await syncWorkspace(process.cwd(), {
           offline,
           dryRun,
@@ -218,6 +212,12 @@ const syncCmd = command({
         }
         console.log('');
       }
+
+      // Print sync header
+      for (const line of formatSyncHeader(result)) {
+        console.log(line);
+      }
+      console.log('');
 
       // Print plugin results
       for (const pluginResult of result.pluginResults) {

--- a/src/cli/format-sync.ts
+++ b/src/cli/format-sync.ts
@@ -150,6 +150,18 @@ export function formatPluginArtifacts(copyResults: CopyResult[], indent = '  '):
 }
 
 /**
+ * Format the sync header shown before individual plugin results.
+ */
+export function formatSyncHeader(result: SyncResult): string[] {
+  const pluginCount = result.pluginResults.length;
+  const successCount = result.pluginResults.filter((p) => p.success).length;
+  return [
+    `Updating ${pluginCount} plugin(s)...`,
+    `\u2713 Successfully updated ${successCount} marketplace(s)`,
+  ];
+}
+
+/**
  * Format the overall sync summary with per-client artifact counts.
  */
 export function formatSyncSummary(


### PR DESCRIPTION
## Summary

- Remove `Syncing user workspace...` and `Syncing project workspace...` messages from `workspace sync` output
- Add `Updating X plugin(s)...` and `✓ Successfully updated X marketplace(s)` summary header before individual plugin results
- New `formatSyncHeader()` function added to shared `format-sync.ts` module

## Before

```
Syncing user workspace...

Syncing project workspace...

✓ Plugin: superpowers@superpowers-dev
  ...
```

## After

```
Updating 2 plugin(s)...
✓ Successfully updated 2 marketplace(s)

✓ Plugin: superpowers@superpowers-dev
  ...
```

## Test plan

- [x] Run `npx allagents workspace sync` in a workspace with plugins and verify the new header lines appear
- [x] Verify the old "Syncing user/project workspace..." messages are gone
- [x] Run `npx allagents plugin install <plugin>` and verify no "Syncing user workspace..." message appears during post-install sync

Closes #266