### PR TITLE
fix(sync): display vscode instead of copilot for MCP server output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,9 +146,11 @@ Shared formatting lives in `src/cli/format-sync.ts`. When adding new sync output
 
 ### VSCode / Copilot Display Alias
 
-`vscode` is a display alias for `copilot`. In CLI output, artifacts for the `vscode` client are always shown as `copilot` and their counts are merged. This is because VS Code's AI features are delivered through GitHub Copilot — they are the same client from the user's perspective.
+`vscode` is a display alias for `copilot` **for artifact counts only** (skills, commands, agents, hooks). Since VS Code and Copilot share skill paths, their counts are merged under the `copilot` label.
 
-Internally, `vscode` and `copilot` remain distinct client types with separate path mappings (see `resolveClientMappings()` in `client-mapping.ts`). The aliasing is purely in the display layer (`format-sync.ts`).
+**MCP output uses the raw client name** — no aliasing. This is because vscode and copilot have independent MCP support (copilot doesn't support MCP yet).
+
+Internally, `vscode` and `copilot` remain distinct client types with separate path mappings (see `resolveClientMappings()` in `client-mapping.ts`).
 
 ## Troubleshooting
 

--- a/src/cli/format-sync.ts
+++ b/src/cli/format-sync.ts
@@ -245,7 +245,9 @@ export function formatMcpResult(
   if (overwritten > 0) parts.push(`${overwritten} updated`);
   if (removed > 0) parts.push(`${removed} removed`);
   if (skipped > 0) parts.push(`${skipped} skipped`);
-  const displayScope = scope ? getDisplayName(scope) : undefined;
+  // MCP scopes use the raw client name (no aliasing) because
+  // vscode and copilot have independent MCP support.
+  const displayScope = scope;
   const label = displayScope ? `MCP servers (${displayScope})` : 'MCP servers';
   lines.push(`${label}: ${parts.join(', ')}`);
 

--- a/src/models/client-mapping.ts
+++ b/src/models/client-mapping.ts
@@ -287,8 +287,8 @@ export function resolveClientMappings(
 
 /**
  * Display name aliases for CLI output.
- * vscode is always displayed as copilot since VS Code's AI features
- * are delivered through GitHub Copilot.
+ * vscode is displayed as copilot for artifact counts since VS Code's AI features
+ * are delivered through GitHub Copilot and they share skill paths.
  */
 export const CLIENT_DISPLAY_ALIASES: Partial<Record<ClientType, string>> = {
   vscode: 'copilot',

--- a/tests/unit/cli/format-sync.test.ts
+++ b/tests/unit/cli/format-sync.test.ts
@@ -69,6 +69,15 @@ describe('formatMcpResult', () => {
 
     expect(lines.some((l) => l.includes('File modified'))).toBe(false);
   });
+
+  test('displays vscode scope as vscode, not copilot', () => {
+    const lines = formatMcpResult(makeResult({
+      added: 1,
+      addedServers: ['deepwiki'],
+    }), 'vscode');
+
+    expect(lines[0]).toBe('MCP servers (vscode): 1 added');
+  });
 });
 
 describe('classifyCopyResults', () => {


### PR DESCRIPTION
## Summary
- MCP server sync output now shows `vscode` instead of `copilot`
- Artifact counts (skills, commands, agents, hooks) still alias vscode→copilot since they share paths
- Copilot doesn't support MCP yet, so the alias was incorrect for MCP output

## Test plan
- [x] Unit tests pass (`bun test`)
- [x] E2E: created temp workspace with vscode client + plugin with `.mcp.json`, ran `workspace sync`, verified output shows `MCP servers (vscode): 1 added`