### PR TITLE
fix(tui): add search to marketplace browse plugins list

### DIFF
--- a/src/cli/tui/actions/plugins.ts
+++ b/src/cli/tui/actions/plugins.ts
@@ -796,9 +796,10 @@ async function runMarketplaceDetail(
           });
         pluginOptions.push({ label: 'Back', value: '__back__' });
 
-        const selectedPlugin = await select({
+        const selectedPlugin = await autocomplete({
           message: 'Select a plugin to install',
           options: pluginOptions,
+          placeholder: 'Type to search...',
         });
 
         if (p.isCancel(selectedPlugin) || selectedPlugin === '__back__') {


### PR DESCRIPTION
Missed in #296 — the Marketplaces → Browse plugins → Select a plugin screen still used plain `select`. Now uses `autocomplete` with search.