### PR TITLE
fix: normalize double slashes in skills index paths

### DIFF
--- a/src/core/repo-skills.ts
+++ b/src/core/repo-skills.ts
@@ -137,7 +137,8 @@ export async function discoverWorkspaceSkills(
     const repoSkills = await discoverRepoSkills(repoAbsPath, discoverOpts);
     for (const skill of repoSkills) {
       // Use forward slashes for consistent cross-platform paths
-      const location = `${repo.path}/${skill.relativePath}`.replace(/\\/g, '/');
+      const base = repo.path.replace(/[/\\]+$/, '');
+      const location = `${base}/${skill.relativePath}`.replace(/\\/g, '/');
       const candidate = {
         repoPath: repo.path,
         name: skill.name,

--- a/tests/unit/core/repo-skills.test.ts
+++ b/tests/unit/core/repo-skills.test.ts
@@ -159,4 +159,18 @@ describe('discoverWorkspaceSkills opt-in', () => {
     expect(results).toHaveLength(1);
     expect(results[0].name).toBe('some-skill');
   });
+
+  it('does not produce double slashes when repo path has trailing slash', async () => {
+    const repoDir = join(tmpDir, 'my-repo');
+    makeSkill(join(repoDir, '.claude', 'skills'), 'some-skill', 'A skill');
+
+    const results = await discoverWorkspaceSkills(
+      tmpDir,
+      [{ path: './my-repo/', skills: true }],
+      ['claude'],
+    );
+
+    expect(results).toHaveLength(1);
+    expect(results[0].location).not.toContain('//');
+  });
 });


### PR DESCRIPTION
## Summary
- Fix double forward slashes in skill `<location>` paths when `repo.path` in `workspace.yaml` has a trailing slash (e.g., `../WiseTechAcademy.Evals/`)
- Root cause: simple string concatenation `${repo.path}/${skill.relativePath}` without normalizing consecutive slashes
- Added `.replace(/\/\/+/g, '/')` after the existing backslash normalization

Closes #349

## E2E test steps

```bash
# Build CLI
bun run build

# Create workspace with trailing-slash repo path
mkdir -p /tmp/e2e-test/.allagents /tmp/e2e-test/my-repo/.claude/skills/test-skill
cat > /tmp/e2e-test/my-repo/.claude/skills/test-skill/SKILL.md <<'SKILL'
---
name: test-skill
description: A test skill.
---
Content.
SKILL

cat > /tmp/e2e-test/.allagents/workspace.yaml <<'YAML'
repositories:
  - path: ./my-repo/
    skills: true
clients:
  - claude
version: 2
YAML

# Init git repos and run sync
cd /tmp/e2e-test/my-repo && git init && git add -A && git commit -m "init"
cd /tmp/e2e-test && git init && git add -A && git commit -m "init"
./dist/index.js workspace sync

# Verify skill locations have no double slashes
cat .allagents/skills-index/*.md
# Should show: <location>./my-repo/.claude/skills/test-skill/SKILL.md</location>
# NOT: <location>./my-repo//.claude/skills/test-skill/SKILL.md</location>
```