### PR TITLE
feat(sync): sync MCP servers to project-scoped .vscode/mcp.json

### DIFF
--- a/src/cli/commands/plugin.ts
+++ b/src/cli/commands/plugin.ts
@@ -114,6 +114,20 @@ async function runSyncAndPrint(options?: { skipAgentFiles?: boolean }): Promise<
       }
     }
 
+    // Print MCP server sync results
+    if (result.mcpResults) {
+      for (const [scope, mcpResult] of Object.entries(result.mcpResults)) {
+        if (!mcpResult) continue;
+        const mcpLines = formatMcpResult(mcpResult, scope);
+        if (mcpLines.length > 0) {
+          console.log('');
+          for (const line of mcpLines) {
+            console.log(line);
+          }
+        }
+      }
+    }
+
     // Print native plugin sync results
     if (result.nativeResult) {
       const nativeLines = formatNativeResult(result.nativeResult);

--- a/src/core/sync.ts
+++ b/src/core/sync.ts
@@ -1896,6 +1896,23 @@ export async function syncWorkspace(
     }
   }
 
+  // Step 5e: Sync MCP server configs to project-scoped .vscode/mcp.json
+  const mcpResults: Record<string, McpMergeResult> = {};
+  if (syncClients.includes('vscode')) {
+    const trackedMcpServers = getPreviouslySyncedMcpServers(previousState, 'vscode');
+    const projectMcpPath = join(workspacePath, '.vscode', 'mcp.json');
+    const vscodeMcp = syncVscodeMcpConfig(validPlugins, {
+      dryRun,
+      force: false,
+      configPath: projectMcpPath,
+      trackedServers: trackedMcpServers,
+    });
+    if (vscodeMcp.warnings.length > 0) {
+      warnings.push(...vscodeMcp.warnings);
+    }
+    mcpResults.vscode = vscodeMcp;
+  }
+
   // Count results
   const { totalCopied, totalFailed, totalSkipped, totalGenerated } = countCopyResults(pluginResults, workspaceFileResults);
   const hasFailures = pluginResults.some((r) => !r.success) || totalFailed > 0;
@@ -1915,7 +1932,14 @@ export async function syncWorkspace(
     await persistSyncState(
       workspacePath, pluginResults, workspaceFileResults, syncClients,
       nativePluginsByClient, nativeResult,
-      vscodeState ? { vscodeState } : undefined,
+      {
+        ...(vscodeState && { vscodeState }),
+        ...(Object.keys(mcpResults).length > 0 && {
+          mcpTrackedServers: Object.fromEntries(
+            Object.entries(mcpResults).map(([scope, r]) => [scope, r.trackedServers]),
+          ),
+        }),
+      },
     );
   }
 
@@ -1930,6 +1954,7 @@ export async function syncWorkspace(
     ...(deletedArtifacts.length > 0 && { deletedArtifacts }),
     ...(warnings.length > 0 && { warnings }),
     ...(messages.length > 0 && { messages }),
+    ...(Object.keys(mcpResults).length > 0 && { mcpResults }),
     ...(nativeResult && { nativeResult }),
   };
 }

