### PR TITLE
feat(tui): use hint field for plugin and skill metadata

### DIFF
--- a/src/cli/tui/actions/plugins.ts
+++ b/src/cli/tui/actions/plugins.ts
@@ -275,7 +275,7 @@ export async function runPlugins(context: TuiContext, cache?: TuiCache): Promise
   try {
     while (true) {
       // Build options: + Add plugin, Update all, then list installed plugins
-      const options: Array<{ label: string; value: string }> = [
+      const options: Array<{ label: string; value: string; hint?: string }> = [
         { label: '+ Add plugin', value: '__add__' },
       ];
 
@@ -298,15 +298,17 @@ export async function runPlugins(context: TuiContext, cache?: TuiCache): Promise
         for (const plugin of status.plugins) {
           const key = `project:${plugin.source}`;
           options.push({
-            label: `${plugin.source} (${plugin.type}) [project]`,
+            label: plugin.source,
             value: key,
+            hint: `${plugin.type} · project`,
           });
         }
         for (const plugin of status.userPlugins ?? []) {
           const key = `user:${plugin.source}`;
           options.push({
-            label: `${plugin.source} (${plugin.type}) [user]`,
+            label: plugin.source,
             value: key,
+            hint: `${plugin.type} · user`,
           });
         }
       }

--- a/src/cli/tui/actions/skills.ts
+++ b/src/cli/tui/actions/skills.ts
@@ -176,10 +176,11 @@ async function runToggleSkills(
   context: TuiContext,
   cache?: TuiCache,
 ): Promise<void> {
-  // Build multiselect options grouped by plugin
+  // Build multiselect options with metadata in hint
   const options = skills.map((s) => ({
-    label: `${s.name} (${s.pluginName}) [${s.scope}]`,
+    label: s.name,
     value: s.key,
+    hint: `${s.pluginName} · ${s.scope}`,
   }));
 
   // Pre-select enabled skills (not disabled)


### PR DESCRIPTION
## Summary

- Move plugin type/scope metadata from labels to the `hint` field in the Plugins list
- Move skill plugin name/scope metadata to the `hint` field in the skill toggle multiselect
- Names stay prominent, metadata renders dimmed to the right

**Before:**
```
stripe@claude-plugins-official (marketplace) [user]
```

**After:**
```
stripe@claude-plugins-official  (marketplace · user)
                                ↑ dimmed hint text
```

## Test Plan

- [x] `bun test` — 1053 pass, 0 fail
- [x] `bun run build` — succeeds
- [x] E2E: `./dist/index.js` → Plugins → verify plugin names prominent, type/scope rendered as dimmed hint in parentheses (e.g., `stripe@claude-plugins-official (marketplace · user)`)
- [x] E2E: Skills → Toggle installed skills → verify skill names prominent, plugin/scope in hint

Closes #292