### PR TITLE
feat(plugin): prompt for client selection on user-scope install

### DIFF
--- a/src/cli/commands/plugin.ts
+++ b/src/cli/commands/plugin.ts
@@ -27,6 +27,8 @@ import {
   getInstalledUserPlugins,
   getInstalledProjectPlugins,
   getUserWorkspaceConfig,
+  getUserWorkspaceConfigPath,
+  ensureUserWorkspace,
   addUserEnabledSkill,
   type InstalledPluginInfo,
 } from '../../core/user-workspace.js';
@@ -930,8 +932,21 @@ const pluginInstallCmd = command({
       // Treat as user scope if explicitly requested or if cwd resolves to user config
       const isUser = scope === 'user' || (!scope && isUserConfigPath(process.cwd()));
 
-      // If no workspace.yaml exists for project scope, prompt for clients first
-      if (!isUser) {
+      // If no workspace.yaml exists, prompt for clients first
+      if (isUser) {
+        const userConfigPath = getUserWorkspaceConfigPath();
+        if (!existsSync(userConfigPath)) {
+          const { promptForClients } = await import('../tui/prompt-clients.js');
+          const clients = await promptForClients();
+          if (clients === null) {
+            if (isJsonMode()) {
+              jsonOutput({ success: false, command: 'plugin install', error: 'Cancelled' });
+            }
+            return;
+          }
+          await ensureUserWorkspace(clients);
+        }
+      } else {
         const configPath = join(process.cwd(), CONFIG_DIR, WORKSPACE_CONFIG_FILE);
         if (!existsSync(configPath)) {
           const { promptForClients } = await import('../tui/prompt-clients.js');

--- a/src/core/user-workspace.ts
+++ b/src/core/user-workspace.ts
@@ -73,14 +73,14 @@ export function isUserConfigPath(workspacePath: string): boolean {
  * Ensure user-level workspace.yaml exists with default config.
  * Creates it if missing, does not overwrite existing.
  */
-export async function ensureUserWorkspace(): Promise<void> {
+export async function ensureUserWorkspace(clients?: ClientEntry[]): Promise<void> {
   const configPath = getUserWorkspaceConfigPath();
   if (existsSync(configPath)) return;
 
   const defaultConfig: WorkspaceConfig = {
     repositories: [],
     plugins: [],
-    clients: [...DEFAULT_USER_CLIENTS],
+    clients: clients ? [...clients] : [...DEFAULT_USER_CLIENTS],
   };
 
   await mkdir(getAllagentsDir(), { recursive: true });


### PR DESCRIPTION
## Summary
- When running `plugin install --scope user` with no existing `~/.allagents/workspace.yaml`, the CLI now shows the interactive client selection TUI instead of silently applying default clients
- Mirrors the existing project-scope behavior where users are prompted to choose their AI clients on first install
- `ensureUserWorkspace()` now accepts an optional `clients` parameter; all existing callers are unaffected

## Test plan
- [x] Run `npx allagents plugin install <plugin> --scope user` with no existing `~/.allagents/workspace.yaml` — verify client selection prompt appears
- [x] Cancel the prompt — verify install is aborted
- [x] Select clients and proceed — verify `~/.allagents/workspace.yaml` is created with chosen clients
- [x] Run the same command again — verify no prompt (workspace already exists)
- [x] Run `bun test tests/unit/core/user-workspace.test.ts` — all 21 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)