### PR TITLE
perf(sync): seed fetchCache from marketplace registry paths

### DIFF
--- a/src/core/__tests__/plugin-seed-cache.test.ts
+++ b/src/core/__tests__/plugin-seed-cache.test.ts
@@ -63,11 +63,11 @@ describe('seedFetchCache', () => {
     expect(result.cachePath).toBe(firstPath);
   });
 
-  it('seeds branch-qualified key via full GitHub URL with /tree/branch', async () => {
+  it('seeds branch-qualified key via explicit branch parameter', async () => {
     const marketplacePath = '/home/user/.allagents/plugins/marketplaces/WTG.AI.Prompts';
 
-    // Seed with a URL containing /tree/main (as workspace source URLs do)
-    seedFetchCache('https://github.com/WiseTechGlobal/WTG.AI.Prompts/tree/main', marketplacePath);
+    // Seed with explicit branch (as seedFetchCacheFromMarketplaces does after reading .git/HEAD)
+    seedFetchCache('WiseTechGlobal/WTG.AI.Prompts', marketplacePath, 'main');
 
     // fetchPlugin with explicit branch should hit the seeded cache
     const result = await fetchPlugin('WiseTechGlobal/WTG.AI.Prompts', { branch: 'main' }, {

--- a/src/core/plugin.ts
+++ b/src/core/plugin.ts
@@ -72,13 +72,14 @@ export function resetFetchCache(): void {
  *
  * @param url - GitHub URL or owner/repo shorthand
  * @param path - Local path where the repo already exists
+ * @param branch - Optional branch override (seeds branch-qualified cache key)
  */
-export function seedFetchCache(url: string, path: string): void {
+export function seedFetchCache(url: string, path: string, branch?: string): void {
   const parsed = parseGitHubUrl(url);
   if (!parsed) return;
 
   const { owner, repo } = parsed;
-  const cachePath = getPluginCachePath(owner, repo, parsed.branch);
+  const cachePath = getPluginCachePath(owner, repo, branch ?? parsed.branch);
 
   // Don't overwrite if already populated (e.g. by a prior fetchPlugin call)
   if (fetchCache.has(cachePath)) return;

--- a/src/core/sync.ts
+++ b/src/core/sync.ts
@@ -2092,9 +2092,11 @@ async function seedFetchCacheFromMarketplaces(
 
     // Also seed the branch-qualified key so that callers using an explicit
     // branch (e.g. workspace.source URLs with /tree/main/) get a cache hit.
+    // The marketplace repo content will be pulled fresh during validateAllPlugins
+    // before any caller reads from this path.
     const branch = readGitBranch(entry.path);
     if (branch) {
-      seedFetchCache(`https://github.com/${entry.source.location}/tree/${branch}`, entry.path);
+      seedFetchCache(entry.source.location, entry.path, branch);
     }
   }
 }


### PR DESCRIPTION
## Summary
- After `ensureMarketplacesRegistered`, seed `fetchCache` with marketplace registry paths so `fetchPlugin` skips redundant git pulls for repos the marketplace already has
- Adds `seedFetchCache(url, path)` to `plugin.ts` that normalises URL via `parseGitHubUrl` and inserts a pre-resolved `FetchResult` into the existing `fetchCache`
- Adds `seedFetchCacheFromMarketplaces()` helper in `sync.ts` called after both marketplace registration sites

## Test plan
- [ ] `bun run typecheck` passes
- [ ] `bun test` passes  
- [ ] Manual e2e: `ALLAGENTS_DEBUG=timing allagents sync` shows no duplicate git pull for marketplace repos
- [ ] Verify `workspace-source-validation` timing drops ~2s when marketplace repo matches workspace source

Closes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)