### PR TITLE
fix(plugin): deduplicate plugin list when cwd is user home directory

### DIFF
--- a/src/cli/commands/plugin.ts
+++ b/src/cli/commands/plugin.ts
@@ -761,8 +761,11 @@ const pluginListCmd = command({
 
       const userConfigPath = join(getAllagentsDir(), WORKSPACE_CONFIG_FILE);
       const projectConfigPath = join(process.cwd(), CONFIG_DIR, WORKSPACE_CONFIG_FILE);
+      const cwdIsHome = isUserConfigPath(process.cwd());
       await loadConfigClients(userConfigPath, 'user');
-      await loadConfigClients(projectConfigPath, 'project');
+      if (!cwdIsHome) {
+        await loadConfigClients(projectConfigPath, 'project');
+      }
 
       // Get installed marketplace plugins
       const userPlugins = await getInstalledUserPlugins();
@@ -771,7 +774,7 @@ const pluginListCmd = command({
 
       // Load native plugins from sync state
       const userSyncState = await loadSyncState(getAllagentsDir());
-      const projectSyncState = await loadSyncState(process.cwd());
+      const projectSyncState = cwdIsHome ? null : await loadSyncState(process.cwd());
 
       // Build merged map: key = "name:marketplace:scope" for format-independent dedup
       interface MergedPlugin {

--- a/src/core/user-workspace.ts
+++ b/src/core/user-workspace.ts
@@ -836,6 +836,10 @@ export async function getInstalledUserPlugins(): Promise<
 export async function getInstalledProjectPlugins(
   workspacePath: string,
 ): Promise<InstalledPluginInfo[]> {
+  // When cwd is the user's home directory, the project config resolves to the
+  // same file as the user config — skip to avoid listing plugins twice.
+  if (isUserConfigPath(workspacePath)) return [];
+
   const configPath = join(workspacePath, CONFIG_DIR, WORKSPACE_CONFIG_FILE);
   if (!existsSync(configPath)) return [];
 

--- a/tests/unit/core/user-workspace.test.ts
+++ b/tests/unit/core/user-workspace.test.ts
@@ -326,5 +326,25 @@ describe('user-workspace', () => {
       expect(plugins[2].name).toBe('local-plugin');
       expect(plugins[2].marketplace).toBe('');
     });
+
+    test('returns empty when workspace path is home directory', async () => {
+      // Write a config directly to ~/.allagents/workspace.yaml (the user config)
+      const configDir = join(tempHome, '.allagents');
+      await mkdir(configDir, { recursive: true });
+      const { dump: yamlDump } = await import('js-yaml');
+      await writeFile(
+        join(configDir, 'workspace.yaml'),
+        yamlDump({
+          plugins: ['code-review@my-marketplace'],
+          clients: ['claude'],
+        }, { lineWidth: -1 }),
+        'utf-8',
+      );
+
+      // When workspace path is the home directory, project config resolves to
+      // the same file as user config — should return empty to avoid duplicates
+      const plugins = await getInstalledProjectPlugins(tempHome);
+      expect(plugins).toHaveLength(0);
+    });
   });
 });


### PR DESCRIPTION
Closes #315

## Summary

- When `cwd` is the user's home directory, `getInstalledProjectPlugins()` now returns empty since the project config resolves to the same file as the user config (`~/.allagents/workspace.yaml`)
- The `plugin list` command also skips project-scope config clients and sync state loading when paths overlap
- Uses the existing `isUserConfigPath()` guard that was already defined but unused in these paths

## E2E test

```bash
TEMP_HOME=$(mktemp -d)
export HOME="$TEMP_HOME"

mkdir -p "$TEMP_HOME/.allagents"
cat > "$TEMP_HOME/.allagents/workspace.yaml" <<YAML
plugins:
  - test-plugin@test-marketplace
clients:
  - universal
  - copilot
  - vscode
YAML

cd "$TEMP_HOME"
allagents plugin list
# Before: shows test-plugin twice (user + project scope)
# After:  shows test-plugin once (user scope only)

rm -rf "$TEMP_HOME"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)