### PR TITLE
feat(docs): add custom 404 page with navigation links

### DIFF
--- a/docs/.astro/content-modules.mjs
+++ b/docs/.astro/content-modules.mjs
@@ -1,13 +1,14 @@
 
 export default new Map([
 ["src/content/docs/index.mdx", () => import("astro:content-layer-deferred-module?astro%3Acontent-layer-deferred-module=&fileName=src%2Fcontent%2Fdocs%2Findex.mdx&astroContentModuleFlag=true")],
-["src/content/docs/reference/configuration.mdx", () => import("astro:content-layer-deferred-module?astro%3Acontent-layer-deferred-module=&fileName=src%2Fcontent%2Fdocs%2Freference%2Fconfiguration.mdx&astroContentModuleFlag=true")],
-["src/content/docs/guides/plugins.mdx", () => import("astro:content-layer-deferred-module?astro%3Acontent-layer-deferred-module=&fileName=src%2Fcontent%2Fdocs%2Fguides%2Fplugins.mdx&astroContentModuleFlag=true")],
-["src/content/docs/guides/workspaces.mdx", () => import("astro:content-layer-deferred-module?astro%3Acontent-layer-deferred-module=&fileName=src%2Fcontent%2Fdocs%2Fguides%2Fworkspaces.mdx&astroContentModuleFlag=true")],
-["src/content/docs/getting-started/quick-start.mdx", () => import("astro:content-layer-deferred-module?astro%3Acontent-layer-deferred-module=&fileName=src%2Fcontent%2Fdocs%2Fgetting-started%2Fquick-start.mdx&astroContentModuleFlag=true")],
 ["src/content/docs/getting-started/installation.mdx", () => import("astro:content-layer-deferred-module?astro%3Acontent-layer-deferred-module=&fileName=src%2Fcontent%2Fdocs%2Fgetting-started%2Finstallation.mdx&astroContentModuleFlag=true")],
+["src/content/docs/getting-started/quick-start.mdx", () => import("astro:content-layer-deferred-module?astro%3Acontent-layer-deferred-module=&fileName=src%2Fcontent%2Fdocs%2Fgetting-started%2Fquick-start.mdx&astroContentModuleFlag=true")],
 ["src/content/docs/guides/marketplaces.mdx", () => import("astro:content-layer-deferred-module?astro%3Acontent-layer-deferred-module=&fileName=src%2Fcontent%2Fdocs%2Fguides%2Fmarketplaces.mdx&astroContentModuleFlag=true")],
-["src/content/docs/getting-started/introduction.mdx", () => import("astro:content-layer-deferred-module?astro%3Acontent-layer-deferred-module=&fileName=src%2Fcontent%2Fdocs%2Fgetting-started%2Fintroduction.mdx&astroContentModuleFlag=true")],
+["src/content/docs/docs.mdx", () => import("astro:content-layer-deferred-module?astro%3Acontent-layer-deferred-module=&fileName=src%2Fcontent%2Fdocs%2Fdocs.mdx&astroContentModuleFlag=true")],
+["src/content/docs/guides/agent-portability.mdx", () => import("astro:content-layer-deferred-module?astro%3Acontent-layer-deferred-module=&fileName=src%2Fcontent%2Fdocs%2Fguides%2Fagent-portability.mdx&astroContentModuleFlag=true")],
+["src/content/docs/guides/workspaces.mdx", () => import("astro:content-layer-deferred-module?astro%3Acontent-layer-deferred-module=&fileName=src%2Fcontent%2Fdocs%2Fguides%2Fworkspaces.mdx&astroContentModuleFlag=true")],
+["src/content/docs/guides/plugins.mdx", () => import("astro:content-layer-deferred-module?astro%3Acontent-layer-deferred-module=&fileName=src%2Fcontent%2Fdocs%2Fguides%2Fplugins.mdx&astroContentModuleFlag=true")],
+["src/content/docs/reference/clients.mdx", () => import("astro:content-layer-deferred-module?astro%3Acontent-layer-deferred-module=&fileName=src%2Fcontent%2Fdocs%2Freference%2Fclients.mdx&astroContentModuleFlag=true")],
 ["src/content/docs/reference/cli.mdx", () => import("astro:content-layer-deferred-module?astro%3Acontent-layer-deferred-module=&fileName=src%2Fcontent%2Fdocs%2Freference%2Fcli.mdx&astroContentModuleFlag=true")],
-["src/content/docs/reference/clients.mdx", () => import("astro:content-layer-deferred-module?astro%3Acontent-layer-deferred-module=&fileName=src%2Fcontent%2Fdocs%2Freference%2Fclients.mdx&astroContentModuleFlag=true")]]);
+["src/content/docs/reference/configuration.mdx", () => import("astro:content-layer-deferred-module?astro%3Acontent-layer-deferred-module=&fileName=src%2Fcontent%2Fdocs%2Freference%2Fconfiguration.mdx&astroContentModuleFlag=true")]]);
 		

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -12,6 +12,7 @@ export default defineConfig({
   integrations: [
     starlight({
       title: 'AllAgents',
+      disable404Route: true,
       description: 'CLI tool for managing AI coding assistant plugins across multiple clients.',
       favicon: '/favicon.svg',
       customCss: ['./src/styles/custom.css'],

--- a/docs/src/pages/404.astro
+++ b/docs/src/pages/404.astro
@@ -1,0 +1,116 @@
+---
+/**
+ * Custom 404 page for the AllAgents docs site.
+ * Self-contained with inline styles matching the site's dark theme.
+ */
+---
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>404 - Page Not Found | AllAgents</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+          'Helvetica Neue', Arial, sans-serif;
+        background-color: #0f1117;
+        color: #e2e8f0;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .card {
+        border: 1px solid rgba(255, 255, 255, 0.12);
+        border-radius: 12px;
+        padding: 3rem 4rem;
+        text-align: center;
+        max-width: 480px;
+        width: 100%;
+        margin: 1rem;
+        background-color: rgba(255, 255, 255, 0.03);
+      }
+
+      .wordmark {
+        font-size: 1.5rem;
+        font-weight: 700;
+        color: #f8fafc;
+        margin-bottom: 2rem;
+        letter-spacing: -0.02em;
+      }
+
+      .error-code {
+        font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono',
+          'Courier New', monospace;
+        font-size: 1.125rem;
+        font-weight: 500;
+        color: #94a3b8;
+        letter-spacing: 0.15em;
+        text-transform: uppercase;
+        margin-bottom: 2.5rem;
+      }
+
+      .nav-links {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 0;
+      }
+
+      .nav-links a {
+        color: #94a3b8;
+        text-decoration: none;
+        font-size: 0.875rem;
+        font-weight: 500;
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+        padding: 0.5rem 1.25rem;
+        transition: color 0.15s ease;
+      }
+
+      .nav-links a:hover {
+        color: rgb(199, 210, 254);
+      }
+
+      .nav-links .separator {
+        width: 1px;
+        height: 1rem;
+        background-color: rgba(255, 255, 255, 0.12);
+        flex-shrink: 0;
+      }
+
+      @media (max-width: 480px) {
+        .card {
+          padding: 2rem 1.5rem;
+        }
+
+        .nav-links a {
+          padding: 0.5rem 0.75rem;
+          font-size: 0.8rem;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="card">
+      <div class="wordmark">AllAgents</div>
+      <div class="error-code">404 - Page Not Found</div>
+      <nav class="nav-links">
+        <a href="/">Home</a>
+        <div class="separator"></div>
+        <a href="/docs/">Docs</a>
+        <div class="separator"></div>
+        <a href="https://github.com/EntityProcess/allagents" target="_blank" rel="noopener noreferrer">GitHub</a>
+      </nav>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Adds a custom 404 page at `docs/src/pages/404.astro` matching the site's dark theme
- Centered card with AllAgents wordmark, monospace "404 - PAGE NOT FOUND" text, and navigation links (HOME | DOCS | GITHUB)
- Self-contained styles using the site's existing color palette (#0f1117 background, slate grays, indigo accent)

## Test plan
- [x] `bun run docs:build` succeeds (13 pages built including 404.html)
- [ ] Visit a non-existent URL on the deployed site to verify the 404 page renders correctly
- [ ] Verify navigation links work: Home (/), Docs (/docs/), GitHub (repo URL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)