### PR TITLE
feat(sync): add timing instrumentation and deduplicate fetchPlugin across scopes

### DIFF
--- a/src/cli/commands/workspace.ts
+++ b/src/cli/commands/workspace.ts
@@ -168,6 +168,10 @@ const syncCmd = command({
 
       let combined: SyncResult | null = null;
 
+      // Reset fetch cache so both user and project scopes share fetched repos
+      const { resetFetchCache } = await import('../../core/plugin.js');
+      resetFetchCache();
+
       // Sync user workspace if config exists
       if (userConfigExists) {
         const userResult = await syncUserWorkspace({ offline, dryRun, force });
@@ -293,6 +297,22 @@ const syncCmd = command({
         }
       }
 
+      // Print timing breakdown (debug only: ALLAGENTS_DEBUG=timing)
+      if (process.env.ALLAGENTS_DEBUG?.includes('timing') && result.timing) {
+        console.error('');
+        const totalMs = result.timing.totalMs;
+        console.error(`[debug] Sync timing (total: ${formatTimingMs(totalMs)})`);
+        console.error(`[debug] ${'─'.repeat(56)}`);
+        for (const step of result.timing.steps) {
+          const pct = totalMs > 0 ? ((step.durationMs / totalMs) * 100).toFixed(1) : '0.0';
+          const detail = step.detail ? ` [${step.detail}]` : '';
+          const label = step.label.padEnd(40);
+          const duration = formatTimingMs(step.durationMs).padStart(8);
+          console.error(`[debug]   ${label} ${duration}  ${pct.padStart(5)}%${detail}`);
+        }
+        console.error(`[debug] ${'─'.repeat(56)}`);
+      }
+
       if (!result.success || result.totalFailed > 0) {
         process.exit(1);
       }
@@ -309,6 +329,11 @@ const syncCmd = command({
     }
   },
 });
+
+function formatTimingMs(ms: number): string {
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  return `${(ms / 1000).toFixed(2)}s`;
+}
 
 // =============================================================================
 // workspace status

--- a/src/core/git.ts
+++ b/src/core/git.ts
@@ -121,4 +121,3 @@ export async function cleanupTempDir(dir: string): Promise<void> {
 
   await rm(dir, { recursive: true, force: true });
 }
-

--- a/src/core/plugin.ts
+++ b/src/core/plugin.ts
@@ -26,6 +26,8 @@ export interface FetchResult {
   action: 'fetched' | 'updated' | 'skipped';
   cachePath: string;
   error?: string;
+  /** Duration of the git operation in milliseconds */
+  durationMs?: number;
 }
 
 /**
@@ -48,17 +50,26 @@ export interface FetchDeps {
   pull?: typeof pull;
 }
 
-// Coalesces concurrent fetches targeting the same cache directory.
-// When multiple callers request the same repo concurrently (e.g. a direct
-// GitHub URL and a marketplace spec both resolving to the same repo), only
-// the first caller performs the git operation; others await its result.
-const inflight = new Map<string, Promise<FetchResult>>();
+// Deduplicates git operations for the same cache directory within a sync session.
+// Both concurrent and sequential callers targeting the same repo reuse the
+// result of the first git operation. Call `resetFetchCache()` between sync
+// sessions to allow fresh fetches.
+const fetchCache = new Map<string, Promise<FetchResult>>();
+
+/**
+ * Reset the fetch cache between sync sessions.
+ * Call this at the start of a sync to ensure fresh fetches.
+ */
+export function resetFetchCache(): void {
+  fetchCache.clear();
+}
 
 /**
  * Fetch a plugin from GitHub to local cache.
  *
- * Concurrent calls for the same cache path are coalesced into a single git
- * operation to avoid racing pulls/clones on the same directory.
+ * Deduplicates git operations: the first caller for a given cache path
+ * performs the git pull/clone; all subsequent callers (concurrent or
+ * sequential) reuse the same result within the current sync session.
  *
  * @param url - GitHub URL of the plugin
  * @param options - Fetch options (force update)
@@ -98,10 +109,10 @@ export async function fetchPlugin(
   const { owner, repo } = parsed;
   const cachePath = getPluginCachePath(owner, repo, branch);
 
-  // Coalesce concurrent fetches for the same cache path
-  const existing = inflight.get(cachePath);
-  if (existing) {
-    return existing;
+  // Return cached result if this repo was already fetched this session
+  const cached = fetchCache.get(cachePath);
+  if (cached) {
+    return cached;
   }
 
   const promise = doFetchPlugin(
@@ -112,12 +123,8 @@ export async function fetchPlugin(
     branch,
     deps,
   );
-  inflight.set(cachePath, promise);
-  try {
-    return await promise;
-  } finally {
-    inflight.delete(cachePath);
-  }
+  fetchCache.set(cachePath, promise);
+  return promise;
 }
 
 /**
@@ -157,8 +164,10 @@ async function doFetchPlugin(
     // cached version is still usable (e.g. concurrent pulls on the same
     // shallow clone can fail with "not something we can merge").
     try {
+      const pullStart = performance.now();
       await pullFn(cachePath);
-      return { success: true, action: 'updated', cachePath };
+      const pullMs = Math.round(performance.now() - pullStart);
+      return { success: true, action: 'updated', cachePath, durationMs: pullMs };
     } catch {
       return { success: true, action: 'skipped', cachePath };
     }
@@ -170,12 +179,15 @@ async function doFetchPlugin(
     const parentDir = dirname(cachePath);
     await mkdirFn(parentDir, { recursive: true });
 
+    const cloneStart = performance.now();
     await cloneToFn(repoUrl, cachePath, branch);
+    const cloneMs = Math.round(performance.now() - cloneStart);
 
     return {
       success: true,
       action: 'fetched',
       cachePath,
+      durationMs: cloneMs,
     };
   } catch (error) {
     if (error instanceof GitCloneError) {

--- a/src/core/sync.ts
+++ b/src/core/sync.ts
@@ -72,6 +72,7 @@ import { syncCodexMcpServers, syncCodexProjectMcpConfig } from './codex-mcp.js';
 import { syncClaudeMcpConfig, syncClaudeMcpServersViaCli } from './claude-mcp.js';
 import { getCopilotMcpConfigPath } from './copilot-mcp.js';
 import { getNativeClient, mergeNativeSyncResults, type NativeSyncResult } from './native/index.js';
+import { Stopwatch } from '../utils/stopwatch.js';
 
 /**
  * Result of deduplicating clients by skillsPath
@@ -159,6 +160,8 @@ export interface SyncResult {
   mcpResults?: Record<string, McpMergeResult>;
   /** Result of native CLI plugin installations */
   nativeResult?: NativeSyncResult;
+  /** Timing data for sync steps (when available) */
+  timing?: { totalMs: number; steps: Array<{ label: string; durationMs: number; detail?: string }> };
 }
 
 /**
@@ -194,6 +197,22 @@ export function mergeSyncResults(a: SyncResult, b: SyncResult): SyncResult {
     ...(deletedArtifacts.length > 0 && { deletedArtifacts }),
     ...(mcpResults && { mcpResults }),
     ...(nativeResult && { nativeResult }),
+    ...(mergeTiming(a.timing, b.timing)),
+  };
+}
+
+function mergeTiming(
+  a?: SyncResult['timing'],
+  b?: SyncResult['timing'],
+): { timing: NonNullable<SyncResult['timing']> } | Record<string, never> {
+  if (!a && !b) return {};
+  const aSteps = (a?.steps ?? []).map((s) => ({ ...s, label: `user:${s.label}` }));
+  const bSteps = (b?.steps ?? []).map((s) => ({ ...s, label: `project:${s.label}` }));
+  return {
+    timing: {
+      totalMs: (a?.totalMs ?? 0) + (b?.totalMs ?? 0),
+      steps: [...aSteps, ...bSteps],
+    },
   };
 }
 
@@ -1657,6 +1676,7 @@ export async function syncWorkspace(
   await migrateWorkspaceSkillsV1toV2(workspacePath);
 
   const { offline = false, dryRun = false, workspaceSourceBase, skipAgentFiles = false } = options;
+  const sw = new Stopwatch();
   const configDir = join(workspacePath, CONFIG_DIR);
   const configPath = join(configDir, WORKSPACE_CONFIG_FILE);
 
@@ -1717,13 +1737,14 @@ export async function syncWorkspace(
   }
 
   // Step 0: Pre-register unique marketplaces to avoid race conditions during parallel validation
-  await ensureMarketplacesRegistered(filteredPlans.map((plan) => plan.source));
+  await sw.measure('marketplace-registration', () =>
+    ensureMarketplacesRegistered(filteredPlans.map((plan) => plan.source)),
+  );
 
   // Step 1: Validate all plugins before any destructive action
-  const validatedPlugins = await validateAllPlugins(
-    filteredPlans,
-    workspacePath,
-    offline,
+  const validatedPlugins = await sw.measure('plugin-validation', () =>
+    validateAllPlugins(filteredPlans, workspacePath, offline),
+    `${filteredPlans.length} plugin(s)`,
   );
 
   // Step 1b: Validate workspace.source if defined
@@ -1732,6 +1753,7 @@ export async function syncWorkspace(
   let validatedWorkspaceSource: ValidatedPlugin | null = null;
   const workspaceSourceWarnings: string[] = [];
   if (config.workspace?.source) {
+    sw.start('workspace-source-validation');
     const sourceBasePath = workspaceSourceBase ?? workspacePath;
     const wsSourceResult = await validatePlugin(
       config.workspace.source,
@@ -1746,6 +1768,7 @@ export async function syncWorkspace(
         `Workspace source: ${wsSourceResult.error}`,
       );
     }
+    sw.stop('workspace-source-validation');
   }
 
   // Separate valid and failed plugins
@@ -1782,7 +1805,9 @@ export async function syncWorkspace(
 
   // Step 3: Selective purge - only remove files we previously synced (skip in dry-run mode)
   if (!dryRun) {
-    await selectivePurgeWorkspace(workspacePath, previousState, syncClients);
+    await sw.measure('selective-purge', () =>
+      selectivePurgeWorkspace(workspacePath, previousState, syncClients),
+    );
   }
 
   // Step 3b: Two-pass skill name resolution
@@ -1791,7 +1816,9 @@ export async function syncWorkspace(
   const isV1Fallback = config.version === undefined || config.version < 2;
   const disabledSkillsSet = isV1Fallback ? new Set(config.disabledSkills ?? []) : undefined;
   const enabledSkillsSet = isV1Fallback && config.enabledSkills ? new Set(config.enabledSkills) : undefined;
-  const allSkills = await collectAllSkills(validPlugins, disabledSkillsSet, enabledSkillsSet);
+  const allSkills = await sw.measure('skill-collection', () =>
+    collectAllSkills(validPlugins, disabledSkillsSet, enabledSkillsSet),
+  );
 
   // Build per-plugin skill name maps (handles conflicts automatically)
   const pluginSkillMaps = buildPluginSkillNameMaps(allSkills);
@@ -1800,25 +1827,28 @@ export async function syncWorkspace(
   // Pass 2: Copy skills using resolved names
   // Use syncMode from config (defaults to 'symlink')
   const syncMode = config.syncMode ?? 'symlink';
-  const pluginResults = await Promise.all(
-    validPlugins.map(async (validatedPlugin) => {
-      const skillNameMap = pluginSkillMaps.get(validatedPlugin.resolved);
-      const result = await copyValidatedPlugin(
-        validatedPlugin,
-        workspacePath,
-        validatedPlugin.clients,
-        dryRun,
-        skillNameMap,
-        undefined, // clientMappings
-        syncMode,
-      );
-      return { ...result, scope: 'project' as const };
-    }),
+  const pluginResults = await sw.measure('plugin-copy', () =>
+    Promise.all(
+      validPlugins.map(async (validatedPlugin) => {
+        const skillNameMap = pluginSkillMaps.get(validatedPlugin.resolved);
+        const result = await copyValidatedPlugin(
+          validatedPlugin,
+          workspacePath,
+          validatedPlugin.clients,
+          dryRun,
+          skillNameMap,
+          undefined, // clientMappings
+          syncMode,
+        );
+        return { ...result, scope: 'project' as const };
+      }),
+    ),
+    `${validPlugins.length} plugin(s)`,
   );
 
   // Step 4b: Native CLI installations
-  const nativeResult = await syncNativePlugins(
-    validPlugins, previousState, 'project', workspacePath, dryRun, warnings, messages,
+  const nativeResult = await sw.measure('native-plugin-sync', () =>
+    syncNativePlugins(validPlugins, previousState, 'project', workspacePath, dryRun, warnings, messages),
   );
 
   // Step 5: Copy workspace files if configured
@@ -1827,6 +1857,7 @@ export async function syncWorkspace(
   let workspaceFileResults: CopyResult[] = [];
   const skipWorkspaceFiles = !!config.workspace?.source && !validatedWorkspaceSource;
   if (config.workspace && !skipWorkspaceFiles) {
+    sw.start('workspace-files');
     const sourcePath = validatedWorkspaceSource?.resolved;
     const filesToCopy = [...config.workspace.files];
 
@@ -1887,6 +1918,7 @@ export async function syncWorkspace(
         await copyFile(agentsPath, claudePath);
       }
     }
+    sw.stop('workspace-files');
   }
 
   // When repositories are configured but no workspace.source is set,
@@ -1900,7 +1932,9 @@ export async function syncWorkspace(
   // Step 5d: Reconcile and generate VSCode .code-workspace file
   let vscodeState: { hash: string; repos: string[] } | undefined;
   if (syncClients.includes('vscode') && !dryRun) {
-    const result = await syncVscodeWorkspaceFile(workspacePath, config, configPath, previousState, messages);
+    const result = await sw.measure('vscode-workspace-file', () =>
+      syncVscodeWorkspaceFile(workspacePath, config, configPath, previousState, messages),
+    );
     config = result.config;
     if (result.hash && result.repos) {
       vscodeState = { hash: result.hash, repos: result.repos };
@@ -1908,6 +1942,7 @@ export async function syncWorkspace(
   }
 
   // Step 5e: Sync MCP server configs to project-scoped .vscode/mcp.json
+  sw.start('mcp-sync');
   const mcpResults: Record<string, McpMergeResult> = {};
   if (syncClients.includes('vscode')) {
     const trackedMcpServers = getPreviouslySyncedMcpServers(previousState, 'vscode');
@@ -1972,6 +2007,8 @@ export async function syncWorkspace(
     mcpResults.copilot = copilotMcp;
   }
 
+  sw.stop('mcp-sync');
+
   // Warn about clients that don't support project-scoped MCP sync
   const PROJECT_MCP_CLIENTS = new Set(['claude', 'codex', 'vscode', 'copilot', 'universal']);
   const { servers: allMcpServers } = collectMcpServers(validPlugins);
@@ -1999,17 +2036,19 @@ export async function syncWorkspace(
   // Persist sync state (skip in dry-run mode)
   const { pluginsByClient: nativePluginsByClient } = collectNativePluginSources(validPlugins);
   if (!dryRun) {
-    await persistSyncState(
-      workspacePath, pluginResults, workspaceFileResults, syncClients,
-      nativePluginsByClient, nativeResult,
-      {
-        ...(vscodeState && { vscodeState }),
-        ...(Object.keys(mcpResults).length > 0 && {
-          mcpTrackedServers: Object.fromEntries(
-            Object.entries(mcpResults).map(([scope, r]) => [scope, r.trackedServers]),
-          ),
-        }),
-      },
+    await sw.measure('persist-state', () =>
+      persistSyncState(
+        workspacePath, pluginResults, workspaceFileResults, syncClients,
+        nativePluginsByClient, nativeResult,
+        {
+          ...(vscodeState && { vscodeState }),
+          ...(Object.keys(mcpResults).length > 0 && {
+            mcpTrackedServers: Object.fromEntries(
+              Object.entries(mcpResults).map(([scope, r]) => [scope, r.trackedServers]),
+            ),
+          }),
+        },
+      ),
     );
   }
 
@@ -2026,6 +2065,7 @@ export async function syncWorkspace(
     ...(messages.length > 0 && { messages }),
     ...(Object.keys(mcpResults).length > 0 && { mcpResults }),
     ...(nativeResult && { nativeResult }),
+    timing: sw.toJSON(),
   };
 }
 
@@ -2042,6 +2082,7 @@ export async function syncUserWorkspace(
   // MIGRATION: v1→v2 - remove after v3 release
   await migrateUserWorkspaceSkillsV1toV2();
 
+  const sw = new Stopwatch();
   const homeDir = resolve(getHomeDir());
   const config = await getUserWorkspaceConfig();
 
@@ -2066,10 +2107,15 @@ export async function syncUserWorkspace(
   const syncClients = collectSyncClients(workspaceClients, pluginPlans);
 
   // Pre-register unique marketplaces to avoid race conditions during parallel validation
-  await ensureMarketplacesRegistered(pluginPlans.map((plan) => plan.source));
+  await sw.measure('marketplace-registration', () =>
+    ensureMarketplacesRegistered(pluginPlans.map((plan) => plan.source)),
+  );
 
   // Validate all plugins
-  const validatedPlugins = await validateAllPlugins(pluginPlans, homeDir, offline);
+  const validatedPlugins = await sw.measure('plugin-validation', () =>
+    validateAllPlugins(pluginPlans, homeDir, offline),
+    `${pluginPlans.length} plugin(s)`,
+  );
   const failedValidations = validatedPlugins.filter((v) => !v.success);
   const validPlugins = validatedPlugins.filter((v) => v.success);
   const warnings = [
@@ -2091,7 +2137,9 @@ export async function syncUserWorkspace(
 
   // Selective purge
   if (!dryRun) {
-    await selectivePurgeWorkspace(homeDir, previousState, syncClients);
+    await sw.measure('selective-purge', () =>
+      selectivePurgeWorkspace(homeDir, previousState, syncClients),
+    );
   }
 
   // Two-pass skill name resolution (excluding disabled/non-enabled skills)
@@ -2099,25 +2147,31 @@ export async function syncUserWorkspace(
   const isV1FallbackUser = config.version === undefined || config.version < 2;
   const disabledSkillsSet = isV1FallbackUser ? new Set(config.disabledSkills ?? []) : undefined;
   const enabledSkillsSet = isV1FallbackUser && config.enabledSkills ? new Set(config.enabledSkills) : undefined;
-  const allSkills = await collectAllSkills(validPlugins, disabledSkillsSet, enabledSkillsSet);
+  const allSkills = await sw.measure('skill-collection', () =>
+    collectAllSkills(validPlugins, disabledSkillsSet, enabledSkillsSet),
+  );
   const pluginSkillMaps = buildPluginSkillNameMaps(allSkills);
 
   // Copy plugins using USER_CLIENT_MAPPINGS
   // Use syncMode from config (defaults to 'symlink')
   const syncMode = config.syncMode ?? 'symlink';
-  const pluginResults = await Promise.all(
-    validPlugins.map(async (vp) => {
-      const skillNameMap = pluginSkillMaps.get(vp.resolved);
-      const resolvedUserMappings = resolveClientMappings(vp.clients, USER_CLIENT_MAPPINGS);
-      const result = await copyValidatedPlugin(vp, homeDir, vp.clients, dryRun, skillNameMap, resolvedUserMappings, syncMode);
-      return { ...result, scope: 'user' as const };
-    }),
+  const pluginResults = await sw.measure('plugin-copy', () =>
+    Promise.all(
+      validPlugins.map(async (vp) => {
+        const skillNameMap = pluginSkillMaps.get(vp.resolved);
+        const resolvedUserMappings = resolveClientMappings(vp.clients, USER_CLIENT_MAPPINGS);
+        const result = await copyValidatedPlugin(vp, homeDir, vp.clients, dryRun, skillNameMap, resolvedUserMappings, syncMode);
+        return { ...result, scope: 'user' as const };
+      }),
+    ),
+    `${validPlugins.length} plugin(s)`,
   );
 
   // Count results
   const { totalCopied, totalFailed, totalSkipped, totalGenerated } = countCopyResults(pluginResults, []);
 
   // Sync MCP server configs to VS Code if vscode client is configured
+  sw.start('mcp-sync');
   const mcpResults: Record<string, McpMergeResult> = {};
   if (syncClients.includes('vscode')) {
     const trackedMcpServers = getPreviouslySyncedMcpServers(previousState, 'vscode');
@@ -2164,6 +2218,8 @@ export async function syncUserWorkspace(
     mcpResults.copilot = copilotMcp;
   }
 
+  sw.stop('mcp-sync');
+
   // Warn about clients that don't support user-scoped MCP sync
   const USER_MCP_CLIENTS = new Set(['claude', 'codex', 'vscode', 'copilot', 'universal']);
   const { servers: allUserMcpServers } = collectMcpServers(validPlugins);
@@ -2176,8 +2232,8 @@ export async function syncUserWorkspace(
   }
 
   // Run native CLI installations for user scope
-  const nativeResult = await syncNativePlugins(
-    validPlugins, previousState, 'user', homeDir, dryRun, warnings, messages,
+  const nativeResult = await sw.measure('native-plugin-sync', () =>
+    syncNativePlugins(validPlugins, previousState, 'user', homeDir, dryRun, warnings, messages),
   );
 
   // Compute deleted artifacts: compare previous state vs what was just synced
@@ -2190,17 +2246,19 @@ export async function syncUserWorkspace(
   // Save sync state (including MCP servers and native plugins)
   if (!dryRun) {
     const { pluginsByClient: nativePluginsByClient } = collectNativePluginSources(validPlugins);
-    await persistSyncState(
-      homeDir, pluginResults, [], syncClients,
-      nativePluginsByClient, nativeResult,
-      {
-        clientMappings: USER_CLIENT_MAPPINGS,
-        ...(Object.keys(mcpResults).length > 0 && {
-          mcpTrackedServers: Object.fromEntries(
-            Object.entries(mcpResults).map(([scope, r]) => [scope, r.trackedServers]),
-          ),
-        }),
-      },
+    await sw.measure('persist-state', () =>
+      persistSyncState(
+        homeDir, pluginResults, [], syncClients,
+        nativePluginsByClient, nativeResult,
+        {
+          clientMappings: USER_CLIENT_MAPPINGS,
+          ...(Object.keys(mcpResults).length > 0 && {
+            mcpTrackedServers: Object.fromEntries(
+              Object.entries(mcpResults).map(([scope, r]) => [scope, r.trackedServers]),
+            ),
+          }),
+        },
+      ),
     );
   }
 
@@ -2216,5 +2274,6 @@ export async function syncUserWorkspace(
     ...(messages.length > 0 && { messages }),
     ...(Object.keys(mcpResults).length > 0 && { mcpResults }),
     ...(nativeResult && { nativeResult }),
+    timing: sw.toJSON(),
   };
 }

--- a/src/utils/stopwatch.ts
+++ b/src/utils/stopwatch.ts
@@ -1,0 +1,105 @@
+/**
+ * Simple stopwatch utility for measuring elapsed time of sync operations.
+ * Collects timing data for individual steps and produces a summary report.
+ */
+
+export interface TimingEntry {
+  label: string;
+  durationMs: number;
+  detail?: string;
+}
+
+export class Stopwatch {
+  private entries: TimingEntry[] = [];
+  private active: Map<string, number> = new Map();
+  private globalStart: number;
+
+  constructor() {
+    this.globalStart = performance.now();
+  }
+
+  /** Start timing a labeled operation. */
+  start(label: string): void {
+    this.active.set(label, performance.now());
+  }
+
+  /** Stop timing a labeled operation and record the duration. */
+  stop(label: string, detail?: string): number {
+    const startTime = this.active.get(label);
+    if (startTime === undefined) {
+      return 0;
+    }
+    const durationMs = performance.now() - startTime;
+    this.active.delete(label);
+    this.entries.push({ label, durationMs, ...(detail !== undefined && { detail }) });
+    return durationMs;
+  }
+
+  /** Measure an async operation and record the duration. */
+  async measure<T>(label: string, fn: () => Promise<T>, detail?: string): Promise<T> {
+    this.start(label);
+    try {
+      const result = await fn();
+      this.stop(label, detail);
+      return result;
+    } catch (error) {
+      this.stop(label, detail ? `${detail} (failed)` : '(failed)');
+      throw error;
+    }
+  }
+
+  /** Get all recorded timing entries. */
+  getEntries(): TimingEntry[] {
+    return [...this.entries];
+  }
+
+  /** Get total elapsed time since stopwatch creation. */
+  getTotalMs(): number {
+    return performance.now() - this.globalStart;
+  }
+
+  /** Format entries as a human-readable report. */
+  formatReport(): string[] {
+    const lines: string[] = [];
+    const totalMs = this.getTotalMs();
+
+    lines.push(`Sync timing report (total: ${formatMs(totalMs)})`);
+    lines.push('─'.repeat(60));
+
+    for (const entry of this.entries) {
+      const pct = totalMs > 0 ? ((entry.durationMs / totalMs) * 100).toFixed(1) : '0.0';
+      const detail = entry.detail ? ` [${entry.detail}]` : '';
+      lines.push(
+        `  ${padEnd(entry.label, 40)} ${padStart(formatMs(entry.durationMs), 8)}  ${padStart(pct, 5)}%${detail}`,
+      );
+    }
+
+    lines.push('─'.repeat(60));
+    return lines;
+  }
+
+  /** Format entries as structured data (for JSON output). */
+  toJSON(): { totalMs: number; steps: Array<{ label: string; durationMs: number; detail?: string }> } {
+    return {
+      totalMs: Math.round(this.getTotalMs()),
+      steps: this.entries.map((e) => ({
+        label: e.label,
+        durationMs: Math.round(e.durationMs),
+        ...(e.detail && { detail: e.detail }),
+      })),
+    };
+  }
+}
+
+function formatMs(ms: number): string {
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  return `${(ms / 1000).toFixed(2)}s`;
+}
+
+function padEnd(str: string, len: number): string {
+  return str.length >= len ? str : str + ' '.repeat(len - str.length);
+}
+
+function padStart(str: string, len: number): string {
+  return str.length >= len ? str : ' '.repeat(len - str.length) + str;
+}

