### PR TITLE
fix(marketplace): show correct scope when registry paths overlap

### DIFF
--- a/src/core/marketplace.ts
+++ b/src/core/marketplace.ts
@@ -1336,6 +1336,13 @@ export async function loadMergedRegistries(
   userRegistryPath: string,
   projectRegistryPath: string,
 ): Promise<MergedRegistriesResult> {
+  // When both paths resolve to the same file (e.g. cwd is the home directory),
+  // there is no separate project registry — return user entries with no overrides.
+  if (resolve(userRegistryPath) === resolve(projectRegistryPath)) {
+    const registry = await loadRegistryFromPath(userRegistryPath);
+    return { registry, overrides: [] };
+  }
+
   const [userRegistry, projectRegistry] = await Promise.all([
     loadRegistryFromPath(userRegistryPath),
     loadRegistryFromPath(projectRegistryPath),
@@ -1398,6 +1405,18 @@ export async function listMarketplacesWithScope(
   userRegistryPath: string,
   projectRegistryPath: string,
 ): Promise<ScopedMarketplaceListResult> {
+  // When both paths resolve to the same file (e.g. cwd is the home directory),
+  // treat all entries as user scope — there is no separate project registry.
+  if (resolve(userRegistryPath) === resolve(projectRegistryPath)) {
+    const registry = await loadRegistryFromPath(userRegistryPath);
+    return {
+      entries: Object.values(registry.marketplaces)
+        .map((entry) => ({ ...entry, scope: 'user' as const }))
+        .sort((a, b) => a.name.localeCompare(b.name)),
+      overrides: [],
+    };
+  }
+
   const [userRegistry, projectRegistry] = await Promise.all([
     loadRegistryFromPath(userRegistryPath),
     loadRegistryFromPath(projectRegistryPath),

--- a/tests/unit/core/marketplace-scope.test.ts
+++ b/tests/unit/core/marketplace-scope.test.ts
@@ -196,6 +196,27 @@ describe('scope-aware registry loading and saving', () => {
       expect(result.overrides).toEqual([]);
     });
 
+    it('returns user entries with no overrides when both paths are the same file', async () => {
+      const sharedPath = join(tmpDir, 'same-registry.json');
+
+      const registry: MarketplaceRegistry = {
+        version: 1,
+        marketplaces: {
+          'my-mp': {
+            name: 'my-mp',
+            source: { type: 'github', location: 'org/repo' },
+            path: '/some/path',
+          },
+        },
+      };
+      writeFileSync(sharedPath, JSON.stringify(registry));
+
+      const result = await loadMergedRegistries(sharedPath, sharedPath);
+
+      expect(result.registry.marketplaces['my-mp']).toBeDefined();
+      expect(result.overrides).toEqual([]);
+    });
+
     it('works when user registry does not exist', async () => {
       const userPath = join(tmpDir, 'nonexistent.json');
       const projectPath = join(tmpDir, 'project-marketplaces.json');
@@ -256,6 +277,29 @@ describe('scope-aware registry loading and saving', () => {
       expect(result.entries[0].scope).toBe('user');
       expect(result.entries[1].name).toBe('beta');
       expect(result.entries[1].scope).toBe('project');
+      expect(result.overrides).toEqual([]);
+    });
+
+    it('treats all entries as user scope when both paths resolve to the same file', async () => {
+      const sharedPath = join(tmpDir, 'same-registry.json');
+
+      const registry: MarketplaceRegistry = {
+        version: 1,
+        marketplaces: {
+          'my-mp': {
+            name: 'my-mp',
+            source: { type: 'github', location: 'org/repo' },
+            path: '/some/path',
+          },
+        },
+      };
+      writeFileSync(sharedPath, JSON.stringify(registry));
+
+      const result = await listMarketplacesWithScope(sharedPath, sharedPath);
+
+      expect(result.entries).toHaveLength(1);
+      expect(result.entries[0].name).toBe('my-mp');
+      expect(result.entries[0].scope).toBe('user');
       expect(result.overrides).toEqual([]);
     });
 


### PR DESCRIPTION
## Summary

- When `cwd` is the home directory, `getRegistryPath()` and `getProjectRegistryPath(cwd)` resolve to the same file (`~/.allagents/marketplaces.json`). `listMarketplacesWithScope` and `loadMergedRegistries` read it twice, causing user-scope marketplaces to appear as project-scope with a spurious override warning.
- Added early-return in both functions to detect path overlap and treat all entries as user scope.

Closes #301

## Test plan

- [x] Added unit test: `listMarketplacesWithScope` with same path for both args returns entries as `user` scope with no overrides
- [x] Added unit test: `loadMergedRegistries` with same path for both args returns entries with no overrides
- [x] All 26 marketplace-scope tests pass
- [x] Build succeeds, pre-commit hooks (lint, typecheck, test) pass

### Manual E2E

```bash
# From the home directory (simulates the user's environment)
cd ~
bun run build
./dist/index.js plugin marketplace add /tmp/test-local-mp
./dist/index.js plugin marketplace list
# Verify: shows (user) scope, no override warning
./dist/index.js plugin marketplace remove test-local-mp
```