### PR TITLE
chore: add repository and homepage to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,11 @@
   ],
   "author": "",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/EntityProcess/allagents.git"
+  },
+  "homepage": "https://allagents.dev",
   "dependencies": {
     "@clack/prompts": "^1.0.0",
     "chalk": "^5.6.2",


### PR DESCRIPTION
## Summary
- Add `repository` field pointing to github.com/EntityProcess/allagents
- Add `homepage` field pointing to allagents.dev

These fields populate the npm package page with the correct links.