### PR TITLE
feat: auto-create .allagents/.gitignore to exclude sync-state.json

### DIFF
--- a/src/core/config-gitignore.ts
+++ b/src/core/config-gitignore.ts
@@ -1,0 +1,28 @@
+import { writeFile, readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { CONFIG_DIR, SYNC_STATE_FILE } from '../constants.js';
+
+const GITIGNORE_ENTRIES = [SYNC_STATE_FILE];
+
+/**
+ * Ensure .allagents/.gitignore exists and contains entries for machine-local files.
+ * Idempotent — safe to call on every sync.
+ */
+export async function ensureConfigGitignore(workspacePath: string): Promise<void> {
+  const gitignorePath = join(workspacePath, CONFIG_DIR, '.gitignore');
+
+  let existing = '';
+  if (existsSync(gitignorePath)) {
+    existing = await readFile(gitignorePath, 'utf-8');
+  }
+
+  const missing = GITIGNORE_ENTRIES.filter((entry) => !existing.split('\n').includes(entry));
+  if (missing.length === 0) return;
+
+  const content = existing
+    ? `${existing.trimEnd()}\n${missing.join('\n')}\n`
+    : `${missing.join('\n')}\n`;
+
+  await writeFile(gitignorePath, content, 'utf-8');
+}

--- a/src/core/sync-state.ts
+++ b/src/core/sync-state.ts
@@ -4,6 +4,7 @@ import { join, dirname } from 'node:path';
 import { CONFIG_DIR, SYNC_STATE_FILE } from '../constants.js';
 import { SyncStateSchema, type SyncState } from '../models/sync-state.js';
 import type { ClientType } from '../models/workspace-config.js';
+import { ensureConfigGitignore } from './config-gitignore.js';
 
 /** MCP scope identifier (e.g., "vscode" for user-level mcp.json) */
 export type McpScope = 'vscode' | 'codex' | 'claude' | 'copilot';
@@ -85,6 +86,7 @@ export async function saveSyncState(
   };
 
   await mkdir(dirname(statePath), { recursive: true });
+  await ensureConfigGitignore(workspacePath);
   await writeFile(statePath, JSON.stringify(state, null, 2), 'utf-8');
 }
 

--- a/src/core/workspace.ts
+++ b/src/core/workspace.ts
@@ -11,6 +11,7 @@ import { isGitHubUrl, parseGitHubUrl, getPluginCachePath } from '../utils/plugin
 import { fetchWorkspaceFromGitHub, readFileFromClone } from './github-fetch.js';
 import { cleanupTempDir } from './git.js';
 import { getMarketplacesDir } from './marketplace.js';
+import { ensureConfigGitignore } from './config-gitignore.js';
 
 /**
  * Options for workspace initialization
@@ -80,6 +81,7 @@ export async function initWorkspace(
 
     // Create .allagents directory
     await mkdir(configDir, { recursive: true });
+    await ensureConfigGitignore(absoluteTarget);
 
     // Determine workspace.yaml source and track source directory for relative path resolution
     let workspaceYamlContent: string;

--- a/tests/unit/core/config-gitignore.test.ts
+++ b/tests/unit/core/config-gitignore.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtemp, rm, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { ensureConfigGitignore } from '../../../src/core/config-gitignore.js';
+
+describe('ensureConfigGitignore', () => {
+  let workspacePath: string;
+
+  beforeEach(async () => {
+    workspacePath = await mkdtemp(join(tmpdir(), 'allagents-gitignore-'));
+    await mkdir(join(workspacePath, '.allagents'), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(workspacePath, { recursive: true, force: true });
+  });
+
+  it('creates .gitignore with sync-state.json when none exists', async () => {
+    await ensureConfigGitignore(workspacePath);
+
+    const content = await readFile(join(workspacePath, '.allagents', '.gitignore'), 'utf-8');
+    expect(content).toBe('sync-state.json\n');
+  });
+
+  it('is idempotent — does not duplicate entries', async () => {
+    await ensureConfigGitignore(workspacePath);
+    await ensureConfigGitignore(workspacePath);
+
+    const content = await readFile(join(workspacePath, '.allagents', '.gitignore'), 'utf-8');
+    expect(content).toBe('sync-state.json\n');
+  });
+
+  it('preserves existing user entries and appends missing ones', async () => {
+    const gitignorePath = join(workspacePath, '.allagents', '.gitignore');
+    await writeFile(gitignorePath, 'my-custom-file.txt\n', 'utf-8');
+
+    await ensureConfigGitignore(workspacePath);
+
+    const content = await readFile(gitignorePath, 'utf-8');
+    expect(content).toBe('my-custom-file.txt\nsync-state.json\n');
+  });
+
+  it('does not append when entry already present in user-managed file', async () => {
+    const gitignorePath = join(workspacePath, '.allagents', '.gitignore');
+    await writeFile(gitignorePath, 'sync-state.json\nother-stuff\n', 'utf-8');
+
+    await ensureConfigGitignore(workspacePath);
+
+    const content = await readFile(gitignorePath, 'utf-8');
+    expect(content).toBe('sync-state.json\nother-stuff\n');
+  });
+});


### PR DESCRIPTION
## Summary

- Auto-creates `.allagents/.gitignore` containing `sync-state.json` on workspace init and on every sync state save
- Idempotent — safe to call repeatedly, preserves existing user entries in `.gitignore`
- `sync-state.json` contains machine-local filesystem paths and should never be committed

Related: #335 (lock file proposal for reproducible remote plugin syncs)

## Test plan

- [x] Unit tests: creation, idempotency, preserving existing entries, skipping when already present (4 tests)
- [x] Full test suite passes (1082 tests)
- [x] E2E: `workspace init` creates `.allagents/.gitignore` with `sync-state.json`
- [x] Pre-push hooks pass (lint, typecheck, test)

### E2E steps to reproduce

```bash
cd /tmp && mkdir gitignore-test && cd gitignore-test
git init
allagents workspace init
cat .allagents/.gitignore
# Expected: sync-state.json
```