### PR TITLE
feat(cli): add 'update' alias for 'workspace sync' command

### DIFF
--- a/src/cli/commands/workspace.ts
+++ b/src/cli/commands/workspace.ts
@@ -137,6 +137,7 @@ const initCmd = command({
 
 const syncCmd = command({
   name: 'sync',
+  aliases: ['update'],
   description: buildDescription(syncMeta),
   args: {
     offline: flag({ long: 'offline', description: 'Use cached plugins without fetching latest from remote' }),


### PR DESCRIPTION
## Summary
- Adds `update` as an alias for `workspace sync`, so users can run `allagents workspace update` as a shorthand

## Test plan
- [x] `npx allagents workspace update` works the same as `npx allagents workspace sync`