--- a/tests/e2e/vscode-project-mcp.test.ts
+++ b/tests/e2e/vscode-project-mcp.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
+import { existsSync, mkdirSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { syncWorkspace } from '../../src/core/sync.js';
+
+describe('vscode project-scoped MCP sync e2e', () => {
+  let testDir: string;
+  let pluginDir: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `allagents-e2e-mcp-${Date.now()}`);
+    pluginDir = join(testDir, 'test-plugin');
+    mkdirSync(join(testDir, '.allagents'), { recursive: true });
+    mkdirSync(pluginDir, { recursive: true });
+
+    // Create a plugin with an MCP server
+    writeFileSync(
+      join(pluginDir, 'plugin.json'),
+      JSON.stringify({ name: 'test-plugin', version: '1.0.0' }),
+    );
+    writeFileSync(
+      join(pluginDir, '.mcp.json'),
+      JSON.stringify({
+        mcpServers: {
+          deepwiki: { type: 'http', url: 'https://mcp.deepwiki.com/mcp' },
+        },
+      }),
+    );
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  test('sync writes MCP servers to project .vscode/mcp.json when vscode client is configured', async () => {
+    writeFileSync(
+      join(testDir, '.allagents', 'workspace.yaml'),
+      `repositories:
+  - path: ../myrepo
+plugins:
+  - ${pluginDir}
+clients:
+  - vscode
+`,
+    );
+
+    const result = await syncWorkspace(testDir);
+
+    expect(result.success).toBe(true);
+
+    // MCP servers should be synced to project-scoped .vscode/mcp.json
+    const mcpConfigPath = join(testDir, '.vscode', 'mcp.json');
+    expect(existsSync(mcpConfigPath)).toBe(true);
+
+    const mcpConfig = JSON.parse(readFileSync(mcpConfigPath, 'utf-8'));
+    expect(mcpConfig.servers).toBeDefined();
+    expect(mcpConfig.servers.deepwiki).toEqual({
+      type: 'http',
+      url: 'https://mcp.deepwiki.com/mcp',
+    });
+
+    // mcpResults should be returned
+    expect(result.mcpResults).toBeDefined();
+    expect(result.mcpResults!.vscode).toBeDefined();
+    expect(result.mcpResults!.vscode!.added).toBe(1);
+    expect(result.mcpResults!.vscode!.addedServers).toContain('deepwiki');
+  });
+
+  test('sync does not write MCP config when vscode client is absent', async () => {
+    writeFileSync(
+      join(testDir, '.allagents', 'workspace.yaml'),
+      `repositories:
+  - path: ../myrepo
+plugins:
+  - ${pluginDir}
+clients:
+  - claude
+`,
+    );
+
+    const result = await syncWorkspace(testDir);
+
+    expect(result.success).toBe(true);
+
+    const mcpConfigPath = join(testDir, '.vscode', 'mcp.json');
+    expect(existsSync(mcpConfigPath)).toBe(false);
+    expect(result.mcpResults).toBeUndefined();
+  });
+
+  test('sync tracks MCP servers in project sync state', async () => {
+    writeFileSync(
+      join(testDir, '.allagents', 'workspace.yaml'),
+      `repositories:
+  - path: ../myrepo
+plugins:
+  - ${pluginDir}
+clients:
+  - vscode
+`,
+    );
+
+    // First sync - adds the server
+    const result1 = await syncWorkspace(testDir);
+    expect(result1.mcpResults?.vscode?.added).toBe(1);
+
+    // Second sync - server already exists, no changes
+    const result2 = await syncWorkspace(testDir);
+    expect(result2.mcpResults?.vscode?.added).toBe(0);
+
+    // Remove plugin and sync again - server should be removed
+    writeFileSync(
+      join(testDir, '.allagents', 'workspace.yaml'),
+      `repositories:
+  - path: ../myrepo
+plugins: []
+clients:
+  - vscode
+`,
+    );
+    const result3 = await syncWorkspace(testDir);
+    expect(result3.mcpResults?.vscode?.removed).toBe(1);
+    expect(result3.mcpResults?.vscode?.removedServers).toContain('deepwiki');
+
+    // Verify the server was removed from the file
+    const mcpConfigPath = join(testDir, '.vscode', 'mcp.json');
+    const mcpConfig = JSON.parse(readFileSync(mcpConfigPath, 'utf-8'));
+    expect(mcpConfig.servers.deepwiki).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #271

## Summary

- Add project-scoped MCP sync in `syncWorkspace()` — when `vscode` is a configured client, plugin MCP servers are written to `<workspace>/.vscode/mcp.json`
- Track MCP servers in project-level sync state for proper add/update/remove lifecycle
- Display MCP sync results in `plugin install` CLI output for project scope

## Changes

- **`src/core/sync.ts`**: Add Step 5e in `syncWorkspace()` to call `syncVscodeMcpConfig()` with project-scoped path; persist MCP tracked servers in project sync state; return `mcpResults`
- **`src/cli/commands/plugin.ts`**: Add MCP result printing to `runSyncAndPrint()` (project scope), matching existing behavior in `runUserSyncAndPrint()`
- **`tests/e2e/vscode-project-mcp.test.ts`**: E2E tests for project-scoped MCP sync (add, skip absent client, tracking lifecycle)

## E2E test

```bash
# Build
bun run build

# Create temp workspace
TMPDIR="/tmp/allagents-e2e-mcp-test"
mkdir -p "$TMPDIR/.allagents" "$TMPDIR/test-plugin"
echo '{"name":"test-plugin","version":"1.0.0"}' > "$TMPDIR/test-plugin/plugin.json"
echo '{"mcpServers":{"deepwiki":{"type":"http","url":"https://mcp.deepwiki.com/mcp"}}}' > "$TMPDIR/test-plugin/.mcp.json"
cat > "$TMPDIR/.allagents/workspace.yaml" << 'YAML'
repositories:
  - path: ../myrepo
plugins:
  - ./test-plugin
clients:
  - vscode
YAML

# Run sync
cd "$TMPDIR" && node <path-to-dist>/index.js workspace sync

# Verify .vscode/mcp.json was created with deepwiki server
cat "$TMPDIR/.vscode/mcp.json"
# Expected: {"servers":{"deepwiki":{"type":"http","url":"https://mcp.deepwiki.com/mcp"}}}

# Verify tracked in sync state
cat "$TMPDIR/.allagents/sync-state.json" | grep -A2 mcpServers
# Expected: "mcpServers":{"vscode":["deepwiki"]}

# Cleanup
rm -rf "$TMPDIR"
```