### PR TITLE
style(plugin): add newlines around install progress output

### DIFF
--- a/src/cli/commands/plugin.ts
+++ b/src/cli/commands/plugin.ts
@@ -1043,7 +1043,7 @@ const pluginInstallCmd = command({
         if (result.autoRegistered) {
           console.log(`  Resolved marketplace: ${result.autoRegistered}`);
         }
-        console.log(`Installing plugin "${displayPlugin}"...`);
+        console.log(`Installing plugin "${displayPlugin}"...\n`);
       }
 
       // Single sync pass (enabledSkills already written if --skill was used)
@@ -1052,7 +1052,7 @@ const pluginInstallCmd = command({
         : await runSyncAndPrint();
 
       if (!isJsonMode() && syncOk) {
-        console.log(`\u2714 Successfully installed plugin: ${displayPlugin} (scope: ${isUser ? 'user' : 'project'})`);
+        console.log(`\n\u2714 Successfully installed plugin: ${displayPlugin} (scope: ${isUser ? 'user' : 'project'})`);
       }
 
       if (isJsonMode()) {


### PR DESCRIPTION
## Summary
- Add blank line after "Installing plugin..." message
- Add blank line before "Successfully installed plugin" message

Improves readability of `plugin install` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)