### PR TITLE
feat(tui): show verbose sync output matching headless commands

### DIFF
--- a/src/cli/format-sync.ts
+++ b/src/cli/format-sync.ts
@@ -296,6 +296,70 @@ export function formatNativeResult(nativeResult: NativeSyncResult): string[] {
 }
 
 /**
+ * Format verbose sync result lines suitable for display in both headless and TUI modes.
+ * Includes per-plugin headers, per-client artifact counts, generated/failed breakdowns,
+ * MCP server changes, native plugin results, warnings, and summary totals.
+ */
+export function formatVerboseSyncLines(result: SyncResult): string[] {
+  const lines: string[] = [];
+
+  for (const pluginResult of result.pluginResults) {
+    lines.push(formatPluginHeader(pluginResult));
+
+    if (pluginResult.error) {
+      lines.push(`  Error: ${pluginResult.error}`);
+    }
+
+    lines.push(...formatPluginArtifacts(pluginResult.copyResults));
+
+    const generated = pluginResult.copyResults.filter((r) => r.action === 'generated').length;
+    const failed = pluginResult.copyResults.filter((r) => r.action === 'failed').length;
+
+    if (generated > 0) lines.push(`  Generated: ${generated} files`);
+    if (failed > 0) {
+      lines.push(`  Failed: ${failed} files`);
+      for (const failedResult of pluginResult.copyResults.filter((r) => r.action === 'failed')) {
+        lines.push(`    - ${failedResult.destination}: ${failedResult.error}`);
+      }
+    }
+  }
+
+  if (result.warnings && result.warnings.length > 0) {
+    lines.push('');
+    for (const warning of result.warnings) {
+      lines.push(`  \u26A0 ${warning}`);
+    }
+  }
+
+  if (result.mcpResults) {
+    for (const [scope, mcpResult] of Object.entries(result.mcpResults)) {
+      if (!mcpResult) continue;
+      const mcpLines = formatMcpResult(mcpResult, scope);
+      if (mcpLines.length > 0) {
+        lines.push('');
+        lines.push(...mcpLines);
+      }
+    }
+  }
+
+  if (result.nativeResult) {
+    const nativeLines = formatNativeResult(result.nativeResult);
+    if (nativeLines.length > 0) {
+      lines.push('');
+      lines.push(...nativeLines);
+    }
+  }
+
+  const summaryLines = formatSyncSummary(result);
+  if (summaryLines.length > 0) {
+    lines.push('');
+    lines.push(...summaryLines);
+  }
+
+  return lines;
+}
+
+/**
  * Build a JSON-friendly sync data object from a sync result.
  */
 export function buildSyncData(result: SyncResult) {

--- a/src/cli/tui/actions/init.ts
+++ b/src/cli/tui/actions/init.ts
@@ -1,5 +1,6 @@
 import * as p from '@clack/prompts';
 import { initWorkspace } from '../../../core/workspace.js';
+import { formatVerboseSyncLines } from '../../format-sync.js';
 import type { ClientEntry } from '../../../models/workspace-config.js';
 import { promptForClients } from '../prompt-clients.js';
 
@@ -64,9 +65,8 @@ export async function runInit(): Promise<void> {
       lines.push(`Clients: ${selectedClients.join(', ')}`);
     }
     if (result.syncResult) {
-      lines.push(
-        `Plugins synced: ${result.syncResult.totalCopied} copied, ${result.syncResult.totalFailed} failed`,
-      );
+      lines.push('');
+      lines.push(...formatVerboseSyncLines(result.syncResult));
     }
     p.note(lines.join('\n'), 'Workspace Created');
   } catch (error) {

--- a/src/cli/tui/actions/plugins.ts
+++ b/src/cli/tui/actions/plugins.ts
@@ -12,7 +12,7 @@ import {
   getInstalledProjectPlugins,
   getUserPluginsForMarketplace,
 } from '../../../core/user-workspace.js';
-import { syncWorkspace, syncUserWorkspace } from '../../../core/sync.js';
+import { syncWorkspace, syncUserWorkspace, type SyncResult } from '../../../core/sync.js';
 import {
   listMarketplaces,
   listMarketplacePlugins,
@@ -25,6 +25,7 @@ import {
   type MarketplacePluginsResult,
 } from '../../../core/marketplace.js';
 import { updatePlugin } from '../../../core/plugin.js';
+import { formatVerboseSyncLines } from '../../format-sync.js';
 import { parseMarketplaceManifest } from '../../../utils/marketplace-manifest-parser.js';
 import { getWorkspaceStatus } from '../../../core/status.js';
 import { getAllSkillsFromPlugins, discoverSkillNames } from '../../../core/skills.js';
@@ -113,6 +114,8 @@ export async function installSelectedPlugin(
   const s = p.spinner();
   s.start('Installing plugin...');
 
+  let syncResult: SyncResult;
+
   if (scope === 'project') {
     const workspacePath = context.workspacePath ?? process.cwd();
     const result = await addPlugin(pluginRef, workspacePath);
@@ -122,7 +125,7 @@ export async function installSelectedPlugin(
       return false;
     }
     s.message('Syncing...');
-    await syncWorkspace(workspacePath);
+    syncResult = await syncWorkspace(workspacePath);
     s.stop('Installed and synced');
   } else {
     const result = await addUserPlugin(pluginRef);
@@ -132,12 +135,13 @@ export async function installSelectedPlugin(
       return false;
     }
     s.message('Syncing...');
-    await syncUserWorkspace();
+    syncResult = await syncUserWorkspace();
     s.stop('Installed and synced');
   }
 
   cache?.invalidate();
-  p.note(`Installed: ${pluginRef}`, 'Success');
+  const lines = formatVerboseSyncLines(syncResult);
+  p.note(lines.join('\n'), `Installed: ${pluginRef}`);
   return true;
 }
 

--- a/src/cli/tui/actions/sync.ts
+++ b/src/cli/tui/actions/sync.ts
@@ -1,6 +1,6 @@
 import * as p from '@clack/prompts';
 import { syncUserWorkspace, syncWorkspace } from '../../../core/sync.js';
-import { formatMcpResult, formatNativeResult, formatSyncSummary, formatPluginHeader } from '../../format-sync.js';
+import { formatVerboseSyncLines } from '../../format-sync.js';
 import type { TuiContext } from '../context.js';
 
 /**
@@ -26,14 +26,7 @@ export async function runSync(context: TuiContext): Promise<void> {
         }
         p.note(result.error, 'Sync Error');
       } else {
-        projectLines = result.pluginResults.map(
-          (pr) => formatPluginHeader(pr),
-        );
-        projectLines.push('');
-        projectLines.push(...formatSyncSummary(result));
-        if (result.nativeResult) {
-          projectLines.push(...formatNativeResult(result.nativeResult));
-        }
+        projectLines = formatVerboseSyncLines(result);
         if (context.userPluginCount > 0) {
           s.message('Syncing user plugins...');
         } else {
@@ -60,22 +53,7 @@ export async function runSync(context: TuiContext): Promise<void> {
       if (userResult.error) {
         p.note(userResult.error, 'User Sync Error');
       } else {
-        const lines = userResult.pluginResults.map(
-          (pr) => formatPluginHeader(pr),
-        );
-        lines.push('');
-        lines.push(...formatSyncSummary(userResult));
-        if (userResult.mcpResults) {
-          for (const [scope, mcpResult] of Object.entries(
-            userResult.mcpResults,
-          )) {
-            if (!mcpResult) continue;
-            lines.push(...formatMcpResult(mcpResult, scope));
-          }
-        }
-        if (userResult.nativeResult) {
-          lines.push(...formatNativeResult(userResult.nativeResult));
-        }
+        const lines = formatVerboseSyncLines(userResult);
         p.note(lines.join('\n'), 'User Sync');
       }
     }


### PR DESCRIPTION
## Summary
- Adds `formatVerboseSyncLines()` shared helper in `format-sync.ts` that consolidates verbose sync output formatting
- Updates TUI `workspace sync`, `workspace init`, and `plugin install` to use the shared helper
- TUI now shows: per-client artifact counts, generated/failed file details, MCP server changes, warnings, native plugin results, and summary totals

Closes #307

## Test plan
- [x] Build CLI and run `workspace sync` in TUI — verify artifact counts and MCP details appear
- [x] Build CLI and run `workspace init` in TUI — verify sync details shown in "Workspace Created" note
- [x] Build CLI and run plugin install in TUI — verify sync details shown in success note
- [x] Compare TUI output with headless `workspace sync` output — should match in content
- [x] Run `bun test` — all tests pass (1072 pass, 0 fail)

## E2E Test Results

Tested with `agent-tui` against `deepwiki@allagents` plugin with `claude` client.

**Plugin install (TUI):**
```
✓ Plugin: deepwiki@allagents (scope: project)
  claude: 1 skill

MCP servers (claude): 1 added
  + deepwiki
File modified: /tmp/test-tui-307/.mcp.json
```

**Workspace sync (TUI):**
```
✓ Plugin: deepwiki@allagents (scope: project)
  claude: 1 skill
```

**Workspace init (TUI):**
```
Path: /tmp/test-tui-307-init

✓ Plugin: deepwiki@allagents (scope: project)
  claude: 1 skill

MCP servers (claude): 1 added
  + deepwiki
File modified: /tmp/test-tui-307-init/.mcp.json
```

**Headless baseline (`plugin install`):**
```
✓ Plugin: deepwiki@allagents (scope: project)
  claude: 1 skill

MCP servers (claude): 1 added
  + deepwiki
File modified: /tmp/test-tui-307/.mcp.json
```

TUI output matches headless output in all three commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)