### PR TITLE
fix(tui): stop spinner before showing error in workspace init

### DIFF
--- a/src/cli/tui/actions/init.ts
+++ b/src/cli/tui/actions/init.ts
@@ -45,11 +45,17 @@ export async function runInit(): Promise<void> {
     const s = p.spinner();
     s.start('Initializing workspace...');
 
-    const options: Parameters<typeof initWorkspace>[1] = {
-      ...(fromSource ? { from: fromSource } : {}),
-      ...(selectedClients && selectedClients.length > 0 ? { clients: selectedClients } : {}),
-    };
-    const result = await initWorkspace(targetPath, options);
+    let result: Awaited<ReturnType<typeof initWorkspace>>;
+    try {
+      const options: Parameters<typeof initWorkspace>[1] = {
+        ...(fromSource ? { from: fromSource } : {}),
+        ...(selectedClients && selectedClients.length > 0 ? { clients: selectedClients } : {}),
+      };
+      result = await initWorkspace(targetPath, options);
+    } catch (error) {
+      s.stop('Failed');
+      throw error;
+    }
 
     s.stop('Workspace initialized');
 


### PR DESCRIPTION
## Summary
- Fixes the TUI freeze when initializing a workspace in a folder that already has one
- The `@clack/prompts` spinner was never stopped when `initWorkspace()` threw an error, leaving a dangling animation that corrupted the TUI display
- Added inner try/catch around `initWorkspace()` to call `s.stop('Failed')` before re-throwing

Closes #313

## Test plan
- [x] Reproduced the bug with `agent-tui` — confirmed dangling `◑ Initializing workspace...` spinner at the bottom of the screen
- [x] Applied fix and verified spinner now shows `◇ Failed` and TUI returns cleanly to the main menu
- [x] All 1072 unit tests pass

### E2E steps
```bash
# Create a workspace
mkdir -p /tmp/test-tui-freeze
bun run build
./dist/index.js workspace init /tmp/test-tui-freeze --client claude

# Launch TUI and try to init in the same folder
./dist/index.js
# Navigate: Workspace → Add workspace → enter /tmp/test-tui-freeze → skip template → confirm clients
# Expected: Error note shown, spinner stopped, TUI responsive
# Before fix: Spinner stuck at bottom, TUI display corrupted

rm -rf /tmp/test-tui-freeze
```