### PR TITLE
feat(tui): add search to skills browse and plugin install

### DIFF
--- a/src/cli/tui/actions/plugins.ts
+++ b/src/cli/tui/actions/plugins.ts
@@ -32,7 +32,7 @@ import { getHomeDir } from '../../../constants.js';
 import type { TuiContext } from '../context.js';
 import type { TuiCache } from '../cache.js';
 
-const { select, text, confirm, multiselect } = p;
+const { select, text, confirm, multiselect, autocomplete } = p;
 
 /**
  * Create dependencies for updatePlugin.
@@ -671,9 +671,10 @@ export async function runInstallPlugin(context: TuiContext, cache?: TuiCache): P
 
     allPlugins.push({ label: 'Back', value: '__back__' });
 
-    const selected = await select({
+    const selected = await autocomplete({
       message: 'Select a plugin to install',
       options: allPlugins,
+      placeholder: 'Type to search...',
     });
 
     if (p.isCancel(selected) || selected === '__back__') {

--- a/src/cli/tui/actions/skills.ts
+++ b/src/cli/tui/actions/skills.ts
@@ -25,7 +25,7 @@ import type { TuiContext } from '../context.js';
 import type { TuiCache } from '../cache.js';
 import { installSelectedPlugin, runBrowsePluginSkills } from './plugins.js';
 
-const { multiselect, select } = p;
+const { multiselect, select, autocomplete } = p;
 
 interface ScopedSkill extends SkillInfo {
   scope: 'user' | 'project';
@@ -332,9 +332,10 @@ async function runBrowseMarketplaceSkills(
   }
   options.push({ label: 'Back', value: '__back__' });
 
-  const selected = await select({
+  const selected = await autocomplete({
     message: 'Select a plugin',
     options,
+    placeholder: 'Type to search...',
   });
 
   if (p.isCancel(selected) || selected === '__back__') {


### PR DESCRIPTION
## Summary

- Replace `select` with `autocomplete` for the marketplace skills browse and plugin install screens
- Users can now type to filter 30+ plugin entries instead of scrolling

## Test Plan

- [x] `bun test` — 1053 pass, 0 fail
- [x] `bun run build` — succeeds
- [x] E2E (agent-tui): Skills → Browse marketplace → type "stripe" → filters to 1 match with hint
- [x] E2E (agent-tui): Type "logo" → filters to logo-creator with description and skill count

## E2E Evidence

```
◆  Select a plugin
│
│  Search: stripe█ (1 match)
│  ● stripe@claude-plugins-official - Stripe development plugin for Claude (1 skills: stripe-best-practices)
│  ↑/↓ to select • Enter: confirm • Type: to search
```