--- a/tests/unit/core/plugin.test.ts
+++ b/tests/unit/core/plugin.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, mock, beforeEach } from 'bun:test';
-import { fetchPlugin, updatePlugin, type FetchDeps, type UpdatePluginDeps } from '../../../src/core/plugin.js';
+import { fetchPlugin, resetFetchCache, updatePlugin, type FetchDeps, type UpdatePluginDeps } from '../../../src/core/plugin.js';
 import { GitCloneError } from '../../../src/core/git.js';
 
 // Create mock functions for dependency injection
@@ -17,10 +17,11 @@ const deps: FetchDeps = {
 };
 
 beforeEach(() => {
-  existsSyncMock.mockClear();
-  mkdirMock.mockClear();
-  cloneToMock.mockClear();
-  pullMock.mockClear();
+  existsSyncMock.mockReset();
+  mkdirMock.mockReset();
+  cloneToMock.mockReset();
+  pullMock.mockReset();
+  resetFetchCache();
 });
 
 describe('fetchPlugin', () => {


### PR DESCRIPTION
## Summary
- Add debug-only timing instrumentation to sync pipeline (`ALLAGENTS_DEBUG=timing`)
- Add `Stopwatch` utility and `durationMs` to `FetchResult` for per-operation timing
- Deduplicate `fetchPlugin` calls across user and project sync scopes by caching resolved results for the sync session lifetime

## Motivation
Investigating sync latency on Windows revealed that Git Credential Manager spawns .NET processes twice per git network call (~1.8s overhead each). The timing instrumentation makes it straightforward to diagnose where time is spent during sync.

The `fetchCache` change deduplicates `fetchPlugin` git pulls for the same cache path across user/project scopes. In practice this only helps when the same GitHub URL plugin appears in both user and project workspace configs, which is rare since the scopes are meant to be separate. It's a minor defensive improvement, not a meaningful performance win for typical configs.

The larger latency opportunity (~2s) from deduplicating marketplace and fetchPlugin clones of the same remote is tracked in #324.

## Test plan
- [x] All 1072 existing tests pass
- [x] `ALLAGENTS_DEBUG=timing allagents workspace sync` shows timing on stderr
- [x] Normal `allagents workspace sync` shows no timing output
- [x] JSON output unchanged
- [x] Lint and typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)