### PR TITLE
fix(marketplace): make `marketplace add` replace existing entries by default

### DIFF
--- a/src/core/marketplace.ts
+++ b/src/core/marketplace.ts
@@ -66,9 +66,9 @@ export interface MarketplaceResult {
   success: boolean;
   marketplace?: MarketplaceEntry;
   error?: string;
-  /** True when addMarketplace returned an already-registered entry (idempotent) */
+  /** @deprecated No longer returned — add always replaces existing entries */
   alreadyRegistered?: boolean;
-  /** True when addMarketplace replaced an existing marketplace with force=true */
+  /** True when addMarketplace replaced an existing marketplace entry */
   replaced?: boolean;
   /** User-level plugins that were removed during marketplace removal cascade */
   removedUserPlugins?: string[];
@@ -266,14 +266,14 @@ export interface MarketplaceScopeOptions {
  * @param source - Marketplace source (URL, path, or name)
  * @param customName - Optional custom name for the marketplace
  * @param branch - Optional branch for GitHub marketplaces
- * @param force - If true, replace existing marketplace with same name instead of erroring
+ * @param _force - Deprecated, marketplace add now always replaces existing entries
  * @param scopeOptions - Optional scope options (user or project)
  */
 export async function addMarketplace(
   source: string,
   customName?: string,
   branch?: string,
-  force?: boolean,
+  _force?: boolean,
   scopeOptions?: MarketplaceScopeOptions,
 ): Promise<MarketplaceResult> {
   const parsed = parseMarketplaceSource(source);
@@ -323,10 +323,7 @@ export async function addMarketplace(
     return parsed.location;
   })();
   const existingBySource = findBySourceLocation(registry, sourceLocation);
-  // Skip idempotency check when force=true to allow overwriting by name
-  if (existingBySource && !force) {
-    return { success: true, marketplace: existingBySource, alreadyRegistered: true };
-  }
+  let alreadyRegistered = !!existingBySource;
 
   let marketplacePath: string;
 
@@ -395,14 +392,9 @@ export async function addMarketplace(
     if (manifestResult.success && manifestResult.data.name) {
       const manifestName = manifestResult.data.name;
       if (manifestName !== name) {
-        // If the manifest name is already registered, return idempotent response (unless forcing)
-        const existing = registry.marketplaces[manifestName];
-        if (existing && !force) {
-          return {
-            success: true,
-            marketplace: existing,
-            alreadyRegistered: true,
-          };
+        // Track if the manifest name is already registered
+        if (registry.marketplaces[manifestName]) {
+          alreadyRegistered = true;
         }
         name = manifestName;
       }
@@ -410,12 +402,8 @@ export async function addMarketplace(
   }
 
   // Check if already registered by name (after manifest parsing to use final name)
-  const wasAlreadyRegistered = !!registry.marketplaces[name];
-  if (wasAlreadyRegistered && !force) {
-    return {
-      success: false,
-      error: `Marketplace '${name}' already exists. Use 'update' to refresh it.`,
-    };
+  if (registry.marketplaces[name]) {
+    alreadyRegistered = true;
   }
 
   // Build location: for GitHub, use owner/repo for default branch, owner/repo/branch for non-default
@@ -447,7 +435,7 @@ export async function addMarketplace(
   return {
     success: true,
     marketplace: entry,
-    ...(wasAlreadyRegistered && force && { replaced: true }),
+    ...(alreadyRegistered && { replaced: true }),
   };
 }
 
@@ -1238,7 +1226,7 @@ async function autoRegisterMarketplace(
         return { success: false, error: result.error || 'Unknown error' };
       }
       const name = result.marketplace?.name ?? parts[1];
-      if (!result.alreadyRegistered) {
+      if (!result.replaced) {
         console.log(`Auto-registered GitHub marketplace: ${source}`);
       }
       registeredSourceCache.set(source, name);

--- a/tests/unit/core/marketplace-add-branch.test.ts
+++ b/tests/unit/core/marketplace-add-branch.test.ts
@@ -27,6 +27,15 @@ mock.module('../../../src/core/git.js', () => ({
     }
   },
   pull: mock(() => Promise.resolve()),
+  repoExists: mock(() => Promise.resolve(true)),
+  refExists: mock(() => Promise.resolve(true)),
+  cloneToTemp: mock((url: string) => {
+    const dest = join(tmpdir(), `mock-clone-${Date.now()}`);
+    mkdirSync(dest, { recursive: true });
+    return Promise.resolve(dest);
+  }),
+  classifyError: (err: Error) => err,
+  cleanupTempDir: mock(() => Promise.resolve()),
 }));
 
 // Mock simple-git for updateMarketplace (it uses simpleGit directly)

--- a/tests/unit/core/marketplace-branch-separation.test.ts
+++ b/tests/unit/core/marketplace-branch-separation.test.ts
@@ -128,7 +128,7 @@ describe('branch separation — each branch is a separate marketplace', () => {
     expect(found).toBeNull();
   });
 
-  it('should be idempotent for the same branch', async () => {
+  it('should replace existing entry for the same branch', async () => {
     // Register feature branch
     const result1 = await addMarketplace(
       'https://github.com/owner/repo/tree/feat/v2',
@@ -136,10 +136,10 @@ describe('branch separation — each branch is a separate marketplace', () => {
     );
     expect(result1.success).toBe(true);
 
-    // Try registering the same branch again with a different name
-    // Should find existing by source location and return it
+    // Re-registering the same branch with a different name replaces the entry
     const result2 = await addMarketplace('owner/repo', 'repo-v2-copy', 'feat/v2');
     expect(result2.success).toBe(true);
-    expect(result2.marketplace?.name).toBe('repo-v2'); // returns existing
+    expect(result2.replaced).toBe(true);
+    expect(result2.marketplace?.name).toBe('repo-v2-copy');
   });
 });

--- a/tests/unit/core/marketplace-dedup.test.ts
+++ b/tests/unit/core/marketplace-dedup.test.ts
@@ -119,8 +119,8 @@ describe('marketplace deduplication', () => {
       expect(results).toHaveLength(2);
       expect(results.every((r) => r.success)).toBe(true);
 
-      // Only the first marketplace is truly new — the second finds
-      // the existing entry via manifest name, so no log is emitted.
+      // The first marketplace is new (logged), the second replaces it
+      // (not logged since replaced=true suppresses the log).
       const autoRegLogs = logMessages.filter((m) =>
         m.includes('Auto-registered'),
       );

--- a/tests/unit/core/marketplace.test.ts
+++ b/tests/unit/core/marketplace.test.ts
@@ -454,22 +454,21 @@ describe('addMarketplace with force parameter', () => {
     expect(result.replaced).toBeUndefined();
   });
 
-  it('should be idempotent when adding same source twice without force', async () => {
+  it('should replace existing marketplace when adding same source twice', async () => {
     const marketplacePath = join(testDir, 'local-marketplace');
 
     // First add should succeed
     const result1 = await addMarketplace(marketplacePath);
     expect(result1.success).toBe(true);
-    expect(result1.alreadyRegistered).toBeUndefined();
+    expect(result1.replaced).toBeUndefined();
 
-    // Second add with same source should return alreadyRegistered=true (idempotent)
+    // Second add with same source should replace and return replaced=true
     const result2 = await addMarketplace(marketplacePath);
     expect(result2.success).toBe(true);
-    expect(result2.alreadyRegistered).toBe(true);
-    expect(result2.replaced).toBeUndefined();
+    expect(result2.replaced).toBe(true);
   });
 
-  it('should replace existing marketplace by name when adding different source with force=true', async () => {
+  it('should replace existing marketplace by name when adding different source', async () => {
     const marketplacePath1 = join(testDir, 'local-marketplace');
     const marketplacePath2 = join(testDir, 'local-marketplace-2');
 
@@ -488,29 +487,23 @@ describe('addMarketplace with force parameter', () => {
     const result1 = await addMarketplace(marketplacePath1);
     expect(result1.success).toBe(true);
 
-    // Second add with different source but same manifest name, without force should be idempotent
+    // Second add with different source but same manifest name replaces by default
     const result2 = await addMarketplace(marketplacePath2);
     expect(result2.success).toBe(true);
-    expect(result2.alreadyRegistered).toBe(true);
-    expect(result2.replaced).toBeUndefined();
-
-    // Third add with force should succeed and return replaced=true
-    const result3 = await addMarketplace(marketplacePath2, undefined, undefined, true);
-    expect(result3.success).toBe(true);
-    expect(result3.replaced).toBe(true);
-    expect(result3.marketplace).not.toBeNull();
+    expect(result2.replaced).toBe(true);
+    expect(result2.marketplace).not.toBeNull();
   });
 
-  it('should keep replaced=undefined when adding new marketplace with force=true', async () => {
+  it('should keep replaced=undefined when adding new marketplace', async () => {
     const marketplacePath = join(testDir, 'local-marketplace');
 
-    // First add with force=true should not have replaced flag
-    const result = await addMarketplace(marketplacePath, undefined, undefined, true);
+    // First add should not have replaced flag
+    const result = await addMarketplace(marketplacePath);
     expect(result.success).toBe(true);
     expect(result.replaced).toBeUndefined();
   });
 
-  it('addMarketplace with force replaces existing marketplace by different source', async () => {
+  it('addMarketplace replaces existing marketplace by different source', async () => {
     const marketplacePath1 = join(testDir, 'local-marketplace');
     const marketplacePath2 = join(testDir, 'local-marketplace-alt');
 
@@ -529,8 +522,8 @@ describe('addMarketplace with force parameter', () => {
     const result1 = await addMarketplace(marketplacePath1);
     expect(result1.success).toBe(true);
 
-    // Action: add same name with different source and force=true
-    const result2 = await addMarketplace(marketplacePath2, undefined, undefined, true);
+    // Action: add same name with different source — replaces by default
+    const result2 = await addMarketplace(marketplacePath2);
 
     // Assert: second add succeeds with replaced=true
     expect(result2.success).toBe(true);
@@ -544,7 +537,7 @@ describe('addMarketplace with force parameter', () => {
     expect(registry.marketplaces['test-marketplace'].path).toBe(marketplacePath2);
   });
 
-  it('addMarketplace is idempotent for same manifest name from different sources', async () => {
+  it('addMarketplace replaces when adding same manifest name from different sources', async () => {
     const marketplacePath1 = join(testDir, 'local-marketplace');
     const marketplacePath2 = join(testDir, 'local-marketplace-diff');
 
@@ -562,34 +555,11 @@ describe('addMarketplace with force parameter', () => {
     // Setup: add initial marketplace
     await addMarketplace(marketplacePath1);
 
-    // Action: try to add different source with same name, without force
-    const result = await addMarketplace(marketplacePath2, undefined, undefined, false);
+    // Action: add different source with same name — replaces by default
+    const result = await addMarketplace(marketplacePath2);
 
-    // Assert: returns idempotent success (same manifest name already registered)
+    // Assert: replaces the existing entry
     expect(result.success).toBe(true);
-    expect(result.alreadyRegistered).toBe(true);
-    expect(result.replaced).toBeUndefined();
-  });
-
-  it('addMarketplace with force on first add returns replaced=undefined', async () => {
-    const marketplacePath = join(testDir, 'local-marketplace');
-    const result = await addMarketplace(marketplacePath, undefined, undefined, true);
-
-    expect(result.success).toBe(true);
-    expect(result.replaced).toBeUndefined();
-  });
-
-  it('addMarketplace is idempotent when adding same source twice without force', async () => {
-    const marketplacePath = join(testDir, 'local-marketplace');
-
-    // First add
-    const result1 = await addMarketplace(marketplacePath);
-    expect(result1.success).toBe(true);
-
-    // Second add with same source
-    const result2 = await addMarketplace(marketplacePath);
-    expect(result2.success).toBe(true);
-    expect(result2.alreadyRegistered).toBe(true);
-    expect(result2.replaced).toBeUndefined();
+    expect(result.replaced).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Remove idempotency guards in `addMarketplace()` that prevented re-registering an existing marketplace
- `marketplace add` now always replaces existing entries by default, matching user intent
- Fix pre-existing broken mock in `marketplace-add-branch.test.ts` (missing `repoExists`, `refExists`, `cloneToTemp`, `classifyError`, `cleanupTempDir` exports)

Closes #333

## E2E test
```bash
# Setup
mkdir -p /tmp/e2e-333/test-mp/.claude-plugin
echo '{"name":"test-mp","description":"Test","plugins":[]}' > /tmp/e2e-333/test-mp/.claude-plugin/marketplace.json
mkdir -p /tmp/e2e-333/workspace
echo 'clients: [claude]' > /tmp/e2e-333/workspace/workspace.yaml

# First add
cd /tmp/e2e-333/workspace
allagents plugin marketplace add /tmp/e2e-333/test-mp
# ✓ Marketplace 'test-mp' added

# Second add — should replace, not error
allagents plugin marketplace add /tmp/e2e-333/test-mp
# Marketplace 'test-mp' already exists. Replacing with new source.
# ✓ Marketplace 'test-mp' added

rm -rf /tmp/e2e-333
```