### PR TITLE
feat(cli): improve plugin install UX

### DIFF
--- a/src/cli/commands/plugin.ts
+++ b/src/cli/commands/plugin.ts
@@ -48,7 +48,7 @@ import {
   pluginUpdateMeta,
 } from '../metadata/plugin.js';
 import { skillsCmd } from './plugin-skills.js';
-import { formatMcpResult, formatNativeResult, buildSyncData, formatPluginArtifacts, formatSyncSummary } from '../format-sync.js';
+import { formatMcpResult, formatNativeResult, buildSyncData, formatPluginArtifacts } from '../format-sync.js';
 import {
   getPluginSource,
   getPluginClients,
@@ -68,7 +68,7 @@ import { load } from 'js-yaml';
  */
 async function runSyncAndPrint(options?: { skipAgentFiles?: boolean }): Promise<{ ok: boolean; syncData: ReturnType<typeof buildSyncData> | null }> {
   if (!isJsonMode()) {
-    console.log('\nSyncing workspace...\n');
+    console.log('\nUpdating workspace...\n');
   }
   const result = await syncWorkspace(process.cwd(), options);
 
@@ -144,11 +144,6 @@ async function runSyncAndPrint(options?: { skipAgentFiles?: boolean }): Promise<
       for (const warning of result.warnings) {
         console.log(`  \u26A0 ${warning}`);
       }
-    }
-
-    console.log('');
-    for (const line of formatSyncSummary(result)) {
-      console.log(line);
     }
   }
 
@@ -228,10 +223,6 @@ async function runUserSyncAndPrint(): Promise<{ ok: boolean; syncData: ReturnTyp
       }
     }
 
-    console.log('');
-    for (const line of formatSyncSummary(result)) {
-      console.log(line);
-    }
   }
 
   return { ok: result.success && result.totalFailed === 0, syncData };
@@ -1069,13 +1060,17 @@ const pluginInstallCmd = command({
         if (result.autoRegistered) {
           console.log(`  Resolved marketplace: ${result.autoRegistered}`);
         }
-        console.log(`\u2713 Installed plugin (${isUser ? 'user' : 'project'} scope): ${displayPlugin}`);
+        console.log(`Installing plugin "${displayPlugin}"...`);
       }
 
       // Single sync pass (enabledSkills already written if --skill was used)
       const { ok: syncOk, syncData } = isUser
         ? await runUserSyncAndPrint()
         : await runSyncAndPrint();
+
+      if (!isJsonMode() && syncOk) {
+        console.log(`\u2714 Successfully installed plugin: ${displayPlugin} (scope: ${isUser ? 'user' : 'project'})`);
+      }
 
       if (isJsonMode()) {
         jsonOutput({


### PR DESCRIPTION
## Summary
- Show `Installing plugin "name"...` before sync (like `claude plugin install`)
- Change "Syncing workspace..." to "Updating workspace..."
- Show `✔ Successfully installed plugin: name (scope: user/project)` on success
- Remove redundant client-grouped summary stats at the bottom

### Before
```
✓ Installed plugin (project scope): deepwiki@allagents

Syncing workspace...

✓ Plugin: deepwiki@allagents
  copilot: 1 skill

  copilot: 1 skill
```

### After
```
Installing plugin "deepwiki@allagents"...

Updating workspace...

✓ Plugin: deepwiki@allagents
  copilot: 1 skill

✔ Successfully installed plugin: deepwiki@allagents (scope: project)
```

## Test plan
- [x] Build and run `./dist/index.js plugin install deepwiki@allagents` in a test workspace
- [x] Verify "Installing plugin" message appears before sync
- [x] Verify "Updating workspace..." replaces "Syncing workspace..."
- [x] Verify success message appears at the end
- [x] Verify no duplicate client stats at the bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)