### PR TITLE
Add built-in HTTP MCP proxy for proxied servers

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "allagents",
       "dependencies": {
         "@clack/prompts": "^1.0.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "chalk": "^5.6.2",
         "cmd-ts": "^0.14.3",
         "execa": "^8.0.1",
@@ -52,6 +53,8 @@
 
     "@clack/prompts": ["@clack/prompts@1.0.0", "", { "dependencies": { "@clack/core": "1.0.0", "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-rWPXg9UaCFqErJVQ+MecOaWsozjaxol4yjnmYcGNipAWzdaWa2x+VJmKfGq7L0APwBohQOYdHC+9RO4qRXej+A=="],
 
+    "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
+
     "@isaacs/balanced-match": ["@isaacs/balanced-match@4.0.1", "", {}, "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ=="],
 
     "@isaacs/brace-expansion": ["@isaacs/brace-expansion@5.0.0", "", { "dependencies": { "@isaacs/balanced-match": "^4.0.1" } }, "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA=="],
@@ -61,6 +64,8 @@
     "@kwsites/file-exists": ["@kwsites/file-exists@1.1.1", "", { "dependencies": { "debug": "^4.1.1" } }, "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw=="],
 
     "@kwsites/promise-deferred": ["@kwsites/promise-deferred@1.1.1", "", {}, "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -78,6 +83,12 @@
 
     "@types/node": ["@types/node@20.19.30", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g=="],
 
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
     "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
@@ -88,11 +99,17 @@
 
     "axios-proxy-builder": ["axios-proxy-builder@0.1.2", "", { "dependencies": { "tunnel": "^0.0.6" } }, "sha512-6uBVsBZzkB3tCC8iyx59mCjQckhB8+GQrI9Cop8eC7ybIsvs/KtnNgEBfRMSEa7GqK2VBGUzgjNYMdPIfotyPA=="],
 
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
     "bun-types": ["bun-types@1.3.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-OlFwHcnNV99r//9v5IIOgQ9Uk37gZqrNMCcqEaExdkVq3Avwqok1bJFmvGMCkCE0FqzdY8VMOZpfpR3lwI+CsQ=="],
 
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
     "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
@@ -104,6 +121,16 @@
 
     "console.table": ["console.table@0.10.0", "", { "dependencies": { "easy-table": "1.1.0" } }, "sha512-dPyZofqggxuvSf7WXvNjuRfnsOk1YazkVP8FdxH4tcH2c37wc79/Yl6Bhr7Lsu00KMgy2ql/qCMuNu8xctZM8g=="],
 
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
@@ -112,6 +139,8 @@
 
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
 
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "didyoumean": ["didyoumean@1.2.2", "", {}, "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="],
@@ -119,6 +148,10 @@
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
     "easy-table": ["easy-table@1.1.0", "", { "optionalDependencies": { "wcwidth": ">=1.0.1" } }, "sha512-oq33hWOSSnl2Hoh00tZWaIPi1ievrD9aFG82/IgjlycAnW9hHx5PkJiXpxPsgEE+H7BsbVQXFVFST8TEXS6/pA=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
     "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
@@ -130,21 +163,43 @@
 
     "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
 
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
     "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.0.8", "", {}, "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="],
 
     "execa": ["execa@8.0.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^8.0.1", "human-signals": "^5.0.0", "is-stream": "^3.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^5.1.0", "onetime": "^6.0.0", "signal-exit": "^4.1.0", "strip-final-newline": "^3.0.0" } }, "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg=="],
 
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.4.0", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-gDK8yiqKxrGta+3WtON59arrrw6GLmadA1qoFgYXzdcch8fmKDID2XqO8itsi3f1wufXYPT51387dN6cvVBS3Q=="],
+
     "extend-shallow": ["extend-shallow@2.0.1", "", { "dependencies": { "is-extendable": "^0.1.0" } }, "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug=="],
 
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
+
+    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
 
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
     "follow-redirects": ["follow-redirects@1.15.11", "", {}, "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ=="],
 
     "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -168,9 +223,21 @@
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
+    "hono": ["hono@4.12.14", "", {}, "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
     "human-signals": ["human-signals@5.0.0", "", {}, "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ=="],
 
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
     "interpret": ["interpret@1.4.0", "", {}, "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="],
+
+    "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
     "is-core-module": ["is-core-module@2.16.1", "", { "dependencies": { "hasown": "^2.0.2" } }, "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w=="],
 
@@ -182,11 +249,19 @@
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
     "is-stream": ["is-stream@3.0.0", "", {}, "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
+    "jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
+
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
@@ -196,15 +271,19 @@
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
     "merge-stream": ["merge-stream@2.0.0", "", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
 
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
-    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
-    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "mimic-fn": ["mimic-fn@4.0.0", "", {}, "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw=="],
 
@@ -216,9 +295,17 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
     "nice-try": ["nice-try@1.0.5", "", {}, "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="],
 
     "npm-run-path": ["npm-run-path@5.3.0", "", { "dependencies": { "path-key": "^4.0.0" } }, "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
@@ -228,23 +315,39 @@
 
     "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
 
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
 
     "path-scurry": ["path-scurry@2.0.1", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA=="],
 
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
     "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
     "pump": ["pump@3.0.3", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA=="],
 
+    "qs": ["qs@6.15.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg=="],
+
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
     "rechoir": ["rechoir@0.6.2", "", { "dependencies": { "resolve": "^1.1.6" } }, "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
     "resolve": ["resolve@1.22.11", "", { "dependencies": { "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ=="],
 
@@ -252,11 +355,21 @@
 
     "rimraf": ["rimraf@6.1.2", "", { "dependencies": { "glob": "^13.0.0", "package-json-from-dist": "^1.0.1" }, "bin": { "rimraf": "dist/esm/bin.mjs" } }, "sha512-cFCkPslJv7BAXJsYlK1dZsbP8/ZNLkCAQ0bi1hf5EKX2QHegmDFEFA6QhuYJlk7UDdc+02JjO80YSOrWPpw06g=="],
 
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
     "section-matter": ["section-matter@1.0.0", "", { "dependencies": { "extend-shallow": "^2.0.1", "kind-of": "^6.0.0" } }, "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA=="],
 
     "semver": ["semver@5.7.2", "", { "bin": { "semver": "bin/semver" } }, "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="],
+
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
@@ -266,6 +379,14 @@
 
     "shx": ["shx@0.4.0", "", { "dependencies": { "minimist": "^1.2.8", "shelljs": "^0.9.2" }, "bin": { "shx": "lib/cli.js" } }, "sha512-Z0KixSIlGPpijKgcH6oCMCbltPImvaKy0sGH8AkLRXw1KyzpKtaCTizP2xen+hNDqVF4xxgvA0KXSb9o4Q6hnA=="],
 
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "simple-git": ["simple-git@3.30.0", "", { "dependencies": { "@kwsites/file-exists": "^1.1.1", "@kwsites/promise-deferred": "^1.1.1", "debug": "^4.4.0" } }, "sha512-q6lxyDsCmEal/MEGhP1aVyQ3oxnagGlBDOVSIB4XUVLl1iZh0Pah6ebC9V4xBap/RfgP2WlI8EKs0WS0rMEJHg=="],
@@ -273,6 +394,8 @@
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
     "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
@@ -286,11 +409,19 @@
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
     "tunnel": ["tunnel@0.0.6", "", {}, "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="],
+
+    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "wcwidth": ["wcwidth@1.0.1", "", { "dependencies": { "defaults": "^1.0.3" } }, "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg=="],
 
@@ -300,11 +431,17 @@
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
+    "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
     "gray-matter/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
 
     "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
 
     "shelljs/execa": ["execa@1.0.0", "", { "dependencies": { "cross-spawn": "^6.0.0", "get-stream": "^4.0.0", "is-stream": "^1.1.0", "npm-run-path": "^2.0.0", "p-finally": "^1.0.0", "signal-exit": "^3.0.0", "strip-eof": "^1.0.0" } }, "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA=="],
+
+    "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "gray-matter/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "allagents",
-  "version": "1.0.14",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "allagents",
-      "version": "1.0.14",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.0.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "chalk": "^5.6.2",
         "cmd-ts": "^0.14.3",
         "execa": "^8.0.1",
@@ -220,6 +221,18 @@
         "@clack/core": "1.0.0",
         "picocolors": "^1.0.0",
         "sisteransi": "^1.0.5"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
       }
     },
     "node_modules/@j178/prek": {
@@ -772,6 +785,46 @@
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
       "license": "MIT"
     },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -849,6 +902,52 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
@@ -865,6 +964,30 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/braces": {
       "version": "3.0.3",
@@ -888,6 +1011,44 @@
         "@types/node": "*"
       }
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/chalk": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -908,6 +1069,63 @@
         "debug": "^4.4.1",
         "didyoumean": "^1.2.2",
         "strip-ansi": "^7.1.0"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/cross-spawn": {
@@ -940,10 +1158,48 @@
         }
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
@@ -954,6 +1210,42 @@
       "dependencies": {
         "once": "^1.4.0"
       }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/esprima": {
       "version": "4.0.1",
@@ -966,6 +1258,36 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/execa": {
@@ -991,6 +1313,67 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.0.tgz",
+      "integrity": "sha512-gDK8yiqKxrGta+3WtON59arrrw6GLmadA1qoFgYXzdcch8fmKDID2XqO8itsi3f1wufXYPT51387dN6cvVBS3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/extend-shallow": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
@@ -1002,6 +1385,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -1018,6 +1407,22 @@
       "engines": {
         "node": ">=8.6.0"
       }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -1040,14 +1445,89 @@
         "node": ">=8"
       }
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -1072,6 +1552,18 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/gray-matter": {
@@ -1111,17 +1603,57 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/human-signals": {
@@ -1133,11 +1665,51 @@
         "node": ">=16.17.0"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
     "node_modules/interpret": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
       "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
@@ -1198,6 +1770,12 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/is-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
@@ -1216,6 +1794,15 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -1227,6 +1814,18 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -1246,6 +1845,36 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/merge-stream": {
@@ -1276,6 +1905,31 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/mimic-fn": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
@@ -1302,6 +1956,15 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/nice-try": {
       "version": "1.0.5",
@@ -1337,11 +2000,43 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -1372,6 +2067,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -1387,6 +2091,16 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -1405,6 +2119,28 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/pump": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
@@ -1414,6 +2150,21 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/queue-microtask": {
@@ -1436,6 +2187,30 @@
       ],
       "license": "MIT"
     },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
@@ -1446,6 +2221,15 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -1479,6 +2263,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -1502,6 +2302,12 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/section-matter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
@@ -1524,6 +2330,57 @@
       "bin": {
         "semver": "bin/semver"
       }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -1707,6 +2564,78 @@
         "node": ">=18"
       }
     },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -1744,6 +2673,15 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/strip-ansi": {
       "version": "7.1.2",
@@ -1815,6 +2753,29 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -1836,6 +2797,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -1855,7 +2834,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/zod": {
@@ -1865,6 +2843,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   "homepage": "https://allagents.dev",
   "dependencies": {
     "@clack/prompts": "^1.0.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "chalk": "^5.6.2",
     "cmd-ts": "^0.14.3",
     "execa": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "shx rm -rf dist && bun build ./src/cli/index.ts --outdir ./dist --target node && shx cp -r src/templates dist/",
     "docs:install": "bun install --cwd docs",
-    "docs:build": "bun run --cwd docs build",
+    "docs:build": "bun run docs:install && bun run --cwd docs build",
     "dev": "bun run src/cli/index.ts",
     "test": "bun test",
     "test:watch": "bun test --watch",

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -18,6 +18,7 @@ import {
   removeWorkspaceMcpServer,
   setWorkspaceMcpServerProxy,
 } from '../../core/mcp-servers.js';
+import { runHttpMcpStdioProxy } from '../../core/mcp-http-stdio-proxy.js';
 import { syncMcpOnly } from '../../core/mcp-sync.js';
 import {
   type ClientType,
@@ -220,7 +221,7 @@ const addArgs = {
   proxy: flag({
     long: 'proxy',
     description:
-      'Rewrite HTTP MCP server sync through mcp-remote for the targeted clients',
+      'Rewrite HTTP MCP server sync through the built-in AllAgents HTTP proxy helper for the targeted clients',
   }),
 };
 
@@ -317,6 +318,30 @@ const mcpRemoveCmd = command({
       `\u2713 Removed MCP server '${name}' from workspace.yaml`,
       { name },
     );
+  },
+});
+
+// =============================================================================
+// mcp proxy-stdio (internal)
+// =============================================================================
+
+const mcpProxyStdioCmd = command({
+  name: 'proxy-stdio',
+  description: 'Internal: expose a remote HTTP MCP server as local stdio',
+  args: {
+    serverUrl: positional({ type: string, displayName: 'serverUrl' }),
+    header: multioption({
+      type: array(string),
+      long: 'header',
+      description: 'HTTP header KEY=VALUE (repeatable)',
+    }),
+  },
+  handler: async ({ serverUrl, header }) => {
+    const headerResult = parseKeyValuePairs(header, '--header');
+    if ('error' in headerResult) {
+      exitWithError('mcp proxy-stdio', headerResult.error);
+    }
+    await runHttpMcpStdioProxy(serverUrl, headerResult.values);
   },
 });
 
@@ -469,6 +494,7 @@ export const mcpCmd = conciseSubcommands({
   description: 'Manage MCP servers for AI clients',
   cmds: {
     add: mcpAddCmd,
+    'proxy-stdio': mcpProxyStdioCmd,
     remove: mcpRemoveCmd,
     list: mcpListCmd,
     get: mcpGetCmd,

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -1,4 +1,3 @@
-import { dump } from 'js-yaml';
 import {
   array,
   command,
@@ -9,6 +8,7 @@ import {
   positional,
   string,
 } from 'cmd-ts';
+import { dump } from 'js-yaml';
 import {
   addWorkspaceMcpServer,
   buildMcpServerConfigFromFlags,
@@ -16,12 +16,17 @@ import {
   listWorkspaceMcpServers,
   parseKeyValuePairs,
   removeWorkspaceMcpServer,
+  setWorkspaceMcpServerProxy,
 } from '../../core/mcp-servers.js';
 import { syncMcpOnly } from '../../core/mcp-sync.js';
-import { ClientTypeSchema, type ClientType, type McpServerConfig } from '../../models/workspace-config.js';
-import { isJsonMode, jsonOutput } from '../json-output.js';
-import { buildDescription, conciseSubcommands } from '../help.js';
+import {
+  type ClientType,
+  ClientTypeSchema,
+  type McpServerConfig,
+} from '../../models/workspace-config.js';
 import { formatMcpResult } from '../format-sync.js';
+import { buildDescription, conciseSubcommands } from '../help.js';
+import { isJsonMode, jsonOutput } from '../json-output.js';
 import {
   mcpAddMeta,
   mcpGetMeta,
@@ -75,7 +80,10 @@ function buildConfigFromAddFlags(
   client: string | undefined,
 ): McpServerConfig {
   if (transport && transport !== 'http' && transport !== 'stdio') {
-    exitWithError(commandName, `Invalid transport '${transport}'. Expected 'http' or 'stdio'.`);
+    exitWithError(
+      commandName,
+      `Invalid transport '${transport}'. Expected 'http' or 'stdio'.`,
+    );
   }
 
   const envResult = parseKeyValuePairs(env, '-e/--env');
@@ -185,7 +193,8 @@ const addArgs = {
   transport: option({
     type: optional(string),
     long: 'transport',
-    description: "Transport: 'http' or 'stdio' (auto-detected from URL if omitted)",
+    description:
+      "Transport: 'http' or 'stdio' (auto-detected from URL if omitted)",
   }),
   args: multioption({
     type: array(string),
@@ -208,6 +217,11 @@ const addArgs = {
     long: 'client',
     description: 'Comma-separated list of client filters',
   }),
+  proxy: flag({
+    long: 'proxy',
+    description:
+      'Rewrite HTTP MCP server sync through mcp-remote for the targeted clients',
+  }),
 };
 
 const mcpAddCmd = command({
@@ -215,9 +229,23 @@ const mcpAddCmd = command({
   description: buildDescription(mcpAddMeta),
   args: {
     ...addArgs,
-    force: flag({ long: 'force', short: 'f', description: 'Replace an existing server with the same name' }),
+    force: flag({
+      long: 'force',
+      short: 'f',
+      description: 'Replace an existing server with the same name',
+    }),
   },
-  handler: async ({ name, commandOrUrl, transport, args, env, header, client, force }) => {
+  handler: async ({
+    name,
+    commandOrUrl,
+    transport,
+    args,
+    env,
+    header,
+    client,
+    proxy,
+    force,
+  }) => {
     const config = buildConfigFromAddFlags(
       'mcp add',
       commandOrUrl,
@@ -227,12 +255,46 @@ const mcpAddCmd = command({
       header,
       client,
     );
-    const addResult = await addWorkspaceMcpServer(name, config, process.cwd(), force);
-    if (!addResult.success) exitWithError('mcp add', addResult.error ?? 'Unknown error');
-    await runPostMutationSync('mcp add', `\u2713 Added MCP server '${name}' to workspace.yaml`, {
+    const proxyClients = client ? parseClientFilter(client) : undefined;
+    if (proxy && !('url' in config)) {
+      exitWithError(
+        'mcp add',
+        '--proxy is only supported for HTTP MCP servers',
+      );
+    }
+
+    const addResult = await addWorkspaceMcpServer(
       name,
-      config: addResult.config,
-    });
+      config,
+      process.cwd(),
+      force,
+    );
+    if (!addResult.success)
+      exitWithError('mcp add', addResult.error ?? 'Unknown error');
+
+    if (proxy) {
+      const proxyResult = await setWorkspaceMcpServerProxy(
+        name,
+        process.cwd(),
+        proxyClients,
+      );
+      if (!proxyResult.success) {
+        exitWithError(
+          'mcp add',
+          proxyResult.error ?? 'Failed to persist MCP proxy config',
+        );
+      }
+    }
+
+    await runPostMutationSync(
+      'mcp add',
+      `\u2713 Added MCP server '${name}' to workspace.yaml`,
+      {
+        name,
+        config: addResult.config,
+        proxy,
+      },
+    );
   },
 });
 
@@ -248,7 +310,8 @@ const mcpRemoveCmd = command({
   },
   handler: async ({ name }) => {
     const removeResult = await removeWorkspaceMcpServer(name, process.cwd());
-    if (!removeResult.success) exitWithError('mcp remove', removeResult.error ?? 'Unknown error');
+    if (!removeResult.success)
+      exitWithError('mcp remove', removeResult.error ?? 'Unknown error');
     await runPostMutationSync(
       'mcp remove',
       `\u2713 Removed MCP server '${name}' from workspace.yaml`,
@@ -322,7 +385,10 @@ const mcpGetCmd = command({
       exitWithError('mcp get', e instanceof Error ? e.message : String(e));
     }
     if (!config) {
-      exitWithError('mcp get', `MCP server '${name}' not found in workspace.yaml`);
+      exitWithError(
+        'mcp get',
+        `MCP server '${name}' not found in workspace.yaml`,
+      );
     }
 
     if (isJsonMode()) {
@@ -346,7 +412,10 @@ const mcpUpdateCmd = command({
   name: 'update',
   description: buildDescription(mcpUpdateMeta),
   args: {
-    offline: flag({ long: 'offline', description: 'Use cached plugins without fetching from remote' }),
+    offline: flag({
+      long: 'offline',
+      description: 'Use cached plugins without fetching from remote',
+    }),
   },
   handler: async ({ offline }) => {
     const result = await syncMcpOnly(process.cwd(), { offline });
@@ -364,7 +433,9 @@ const mcpUpdateCmd = command({
     }
 
     const hasAnyChanges = Object.values(result.mcpResults).some(
-      (r) => r && (r.added > 0 || r.overwritten > 0 || r.removed > 0 || r.skipped > 0),
+      (r) =>
+        r &&
+        (r.added > 0 || r.overwritten > 0 || r.removed > 0 || r.skipped > 0),
     );
 
     if (!hasAnyChanges) {

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -12,6 +12,7 @@ import { dump } from 'js-yaml';
 import {
   addWorkspaceMcpServer,
   buildMcpServerConfigFromFlags,
+  clearWorkspaceMcpServerProxy,
   getWorkspaceMcpServer,
   listWorkspaceMcpServers,
   parseKeyValuePairs,
@@ -283,6 +284,17 @@ const mcpAddCmd = command({
         exitWithError(
           'mcp add',
           proxyResult.error ?? 'Failed to persist MCP proxy config',
+        );
+      }
+    } else if (force) {
+      const clearResult = await clearWorkspaceMcpServerProxy(
+        name,
+        process.cwd(),
+      );
+      if (!clearResult.success) {
+        exitWithError(
+          'mcp add',
+          clearResult.error ?? 'Failed to clear MCP proxy config',
         );
       }
     }

--- a/src/cli/metadata/mcp.ts
+++ b/src/cli/metadata/mcp.ts
@@ -10,11 +10,17 @@ export const mcpAddMeta: AgentCommandMeta = {
     'allagents mcp add my-server npx --arg=-y --arg=@my/mcp-server',
     'allagents mcp add gh-api npx -e GH_TOKEN=abc123 --arg=-y --arg=@modelcontextprotocol/server-github',
     'allagents mcp add deepwiki https://mcp.deepwiki.com/mcp --client claude,copilot',
+    'allagents mcp add wtgkb https://knowledge.mcp.wtg.zone --proxy',
   ],
   expectedOutput:
-    'Adds the server to workspace.yaml and syncs it to all configured clients. Exit 0 on success, 1 on failure.',
+    'Adds the server to workspace.yaml and syncs it to all configured clients. With --proxy, HTTP servers are rewritten through the existing mcp-remote proxy path for the targeted clients. Exit 0 on success, 1 on failure.',
   positionals: [
-    { name: 'name', type: 'string', required: true, description: 'Server name (unique within workspace.yaml)' },
+    {
+      name: 'name',
+      type: 'string',
+      required: true,
+      description: 'Server name (unique within workspace.yaml)',
+    },
     {
       name: 'commandOrUrl',
       type: 'string',
@@ -24,12 +30,47 @@ export const mcpAddMeta: AgentCommandMeta = {
     },
   ],
   options: [
-    { flag: '--transport', type: 'string', description: "Transport type: 'http' or 'stdio' (auto-detected from URL by default)" },
-    { flag: '--arg', type: 'string', description: 'Argument to pass to the stdio command (repeatable)' },
-    { flag: '--env', short: '-e', type: 'string', description: 'Environment variable KEY=VALUE for stdio transport (repeatable)' },
-    { flag: '--header', type: 'string', description: 'HTTP header KEY=VALUE for http transport (repeatable)' },
-    { flag: '--client', type: 'string', description: "Comma-separated list of clients that should receive this server (default: all project-scoped clients)" },
-    { flag: '--force', short: '-f', type: 'boolean', description: 'Replace an existing server with the same name' },
+    {
+      flag: '--transport',
+      type: 'string',
+      description:
+        "Transport type: 'http' or 'stdio' (auto-detected from URL by default)",
+    },
+    {
+      flag: '--arg',
+      type: 'string',
+      description: 'Argument to pass to the stdio command (repeatable)',
+    },
+    {
+      flag: '--env',
+      short: '-e',
+      type: 'string',
+      description:
+        'Environment variable KEY=VALUE for stdio transport (repeatable)',
+    },
+    {
+      flag: '--header',
+      type: 'string',
+      description: 'HTTP header KEY=VALUE for http transport (repeatable)',
+    },
+    {
+      flag: '--client',
+      type: 'string',
+      description:
+        'Comma-separated list of clients that should receive this server (default: all project-scoped clients)',
+    },
+    {
+      flag: '--proxy',
+      type: 'boolean',
+      description:
+        'For HTTP servers, persist server-scoped proxy intent and sync targeted clients via mcp-remote',
+    },
+    {
+      flag: '--force',
+      short: '-f',
+      type: 'boolean',
+      description: 'Replace an existing server with the same name',
+    },
   ],
 };
 
@@ -41,14 +82,20 @@ export const mcpRemoveMeta: AgentCommandMeta = {
   expectedOutput:
     'Removes the server from workspace.yaml and unsyncs it from all configured clients. Exit 0 on success, 1 if the server is not defined in workspace.yaml.',
   positionals: [
-    { name: 'name', type: 'string', required: true, description: 'Server name to remove' },
+    {
+      name: 'name',
+      type: 'string',
+      required: true,
+      description: 'Server name to remove',
+    },
   ],
 };
 
 export const mcpListMeta: AgentCommandMeta = {
   command: 'mcp list',
   description: 'List MCP servers defined in workspace.yaml',
-  whenToUse: 'To inspect MCP servers AllAgents is managing at the workspace level',
+  whenToUse:
+    'To inspect MCP servers AllAgents is managing at the workspace level',
   examples: ['allagents mcp list'],
   expectedOutput:
     'Prints a table of workspace-defined MCP servers with transport, target, and client filter. Exit 0 on success.',
@@ -59,9 +106,15 @@ export const mcpGetMeta: AgentCommandMeta = {
   description: 'Show the workspace definition for an MCP server',
   whenToUse: 'To see how an MCP server is configured in workspace.yaml',
   examples: ['allagents mcp get deepwiki'],
-  expectedOutput: 'Prints the server config (YAML). Exit 0 on success, 1 if not found.',
+  expectedOutput:
+    'Prints the server config (YAML). Exit 0 on success, 1 if not found.',
   positionals: [
-    { name: 'name', type: 'string', required: true, description: 'Server name' },
+    {
+      name: 'name',
+      type: 'string',
+      required: true,
+      description: 'Server name',
+    },
   ],
 };
 
@@ -74,6 +127,10 @@ export const mcpUpdateMeta: AgentCommandMeta = {
   expectedOutput:
     'Runs the MCP portion of sync for all project-scoped clients. Prints per-scope added/updated/removed counts. Exit 0 on success, 1 on failure.',
   options: [
-    { flag: '--offline', type: 'boolean', description: 'Use cached plugins without fetching from remote' },
+    {
+      flag: '--offline',
+      type: 'boolean',
+      description: 'Use cached plugins without fetching from remote',
+    },
   ],
 };

--- a/src/cli/metadata/mcp.ts
+++ b/src/cli/metadata/mcp.ts
@@ -10,10 +10,10 @@ export const mcpAddMeta: AgentCommandMeta = {
     'allagents mcp add my-server npx --arg=-y --arg=@my/mcp-server',
     'allagents mcp add gh-api npx -e GH_TOKEN=abc123 --arg=-y --arg=@modelcontextprotocol/server-github',
     'allagents mcp add deepwiki https://mcp.deepwiki.com/mcp --client claude,copilot',
-    'allagents mcp add wtgkb https://knowledge.mcp.wtg.zone --proxy',
+    'allagents mcp add secure-api https://api.example.com/mcp --proxy',
   ],
   expectedOutput:
-    'Adds the server to workspace.yaml and syncs it to all configured clients. With --proxy, HTTP servers are rewritten through the existing mcp-remote proxy path for the targeted clients. Exit 0 on success, 1 on failure.',
+    'Adds the server to workspace.yaml and syncs it to all configured clients. With --proxy, HTTP servers are rewritten through the built-in AllAgents HTTP-to-stdio proxy path for the targeted clients. Exit 0 on success, 1 on failure.',
   positionals: [
     {
       name: 'name',
@@ -63,7 +63,7 @@ export const mcpAddMeta: AgentCommandMeta = {
       flag: '--proxy',
       type: 'boolean',
       description:
-        'For HTTP servers, persist server-scoped proxy intent and sync targeted clients via mcp-remote',
+        'For HTTP servers, persist server-scoped proxy intent and sync targeted clients via the built-in AllAgents HTTP proxy helper',
     },
     {
       flag: '--force',

--- a/src/core/mcp-http-stdio-proxy.ts
+++ b/src/core/mcp-http-stdio-proxy.ts
@@ -147,7 +147,12 @@ function tryOpenBrowser(url: string): Promise<void> {
         return;
       }
 
-      const { command, args } = commands[index]!;
+      const entry = commands[index];
+      if (!entry) {
+        resolve();
+        return;
+      }
+      const { command, args } = entry;
       const child = spawn(command, args, {
         detached: true,
         stdio: 'ignore',

--- a/src/core/mcp-http-stdio-proxy.ts
+++ b/src/core/mcp-http-stdio-proxy.ts
@@ -129,7 +129,7 @@ function findFreePort(): Promise<number> {
   });
 }
 
-function tryOpenBrowser(url: string): void {
+function tryOpenBrowser(url: string): Promise<void> {
   const commands: Array<{ command: string; args: string[] }> =
     process.platform === 'darwin'
       ? [{ command: 'open', args: [url] }]
@@ -140,18 +140,29 @@ function tryOpenBrowser(url: string): void {
             { command: 'gio', args: ['open', url] },
           ];
 
-  for (const { command, args } of commands) {
-    try {
+  return new Promise((resolve) => {
+    const tryCommand = (index: number) => {
+      if (index >= commands.length) {
+        resolve();
+        return;
+      }
+
+      const { command, args } = commands[index]!;
       const child = spawn(command, args, {
         detached: true,
         stdio: 'ignore',
       });
-      child.unref();
-      return;
-    } catch {
-      // Try the next launcher.
-    }
-  }
+      child.once('spawn', () => {
+        child.unref();
+        resolve();
+      });
+      child.once('error', () => {
+        tryCommand(index + 1);
+      });
+    };
+
+    tryCommand(0);
+  });
 }
 
 class FileOAuthClientProvider implements OAuthClientProvider {
@@ -304,8 +315,20 @@ class FileOAuthClientProvider implements OAuthClientProvider {
             );
             const code = parsed.searchParams.get('code');
             const error = parsed.searchParams.get('error');
+            const state = parsed.searchParams.get('state');
 
             if (code) {
+              if (state !== this.stateValue) {
+                response.writeHead(400, {
+                  'content-type': 'text/html; charset=utf-8',
+                });
+                response.end(
+                  '<html><body><h1>Authorization failed</h1><p>State validation failed.</p></body></html>',
+                );
+                server.close();
+                reject(new Error('OAuth state validation failed'));
+                return;
+              }
               response.writeHead(200, {
                 'content-type': 'text/html; charset=utf-8',
               });
@@ -347,7 +370,7 @@ class FileOAuthClientProvider implements OAuthClientProvider {
         console.error(
           `If the browser does not open, visit: ${authorizationUrl.toString()}`,
         );
-        tryOpenBrowser(authorizationUrl.toString());
+        void tryOpenBrowser(authorizationUrl.toString());
       });
     });
   }

--- a/src/core/mcp-http-stdio-proxy.ts
+++ b/src/core/mcp-http-stdio-proxy.ts
@@ -1,0 +1,471 @@
+import { createHash, randomUUID } from 'node:crypto';
+import {
+  createServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from 'node:http';
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { constants as fsConstants } from 'node:fs';
+import { access } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { spawn } from 'node:child_process';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import {
+  type OAuthDiscoveryState,
+  type OAuthClientProvider,
+  UnauthorizedError,
+} from '@modelcontextprotocol/sdk/client/auth.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+import type {
+  OAuthClientInformationMixed,
+  OAuthClientMetadata,
+  OAuthTokens,
+} from '@modelcontextprotocol/sdk/shared/auth.js';
+import { getHomeDir } from '../constants.js';
+import {
+  GetPromptRequestSchema as GetPromptSchema,
+  ListPromptsRequestSchema as ListPromptsSchema,
+  ListResourceTemplatesRequestSchema as ListResourceTemplatesSchema,
+  ListResourcesRequestSchema as ListResourcesSchema,
+  ListToolsRequestSchema as ListToolsSchema,
+  ReadResourceRequestSchema as ReadResourceSchema,
+  CallToolRequestSchema as CallToolSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+
+const AUTH_TIMEOUT_MS = 5 * 60 * 1000;
+
+function hashServerUrl(serverUrl: string): string {
+  return createHash('sha256').update(serverUrl).digest('hex').slice(0, 16);
+}
+
+function getCacheDir(serverUrl: string): string {
+  return join(
+    getHomeDir(),
+    '.allagents',
+    'oauth-proxy',
+    hashServerUrl(serverUrl),
+  );
+}
+
+function getRequestInit(
+  headers: Record<string, string>,
+): RequestInit | undefined {
+  if (Object.keys(headers).length === 0) {
+    return undefined;
+  }
+  return { headers };
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path, fsConstants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readJsonFile<T>(path: string): Promise<T | undefined> {
+  if (!(await pathExists(path))) {
+    return undefined;
+  }
+  return JSON.parse(await readFile(path, 'utf-8')) as T;
+}
+
+async function writePrivateFile(path: string, content: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, content, { encoding: 'utf-8', mode: 0o600 });
+}
+
+function parseLoopbackPort(
+  clientInfo?: OAuthClientInformationMixed,
+): number | undefined {
+  const redirectUri =
+    clientInfo && 'redirect_uris' in clientInfo
+      ? clientInfo.redirect_uris?.[0]
+      : undefined;
+  if (!redirectUri) {
+    return undefined;
+  }
+
+  try {
+    const parsed = new URL(redirectUri);
+    if (
+      (parsed.hostname === '127.0.0.1' || parsed.hostname === 'localhost') &&
+      parsed.port
+    ) {
+      return Number(parsed.port);
+    }
+  } catch {
+    return undefined;
+  }
+
+  return undefined;
+}
+
+function findFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      const port =
+        typeof address === 'object' && address ? address.port : undefined;
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        if (!port) {
+          reject(new Error('Failed to determine a free loopback port'));
+          return;
+        }
+        resolve(port);
+      });
+    });
+  });
+}
+
+function tryOpenBrowser(url: string): void {
+  const commands: Array<{ command: string; args: string[] }> =
+    process.platform === 'darwin'
+      ? [{ command: 'open', args: [url] }]
+      : process.platform === 'win32'
+        ? [{ command: 'cmd', args: ['/c', 'start', '', url] }]
+        : [
+            { command: 'xdg-open', args: [url] },
+            { command: 'gio', args: ['open', url] },
+          ];
+
+  for (const { command, args } of commands) {
+    try {
+      const child = spawn(command, args, {
+        detached: true,
+        stdio: 'ignore',
+      });
+      child.unref();
+      return;
+    } catch {
+      // Try the next launcher.
+    }
+  }
+}
+
+class FileOAuthClientProvider implements OAuthClientProvider {
+  private readonly clientInfoPath: string;
+  private readonly tokensPath: string;
+  private readonly verifierPath: string;
+  private readonly discoveryPath: string;
+  private readonly redirectUriValue: string;
+  private clientInfo: OAuthClientInformationMixed | undefined = undefined;
+  private tokenSet: OAuthTokens | undefined = undefined;
+  private discovery: OAuthDiscoveryState | undefined = undefined;
+  private codeVerifierValue: string | undefined = undefined;
+  private pendingAuth: Promise<string> | undefined = undefined;
+  private readonly stateValue = randomUUID();
+
+  constructor(
+    private readonly port: number,
+    serverUrl: string,
+  ) {
+    const cacheDir = getCacheDir(serverUrl);
+    this.clientInfoPath = join(cacheDir, 'client-info.json');
+    this.tokensPath = join(cacheDir, 'tokens.json');
+    this.verifierPath = join(cacheDir, 'code-verifier.txt');
+    this.discoveryPath = join(cacheDir, 'discovery.json');
+    this.redirectUriValue = `http://127.0.0.1:${port}/callback`;
+  }
+
+  get redirectUrl(): string {
+    return this.redirectUriValue;
+  }
+
+  get clientMetadata(): OAuthClientMetadata {
+    return {
+      client_name: 'AllAgents',
+      redirect_uris: [this.redirectUriValue],
+      grant_types: ['authorization_code', 'refresh_token'],
+      response_types: ['code'],
+      token_endpoint_auth_method: 'none',
+    };
+  }
+
+  state(): string {
+    return this.stateValue;
+  }
+
+  async load(): Promise<void> {
+    this.clientInfo = await readJsonFile<OAuthClientInformationMixed>(
+      this.clientInfoPath,
+    );
+    this.tokenSet = await readJsonFile<OAuthTokens>(this.tokensPath);
+    this.discovery = await readJsonFile<OAuthDiscoveryState>(
+      this.discoveryPath,
+    );
+    if (await pathExists(this.verifierPath)) {
+      this.codeVerifierValue = await readFile(this.verifierPath, 'utf-8');
+    }
+  }
+
+  clientInformation(): OAuthClientInformationMixed | undefined {
+    return this.clientInfo;
+  }
+
+  async saveClientInformation(
+    clientInformation: OAuthClientInformationMixed,
+  ): Promise<void> {
+    this.clientInfo = clientInformation;
+    await writePrivateFile(
+      this.clientInfoPath,
+      `${JSON.stringify(clientInformation, null, 2)}\n`,
+    );
+  }
+
+  tokens(): OAuthTokens | undefined {
+    return this.tokenSet;
+  }
+
+  async saveTokens(tokens: OAuthTokens): Promise<void> {
+    this.tokenSet = tokens;
+    await writePrivateFile(
+      this.tokensPath,
+      `${JSON.stringify(tokens, null, 2)}\n`,
+    );
+  }
+
+  redirectToAuthorization(authorizationUrl: URL): void {
+    this.pendingAuth ??= this.waitForAuthorizationCode(authorizationUrl);
+  }
+
+  async saveCodeVerifier(codeVerifier: string): Promise<void> {
+    this.codeVerifierValue = codeVerifier;
+    await writePrivateFile(this.verifierPath, codeVerifier);
+  }
+
+  codeVerifier(): string {
+    if (!this.codeVerifierValue) {
+      throw new Error('No OAuth code verifier is available');
+    }
+    return this.codeVerifierValue;
+  }
+
+  async saveDiscoveryState(state: OAuthDiscoveryState): Promise<void> {
+    this.discovery = state;
+    await writePrivateFile(
+      this.discoveryPath,
+      `${JSON.stringify(state, null, 2)}\n`,
+    );
+  }
+
+  discoveryState(): OAuthDiscoveryState | undefined {
+    return this.discovery;
+  }
+
+  async invalidateCredentials(
+    scope: 'all' | 'client' | 'tokens' | 'verifier' | 'discovery',
+  ): Promise<void> {
+    const removals =
+      scope === 'all'
+        ? [
+            this.clientInfoPath,
+            this.tokensPath,
+            this.verifierPath,
+            this.discoveryPath,
+          ]
+        : scope === 'client'
+          ? [this.clientInfoPath]
+          : scope === 'tokens'
+            ? [this.tokensPath]
+            : scope === 'verifier'
+              ? [this.verifierPath]
+              : [this.discoveryPath];
+
+    await Promise.all(removals.map((path) => rm(path, { force: true })));
+  }
+
+  async waitForAuthCode(): Promise<string> {
+    if (!this.pendingAuth) {
+      throw new Error('OAuth authorization has not been started');
+    }
+    return this.pendingAuth;
+  }
+
+  private waitForAuthorizationCode(authorizationUrl: URL): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const server = createServer(
+        (request: IncomingMessage, response: ServerResponse) => {
+          try {
+            const parsed = new URL(
+              request.url ?? '/',
+              `http://127.0.0.1:${this.port}`,
+            );
+            const code = parsed.searchParams.get('code');
+            const error = parsed.searchParams.get('error');
+
+            if (code) {
+              response.writeHead(200, {
+                'content-type': 'text/html; charset=utf-8',
+              });
+              response.end(
+                '<html><body><h1>Authorization complete</h1><p>You can close this window.</p></body></html>',
+              );
+              server.close();
+              resolve(code);
+              return;
+            }
+
+            const message = error ?? 'No authorization code received';
+            response.writeHead(400, {
+              'content-type': 'text/html; charset=utf-8',
+            });
+            response.end(
+              `<html><body><h1>Authorization failed</h1><p>${message}</p></body></html>`,
+            );
+            server.close();
+            reject(new Error(message));
+          } catch (error) {
+            server.close();
+            reject(error instanceof Error ? error : new Error(String(error)));
+          }
+        },
+      );
+
+      const timeout = setTimeout(() => {
+        server.close();
+        reject(new Error('Timed out waiting for OAuth authorization callback'));
+      }, AUTH_TIMEOUT_MS);
+
+      server.on('close', () => {
+        clearTimeout(timeout);
+      });
+      server.on('error', reject);
+      server.listen(this.port, '127.0.0.1', () => {
+        console.error('Opening browser for authorization...');
+        console.error(
+          `If the browser does not open, visit: ${authorizationUrl.toString()}`,
+        );
+        tryOpenBrowser(authorizationUrl.toString());
+      });
+    });
+  }
+}
+
+async function buildOAuthProvider(
+  serverUrl: string,
+): Promise<FileOAuthClientProvider> {
+  const cacheDir = getCacheDir(serverUrl);
+  const cachedClientInfo = await readJsonFile<OAuthClientInformationMixed>(
+    join(cacheDir, 'client-info.json'),
+  );
+
+  let port = parseLoopbackPort(cachedClientInfo);
+  if (!port) {
+    port = await findFreePort();
+  }
+
+  const provider = new FileOAuthClientProvider(port, serverUrl);
+  await provider.load();
+  return provider;
+}
+
+function parseCallToolResponse(
+  result: Awaited<ReturnType<Client['callTool']>>,
+) {
+  return {
+    content: result.content,
+    ...(result.structuredContent !== undefined && {
+      structuredContent: result.structuredContent,
+    }),
+    ...(result.isError !== undefined && { isError: result.isError }),
+    ...(result._meta !== undefined && { _meta: result._meta }),
+  };
+}
+
+async function connectRemoteTransport(
+  serverUrl: string,
+  headers: Record<string, string>,
+): Promise<Client> {
+  const provider = await buildOAuthProvider(serverUrl);
+  const client = new Client(
+    {
+      name: 'AllAgents',
+      version: '1.0.0',
+    },
+    { capabilities: {} },
+  );
+
+  const buildTransport = () => {
+    const requestInit = getRequestInit(headers);
+    return new StreamableHTTPClientTransport(new URL(serverUrl), {
+      authProvider: provider,
+      ...(requestInit && { requestInit }),
+    });
+  };
+
+  let transport = buildTransport();
+  try {
+    await client.connect(transport as unknown as Transport);
+  } catch (error) {
+    if (!(error instanceof UnauthorizedError)) {
+      throw error;
+    }
+    const authorizationCode = await provider.waitForAuthCode();
+    await transport.finishAuth(authorizationCode);
+    await transport.close();
+    transport = buildTransport();
+    await client.connect(transport as unknown as Transport);
+  }
+
+  return client;
+}
+
+export async function runHttpMcpStdioProxy(
+  serverUrl: string,
+  headers: Record<string, string> = {},
+): Promise<void> {
+  const remote = await connectRemoteTransport(serverUrl, headers);
+  const local = new Server(
+    {
+      name: 'AllAgents',
+      version: '1.0.0',
+    },
+    {
+      capabilities: {
+        tools: {},
+        resources: {},
+        prompts: {},
+      },
+    },
+  );
+
+  local.setRequestHandler(ListToolsSchema, async (request) =>
+    remote.listTools(request.params),
+  );
+  local.setRequestHandler(CallToolSchema, async (request) =>
+    parseCallToolResponse(await remote.callTool(request.params)),
+  );
+  local.setRequestHandler(ListResourcesSchema, async (request) =>
+    remote.listResources(request.params),
+  );
+  local.setRequestHandler(ReadResourceSchema, async (request) =>
+    remote.readResource(request.params),
+  );
+  local.setRequestHandler(ListResourceTemplatesSchema, async (request) =>
+    remote.listResourceTemplates(request.params),
+  );
+  local.setRequestHandler(ListPromptsSchema, async (request) =>
+    remote.listPrompts(request.params),
+  );
+  local.setRequestHandler(GetPromptSchema, async (request) =>
+    remote.getPrompt(request.params),
+  );
+
+  const transport = new StdioServerTransport();
+  transport.onerror = (error) => {
+    console.error(error.message);
+  };
+  await local.connect(transport);
+}

--- a/src/core/mcp-proxy.ts
+++ b/src/core/mcp-proxy.ts
@@ -1,14 +1,4 @@
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
-import { join, dirname } from 'node:path';
-import { getHomeDir } from '../constants.js';
 import type { McpProxyConfig } from '../models/workspace-config.js';
-
-/**
- * Get the path to the mcp-remote metadata settings file.
- */
-export function getProxyMetadataPath(): string {
-  return join(getHomeDir(), '.allagents', 'mcp-remote', 'mcp-metadata-settings.json');
-}
 
 /**
  * Determine if a server+client pair should be proxied.
@@ -31,7 +21,9 @@ export function shouldProxy(
 /**
  * Check if a server config uses HTTP transport (has a `url` field).
  */
-function isHttpServer(config: unknown): config is { url: string } {
+function isHttpServer(
+  config: unknown,
+): config is { url: string; headers?: Record<string, string> } {
   return (
     typeof config === 'object' &&
     config !== null &&
@@ -41,18 +33,23 @@ function isHttpServer(config: unknown): config is { url: string } {
 }
 
 /**
- * Rewrite an HTTP server config to a stdio config using mcp-remote.
+ * Rewrite an HTTP server config to a stdio config using the built-in
+ * AllAgents HTTP-to-stdio proxy helper.
  */
-function toProxiedConfig(url: string, metadataPath: string): Record<string, unknown> {
+function toProxiedConfig(
+  url: string,
+  headers?: Record<string, string>,
+): Record<string, unknown> {
+  const args = ['mcp', 'proxy-stdio', url];
+  if (headers) {
+    for (const [key, value] of Object.entries(headers)) {
+      args.push('--header', `${key}=${value}`);
+    }
+  }
+
   return {
-    command: 'npx',
-    args: [
-      'mcp-remote',
-      url,
-      '--http',
-      '--static-oauth-client-metadata',
-      `@${metadataPath}`,
-    ],
+    command: 'allagents',
+    args,
   };
 }
 
@@ -65,28 +62,14 @@ export function applyMcpProxy(
   servers: Map<string, unknown>,
   client: string,
   config: McpProxyConfig,
-  metadataPath: string,
 ): Map<string, unknown> {
   const result = new Map<string, unknown>();
   for (const [name, serverConfig] of servers) {
     if (isHttpServer(serverConfig) && shouldProxy(name, client, config)) {
-      result.set(name, toProxiedConfig(serverConfig.url, metadataPath));
+      result.set(name, toProxiedConfig(serverConfig.url, serverConfig.headers));
     } else {
       result.set(name, serverConfig);
     }
   }
   return result;
-}
-
-/**
- * Ensure the mcp-remote metadata file exists. Creates it with default
- * content if missing. Does not overwrite existing files.
- */
-export function ensureProxyMetadata(metadataPath?: string): void {
-  const path = metadataPath ?? getProxyMetadataPath();
-  if (existsSync(path)) {
-    return;
-  }
-  mkdirSync(dirname(path), { recursive: true });
-  writeFileSync(path, JSON.stringify({ client_uri: 'http://localhost' }, null, 2), 'utf-8');
 }

--- a/src/core/mcp-servers.ts
+++ b/src/core/mcp-servers.ts
@@ -39,6 +39,26 @@ export interface McpProxyModifyResult {
   proxyClients?: ClientType[];
 }
 
+function removeServerScopedProxyIntent(
+  workspaceConfig: WorkspaceConfig,
+  name: string,
+): void {
+  if (!workspaceConfig.mcpProxy?.servers?.[name]) {
+    return;
+  }
+
+  delete workspaceConfig.mcpProxy.servers[name];
+  if (Object.keys(workspaceConfig.mcpProxy.servers).length === 0) {
+    workspaceConfig.mcpProxy.servers = undefined;
+  }
+  if (
+    workspaceConfig.mcpProxy.clients.length === 0 &&
+    !workspaceConfig.mcpProxy.servers
+  ) {
+    workspaceConfig.mcpProxy = undefined;
+  }
+}
+
 function getConfigPath(workspacePath: string): string {
   return join(workspacePath, CONFIG_DIR, WORKSPACE_CONFIG_FILE);
 }
@@ -159,6 +179,33 @@ export async function setWorkspaceMcpServerProxy(
   }
 }
 
+export async function clearWorkspaceMcpServerProxy(
+  name: string,
+  workspacePath: string = process.cwd(),
+): Promise<McpProxyModifyResult> {
+  try {
+    await ensureWorkspace(workspacePath);
+    const configPath = getConfigPath(workspacePath);
+    const workspaceConfig = await readConfig(configPath);
+
+    if (!workspaceConfig.mcpServers || !(name in workspaceConfig.mcpServers)) {
+      return {
+        success: false,
+        error: `MCP server '${name}' not found in workspace.yaml`,
+      };
+    }
+
+    removeServerScopedProxyIntent(workspaceConfig, name);
+    await writeConfig(configPath, workspaceConfig);
+    return { success: true };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
 /**
  * Remove an MCP server entry from workspace.yaml. Returns success: false if
  * the server is not defined in workspace.yaml (it may still exist in a plugin).
@@ -189,18 +236,7 @@ export async function removeWorkspaceMcpServer(
       workspaceConfig.mcpServers = undefined;
     }
 
-    if (workspaceConfig.mcpProxy?.servers?.[name]) {
-      delete workspaceConfig.mcpProxy.servers[name];
-      if (Object.keys(workspaceConfig.mcpProxy.servers).length === 0) {
-        workspaceConfig.mcpProxy.servers = undefined;
-      }
-      if (
-        workspaceConfig.mcpProxy.clients.length === 0 &&
-        !workspaceConfig.mcpProxy.servers
-      ) {
-        workspaceConfig.mcpProxy = undefined;
-      }
-    }
+    removeServerScopedProxyIntent(workspaceConfig, name);
 
     await writeConfig(configPath, workspaceConfig);
     return { success: true };

--- a/src/core/mcp-servers.ts
+++ b/src/core/mcp-servers.ts
@@ -4,12 +4,24 @@ import { join } from 'node:path';
 import { dump, load } from 'js-yaml';
 import { CONFIG_DIR, WORKSPACE_CONFIG_FILE } from '../constants.js';
 import type {
+  ClientEntry,
   ClientType,
   McpServerConfig,
   WorkspaceConfig,
 } from '../models/workspace-config.js';
-import { McpServerConfigSchema } from '../models/workspace-config.js';
+import {
+  McpServerConfigSchema,
+  getClientTypes,
+} from '../models/workspace-config.js';
 import { ensureWorkspace } from './workspace-modify.js';
+
+const PROJECT_MCP_CLIENTS: ReadonlySet<ClientType> = new Set<ClientType>([
+  'claude',
+  'codex',
+  'vscode',
+  'copilot',
+  'universal',
+]);
 
 /**
  * Result of add/remove/update operations on workspace mcpServers.
@@ -21,6 +33,12 @@ export interface McpServerModifyResult {
   config?: McpServerConfig;
 }
 
+export interface McpProxyModifyResult {
+  success: boolean;
+  error?: string;
+  proxyClients?: ClientType[];
+}
+
 function getConfigPath(workspacePath: string): string {
   return join(workspacePath, CONFIG_DIR, WORKSPACE_CONFIG_FILE);
 }
@@ -30,8 +48,17 @@ async function readConfig(configPath: string): Promise<WorkspaceConfig> {
   return load(content) as WorkspaceConfig;
 }
 
-async function writeConfig(configPath: string, config: WorkspaceConfig): Promise<void> {
+async function writeConfig(
+  configPath: string,
+  config: WorkspaceConfig,
+): Promise<void> {
   await writeFile(configPath, dump(config, { lineWidth: -1 }), 'utf-8');
+}
+
+function getProjectMcpClients(entries: ClientEntry[]): ClientType[] {
+  return getClientTypes(entries).filter((client): client is ClientType =>
+    PROJECT_MCP_CLIENTS.has(client),
+  );
 }
 
 /**
@@ -43,8 +70,13 @@ function validateServerConfig(
 ): { valid: true; data: McpServerConfig } | { valid: false; error: string } {
   const result = McpServerConfigSchema.safeParse(config);
   if (!result.success) {
-    const issues = result.error.issues.map((i) => `  - ${i.path.join('.')}: ${i.message}`);
-    return { valid: false, error: `Invalid MCP server config:\n${issues.join('\n')}` };
+    const issues = result.error.issues.map(
+      (i) => `  - ${i.path.join('.')}: ${i.message}`,
+    );
+    return {
+      valid: false,
+      error: `Invalid MCP server config:\n${issues.join('\n')}`,
+    };
   }
   return { valid: true, data: result.data };
 }
@@ -89,6 +121,45 @@ export async function addWorkspaceMcpServer(
 }
 
 /**
+ * Persist server-scoped MCP proxy intent for a workspace-defined server.
+ * Keeps any existing workspace-wide proxy defaults unchanged.
+ */
+export async function setWorkspaceMcpServerProxy(
+  name: string,
+  workspacePath: string = process.cwd(),
+  proxyClients?: ClientType[],
+): Promise<McpProxyModifyResult> {
+  try {
+    await ensureWorkspace(workspacePath);
+    const configPath = getConfigPath(workspacePath);
+    const workspaceConfig = await readConfig(configPath);
+
+    if (!workspaceConfig.mcpServers || !(name in workspaceConfig.mcpServers)) {
+      return {
+        success: false,
+        error: `MCP server '${name}' not found in workspace.yaml`,
+      };
+    }
+
+    const resolvedClients = [
+      ...new Set(proxyClients ?? getProjectMcpClients(workspaceConfig.clients)),
+    ];
+    workspaceConfig.mcpProxy ??= { clients: [] };
+    workspaceConfig.mcpProxy.clients ??= [];
+    workspaceConfig.mcpProxy.servers ??= {};
+    workspaceConfig.mcpProxy.servers[name] = { proxy: resolvedClients };
+
+    await writeConfig(configPath, workspaceConfig);
+    return { success: true, proxyClients: resolvedClients };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+/**
  * Remove an MCP server entry from workspace.yaml. Returns success: false if
  * the server is not defined in workspace.yaml (it may still exist in a plugin).
  */
@@ -116,6 +187,19 @@ export async function removeWorkspaceMcpServer(
     delete workspaceConfig.mcpServers[name];
     if (Object.keys(workspaceConfig.mcpServers).length === 0) {
       workspaceConfig.mcpServers = undefined;
+    }
+
+    if (workspaceConfig.mcpProxy?.servers?.[name]) {
+      delete workspaceConfig.mcpProxy.servers[name];
+      if (Object.keys(workspaceConfig.mcpProxy.servers).length === 0) {
+        workspaceConfig.mcpProxy.servers = undefined;
+      }
+      if (
+        workspaceConfig.mcpProxy.clients.length === 0 &&
+        !workspaceConfig.mcpProxy.servers
+      ) {
+        workspaceConfig.mcpProxy = undefined;
+      }
     }
 
     await writeConfig(configPath, workspaceConfig);
@@ -169,7 +253,8 @@ export function buildMcpServerConfigFromFlags(options: {
 }): { config: McpServerConfig } | { error: string } {
   const { commandOrUrl, args, env, headers, clients } = options;
   const transport =
-    options.transport ?? (/^https?:\/\//i.test(commandOrUrl) ? 'http' : 'stdio');
+    options.transport ??
+    (/^https?:\/\//i.test(commandOrUrl) ? 'http' : 'stdio');
 
   if (transport === 'http') {
     if (!/^https?:\/\//i.test(commandOrUrl)) {

--- a/src/core/mcp-sync.ts
+++ b/src/core/mcp-sync.ts
@@ -1,7 +1,10 @@
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { CONFIG_DIR, WORKSPACE_CONFIG_FILE } from '../constants.js';
-import type { ClientType, WorkspaceConfig } from '../models/workspace-config.js';
+import type {
+  ClientType,
+  WorkspaceConfig,
+} from '../models/workspace-config.js';
 import type { SyncState } from '../models/sync-state.js';
 import {
   buildPluginSyncPlans,
@@ -14,7 +17,7 @@ import type { McpMergeResult } from './vscode-mcp.js';
 import { collectMcpServers, syncVscodeMcpConfig } from './vscode-mcp.js';
 import { syncClaudeMcpConfig } from './claude-mcp.js';
 import { syncCodexProjectMcpConfig } from './codex-mcp.js';
-import { applyMcpProxy, ensureProxyMetadata, getProxyMetadataPath } from './mcp-proxy.js';
+import { applyMcpProxy } from './mcp-proxy.js';
 import {
   getPreviouslySyncedMcpServers,
   loadSyncState,
@@ -117,13 +120,6 @@ export function syncMcpServers(
 
   // Prepare MCP proxy transform if configured
   const mcpProxyConfig = config.mcpProxy;
-  let proxyMetadataPath: string | undefined;
-  if (mcpProxyConfig) {
-    if (!dryRun) {
-      ensureProxyMetadata();
-    }
-    proxyMetadataPath = getProxyMetadataPath();
-  }
 
   // Emit collection warnings once (e.g. workspace overriding plugin server)
   // rather than repeating them for every client scope.
@@ -138,8 +134,8 @@ export function syncMcpServers(
       warnings.push(...collectWarnings);
       collectWarningsEmitted = true;
     }
-    if (mcpProxyConfig && proxyMetadataPath) {
-      return applyMcpProxy(servers, client, mcpProxyConfig, proxyMetadataPath);
+    if (mcpProxyConfig) {
+      return applyMcpProxy(servers, client, mcpProxyConfig);
     }
     return servers;
   }
@@ -169,7 +165,9 @@ export function syncMcpServers(
   if (anyServers.size > 0) {
     for (const client of syncClients) {
       if (!PROJECT_MCP_CLIENTS.has(client)) {
-        warnings.push(`MCP servers not synced for ${client} (not supported at project scope)`);
+        warnings.push(
+          `MCP servers not synced for ${client} (not supported at project scope)`,
+        );
       }
     }
   }
@@ -252,10 +250,18 @@ export async function syncMcpOnly(
   }
 
   // Validate plugins so we can read their .mcp.json files
-  const validatedPlugins = await validateAllPlugins(filteredPlans, workspacePath, offline);
-  const validPlugins = validatedPlugins.filter((v): v is ValidatedPlugin => v.success);
+  const validatedPlugins = await validateAllPlugins(
+    filteredPlans,
+    workspacePath,
+    offline,
+  );
+  const validPlugins = validatedPlugins.filter(
+    (v): v is ValidatedPlugin => v.success,
+  );
   warnings.push(
-    ...validatedPlugins.filter((v) => !v.success).map((v) => `${v.plugin}: ${v.error} (skipped)`),
+    ...validatedPlugins
+      .filter((v) => !v.success)
+      .map((v) => `${v.plugin}: ${v.error} (skipped)`),
   );
 
   const previousState = await loadSyncState(workspacePath);
@@ -280,10 +286,18 @@ export async function syncMcpOnly(
       await saveSyncState(workspacePath, {
         files: (previousState?.files as Record<ClientType, string[]>) ?? {},
         mcpServers: syncResult.trackedServers,
-        ...(previousState?.nativePlugins && { nativePlugins: previousState.nativePlugins }),
-        ...(previousState?.vscodeWorkspaceHash && { vscodeWorkspaceHash: previousState.vscodeWorkspaceHash }),
-        ...(previousState?.vscodeWorkspaceRepos && { vscodeWorkspaceRepos: previousState.vscodeWorkspaceRepos }),
-        ...(previousState?.skillsIndex && { skillsIndex: previousState.skillsIndex }),
+        ...(previousState?.nativePlugins && {
+          nativePlugins: previousState.nativePlugins,
+        }),
+        ...(previousState?.vscodeWorkspaceHash && {
+          vscodeWorkspaceHash: previousState.vscodeWorkspaceHash,
+        }),
+        ...(previousState?.vscodeWorkspaceRepos && {
+          vscodeWorkspaceRepos: previousState.vscodeWorkspaceRepos,
+        }),
+        ...(previousState?.skillsIndex && {
+          skillsIndex: previousState.skillsIndex,
+        }),
       });
     }
   }

--- a/src/core/sync.ts
+++ b/src/core/sync.ts
@@ -2,7 +2,12 @@ import { existsSync, readFileSync, writeFileSync, lstatSync } from 'node:fs';
 import { rm, unlink, rmdir, copyFile } from 'node:fs/promises';
 import { join, resolve, dirname, relative } from 'node:path';
 import JSON5 from 'json5';
-import { CONFIG_DIR, WORKSPACE_CONFIG_FILE, AGENT_FILES, getHomeDir } from '../constants.js';
+import {
+  CONFIG_DIR,
+  WORKSPACE_CONFIG_FILE,
+  AGENT_FILES,
+  getHomeDir,
+} from '../constants.js';
 import { parseWorkspaceConfig } from '../utils/workspace-parser.js';
 import type {
   WorkspaceConfig,
@@ -34,8 +39,19 @@ import {
   type CopyResult,
 } from './transform.js';
 import { updateAgentFiles } from './workspace-repo.js';
-import { discoverWorkspaceSkills, writeSkillsIndex, cleanupSkillsIndex, groupSkillsByRepo } from './repo-skills.js';
-import { CLIENT_MAPPINGS, USER_CLIENT_MAPPINGS, CANONICAL_SKILLS_PATH, isUniversalClient, resolveClientMappings } from '../models/client-mapping.js';
+import {
+  discoverWorkspaceSkills,
+  writeSkillsIndex,
+  cleanupSkillsIndex,
+  groupSkillsByRepo,
+} from './repo-skills.js';
+import {
+  CLIENT_MAPPINGS,
+  USER_CLIENT_MAPPINGS,
+  CANONICAL_SKILLS_PATH,
+  isUniversalClient,
+  resolveClientMappings,
+} from '../models/client-mapping.js';
 import type { ClientMapping } from '../models/client-mapping.js';
 import {
   resolveSkillNames,
@@ -60,22 +76,36 @@ import {
   getPreviouslySyncedNativePlugins,
 } from './sync-state.js';
 import type { SyncState } from '../models/sync-state.js';
-import { getUserWorkspaceConfig, migrateUserWorkspaceSkillsV1toV2 } from './user-workspace.js';
+import {
+  getUserWorkspaceConfig,
+  migrateUserWorkspaceSkillsV1toV2,
+} from './user-workspace.js';
 import {
   generateVscodeWorkspace,
   getWorkspaceOutputPath,
   computeWorkspaceHash,
   reconcileVscodeWorkspaceFolders,
 } from './vscode-workspace.js';
-import { setRepositories, updateRepositories, migrateWorkspaceSkillsV1toV2 } from './workspace-modify.js';
+import {
+  setRepositories,
+  updateRepositories,
+  migrateWorkspaceSkillsV1toV2,
+} from './workspace-modify.js';
 import { collectMcpServers, syncVscodeMcpConfig } from './vscode-mcp.js';
 import type { McpMergeResult } from './vscode-mcp.js';
-import { applyMcpProxy, ensureProxyMetadata, getProxyMetadataPath } from './mcp-proxy.js';
+import { applyMcpProxy } from './mcp-proxy.js';
 import { syncCodexMcpServers } from './codex-mcp.js';
-import { syncClaudeMcpConfig, syncClaudeMcpServersViaCli } from './claude-mcp.js';
+import {
+  syncClaudeMcpConfig,
+  syncClaudeMcpServersViaCli,
+} from './claude-mcp.js';
 import { getCopilotMcpConfigPath } from './copilot-mcp.js';
 import { syncMcpServers as runMcpSync } from './mcp-sync.js';
-import { getNativeClient, mergeNativeSyncResults, type NativeSyncResult } from './native/index.js';
+import {
+  getNativeClient,
+  mergeNativeSyncResults,
+  type NativeSyncResult,
+} from './native/index.js';
 import { Stopwatch } from '../utils/stopwatch.js';
 import { processManagedRepos } from './managed-repos.js';
 
@@ -166,7 +196,10 @@ export interface SyncResult {
   /** Result of native CLI plugin installations */
   nativeResult?: NativeSyncResult;
   /** Timing data for sync steps (when available) */
-  timing?: { totalMs: number; steps: Array<{ label: string; durationMs: number; detail?: string }> };
+  timing?: {
+    totalMs: number;
+    steps: Array<{ label: string; durationMs: number; detail?: string }>;
+  };
   /** Results of managed repository clone/pull operations */
   managedRepoResults?: import('./managed-repos.js').ManagedRepoResult[];
 }
@@ -178,19 +211,33 @@ export function mergeSyncResults(a: SyncResult, b: SyncResult): SyncResult {
   const warnings = [...(a.warnings || []), ...(b.warnings || [])];
   const messages = [...(a.messages || []), ...(b.messages || [])];
   const purgedPaths = [...(a.purgedPaths || []), ...(b.purgedPaths || [])];
-  const deletedArtifacts = [...(a.deletedArtifacts || []), ...(b.deletedArtifacts || [])];
-  const mcpResults = (a.mcpResults || b.mcpResults)
-    ? { ...a.mcpResults, ...b.mcpResults }
-    : undefined;
+  const deletedArtifacts = [
+    ...(a.deletedArtifacts || []),
+    ...(b.deletedArtifacts || []),
+  ];
+  const mcpResults =
+    a.mcpResults || b.mcpResults
+      ? { ...a.mcpResults, ...b.mcpResults }
+      : undefined;
   // Merge nativeResults when both scopes produce them
-  const nativeResult = a.nativeResult && b.nativeResult
-    ? {
-        marketplacesAdded: [...a.nativeResult.marketplacesAdded, ...b.nativeResult.marketplacesAdded],
-        pluginsInstalled: [...a.nativeResult.pluginsInstalled, ...b.nativeResult.pluginsInstalled],
-        pluginsFailed: [...a.nativeResult.pluginsFailed, ...b.nativeResult.pluginsFailed],
-        skipped: [...a.nativeResult.skipped, ...b.nativeResult.skipped],
-      }
-    : a.nativeResult ?? b.nativeResult;
+  const nativeResult =
+    a.nativeResult && b.nativeResult
+      ? {
+          marketplacesAdded: [
+            ...a.nativeResult.marketplacesAdded,
+            ...b.nativeResult.marketplacesAdded,
+          ],
+          pluginsInstalled: [
+            ...a.nativeResult.pluginsInstalled,
+            ...b.nativeResult.pluginsInstalled,
+          ],
+          pluginsFailed: [
+            ...a.nativeResult.pluginsFailed,
+            ...b.nativeResult.pluginsFailed,
+          ],
+          skipped: [...a.nativeResult.skipped, ...b.nativeResult.skipped],
+        }
+      : (a.nativeResult ?? b.nativeResult);
   return {
     success: a.success && b.success,
     pluginResults: [...a.pluginResults, ...b.pluginResults],
@@ -205,10 +252,13 @@ export function mergeSyncResults(a: SyncResult, b: SyncResult): SyncResult {
     ...(mcpResults && { mcpResults }),
     ...(nativeResult && { nativeResult }),
     ...(() => {
-      const managedRepoResults = [...(a.managedRepoResults || []), ...(b.managedRepoResults || [])];
+      const managedRepoResults = [
+        ...(a.managedRepoResults || []),
+        ...(b.managedRepoResults || []),
+      ];
       return managedRepoResults.length > 0 ? { managedRepoResults } : {};
     })(),
-    ...(mergeTiming(a.timing, b.timing)),
+    ...mergeTiming(a.timing, b.timing),
   };
 }
 
@@ -217,8 +267,14 @@ function mergeTiming(
   b?: SyncResult['timing'],
 ): { timing: NonNullable<SyncResult['timing']> } | Record<string, never> {
   if (!a && !b) return {};
-  const aSteps = (a?.steps ?? []).map((s) => ({ ...s, label: `user:${s.label}` }));
-  const bSteps = (b?.steps ?? []).map((s) => ({ ...s, label: `project:${s.label}` }));
+  const aSteps = (a?.steps ?? []).map((s) => ({
+    ...s,
+    label: `user:${s.label}`,
+  }));
+  const bSteps = (b?.steps ?? []).map((s) => ({
+    ...s,
+    label: `project:${s.label}`,
+  }));
   return {
     timing: {
       totalMs: (a?.totalMs ?? 0) + (b?.totalMs ?? 0),
@@ -307,19 +363,31 @@ function resolveNativePluginSource(vp: ValidatedPlugin): {
   marketplaceSource?: string;
 } {
   if (!vp.registeredAs) {
-    return { spec: vp.plugin, ...(vp.marketplaceSource && { marketplaceSource: vp.marketplaceSource }) };
+    return {
+      spec: vp.plugin,
+      ...(vp.marketplaceSource && { marketplaceSource: vp.marketplaceSource }),
+    };
   }
 
   const parsed = parsePluginSpec(vp.plugin);
   if (!parsed) {
-    return { spec: vp.plugin, ...(vp.marketplaceSource && { marketplaceSource: vp.marketplaceSource }) };
+    return {
+      spec: vp.plugin,
+      ...(vp.marketplaceSource && { marketplaceSource: vp.marketplaceSource }),
+    };
   }
 
   const canonicalSpec = `${parsed.plugin}@${vp.registeredAs}`;
   if (parsed.owner && parsed.repo) {
-    return { spec: canonicalSpec, marketplaceSource: `${parsed.owner}/${parsed.repo}` };
+    return {
+      spec: canonicalSpec,
+      marketplaceSource: `${parsed.owner}/${parsed.repo}`,
+    };
   }
-  return { spec: canonicalSpec, ...(vp.marketplaceSource && { marketplaceSource: vp.marketplaceSource }) };
+  return {
+    spec: canonicalSpec,
+    ...(vp.marketplaceSource && { marketplaceSource: vp.marketplaceSource }),
+  };
 }
 
 /**
@@ -351,11 +419,20 @@ export function collectNativePluginSources(validPlugins: ValidatedPlugin[]): {
   return { pluginsByClient, marketplaceSourcesByClient };
 }
 
-function attachNativeClientContext(result: NativeSyncResult, clientType: ClientType): NativeSyncResult {
+function attachNativeClientContext(
+  result: NativeSyncResult,
+  clientType: ClientType,
+): NativeSyncResult {
   return {
     ...result,
-    pluginsInstalled: result.pluginsInstalled.map((installed) => ({ ...installed, client: clientType })),
-    pluginsFailed: result.pluginsFailed.map((failure) => ({ ...failure, client: clientType })),
+    pluginsInstalled: result.pluginsInstalled.map((installed) => ({
+      ...installed,
+      client: clientType,
+    })),
+    pluginsFailed: result.pluginsFailed.map((failure) => ({
+      ...failure,
+      client: clientType,
+    })),
   };
 }
 
@@ -364,7 +441,12 @@ export function collectSyncClients(
   plans: PluginSyncPlan[],
 ): ClientType[] {
   const workspaceClientTypes = getClientTypes(clientEntries);
-  return [...new Set([...workspaceClientTypes, ...plans.flatMap((plan) => [...plan.clients, ...plan.nativeClients])])];
+  return [
+    ...new Set([
+      ...workspaceClientTypes,
+      ...plans.flatMap((plan) => [...plan.clients, ...plan.nativeClients]),
+    ]),
+  ];
 }
 
 /**
@@ -450,22 +532,34 @@ export function getPurgePaths(
     const paths: string[] = [];
 
     // Check commands directory
-    if (mapping.commandsPath && existsSync(join(workspacePath, mapping.commandsPath))) {
+    if (
+      mapping.commandsPath &&
+      existsSync(join(workspacePath, mapping.commandsPath))
+    ) {
       paths.push(mapping.commandsPath);
     }
 
     // Check skills directory
-    if (mapping.skillsPath && existsSync(join(workspacePath, mapping.skillsPath))) {
+    if (
+      mapping.skillsPath &&
+      existsSync(join(workspacePath, mapping.skillsPath))
+    ) {
       paths.push(mapping.skillsPath);
     }
 
     // Check hooks directory
-    if (mapping.hooksPath && existsSync(join(workspacePath, mapping.hooksPath))) {
+    if (
+      mapping.hooksPath &&
+      existsSync(join(workspacePath, mapping.hooksPath))
+    ) {
       paths.push(mapping.hooksPath);
     }
 
     // Check agents directory
-    if (mapping.agentsPath && existsSync(join(workspacePath, mapping.agentsPath))) {
+    if (
+      mapping.agentsPath &&
+      existsSync(join(workspacePath, mapping.agentsPath))
+    ) {
       paths.push(mapping.agentsPath);
     }
 
@@ -564,7 +658,10 @@ export async function selectivePurgeWorkspace(
  * Clean up empty parent directories after file deletion
  * Stops at workspace root
  */
-async function cleanupEmptyParents(workspacePath: string, filePath: string): Promise<void> {
+async function cleanupEmptyParents(
+  workspacePath: string,
+  filePath: string,
+): Promise<void> {
   let parentPath = dirname(filePath);
 
   while (parentPath && parentPath !== '.' && parentPath !== '/') {
@@ -615,11 +712,20 @@ function isExplicitGitHubSourceForCollection(source: string): boolean {
   }
 
   // For shorthand format, require at least 3 segments (owner/repo/path)
-  if (!source.startsWith('.') && !source.startsWith('/') && source.includes('/')) {
+  if (
+    !source.startsWith('.') &&
+    !source.startsWith('/') &&
+    source.includes('/')
+  ) {
     const parts = source.split('/');
     if (parts.length >= 3) {
       const validOwnerRepo = /^[a-zA-Z0-9_.-]+$/;
-      if (parts[0] && parts[1] && validOwnerRepo.test(parts[0]) && validOwnerRepo.test(parts[1])) {
+      if (
+        parts[0] &&
+        parts[1] &&
+        validOwnerRepo.test(parts[0]) &&
+        validOwnerRepo.test(parts[1])
+      ) {
         return true;
       }
     }
@@ -675,7 +781,9 @@ async function fetchFileSourceRepos(
     if (result.success) {
       cache.set(repo.key, result.cachePath);
     } else {
-      errors.push(`Failed to fetch ${repo.key}: ${result.error || 'Unknown error'}`);
+      errors.push(
+        `Failed to fetch ${repo.key}: ${result.error || 'Unknown error'}`,
+      );
     }
   }
 
@@ -697,11 +805,20 @@ function isExplicitGitHubSourceForValidation(source: string): boolean {
   }
 
   // For shorthand format, require at least 3 segments (owner/repo/path)
-  if (!source.startsWith('.') && !source.startsWith('/') && source.includes('/')) {
+  if (
+    !source.startsWith('.') &&
+    !source.startsWith('/') &&
+    source.includes('/')
+  ) {
     const parts = source.split('/');
     if (parts.length >= 3) {
       const validOwnerRepo = /^[a-zA-Z0-9_.-]+$/;
-      if (parts[0] && parts[1] && validOwnerRepo.test(parts[0]) && validOwnerRepo.test(parts[1])) {
+      if (
+        parts[0] &&
+        parts[1] &&
+        validOwnerRepo.test(parts[0]) &&
+        validOwnerRepo.test(parts[1])
+      ) {
         return true;
       }
     }
@@ -728,7 +845,9 @@ function validateFileSources(
     if (typeof file === 'string') {
       // String entries are resolved relative to defaultSourcePath
       if (!defaultSourcePath) {
-        errors.push(`Cannot resolve file '${file}' - no workspace.source configured`);
+        errors.push(
+          `Cannot resolve file '${file}' - no workspace.source configured`,
+        );
         continue;
       }
       const fullPath = join(defaultSourcePath, file);
@@ -745,7 +864,9 @@ function validateFileSources(
         // GitHub source - validate path exists in cache
         const parsed = parseFileSource(file.source);
         if (!parsed.owner || !parsed.repo || !parsed.filePath) {
-          errors.push(`Invalid GitHub file source: ${file.source}. Must include path to file.`);
+          errors.push(
+            `Invalid GitHub file source: ${file.source}. Must include path to file.`,
+          );
           continue;
         }
         const cacheKey = `${parsed.owner}/${parsed.repo}`;
@@ -756,7 +877,9 @@ function validateFileSources(
         }
         const fullPath = join(cachePath, parsed.filePath);
         if (!existsSync(fullPath)) {
-          errors.push(`Path not found in repository: ${cacheKey}/${parsed.filePath}`);
+          errors.push(
+            `Path not found in repository: ${cacheKey}/${parsed.filePath}`,
+          );
         }
       } else {
         // Local path with explicit source
@@ -781,7 +904,9 @@ function validateFileSources(
     } else {
       // No explicit source - resolve relative to defaultSourcePath
       if (!defaultSourcePath) {
-        errors.push(`Cannot resolve file '${file.dest}' - no workspace.source configured and no explicit source provided`);
+        errors.push(
+          `Cannot resolve file '${file.dest}' - no workspace.source configured and no explicit source provided`,
+        );
         continue;
       }
       const fullPath = join(defaultSourcePath, file.dest ?? '');
@@ -827,7 +952,10 @@ export function collectSyncedPaths(
     }
 
     // Get relative path from workspace (normalize to forward slashes for cross-platform consistency)
-    const relativePath = relative(workspacePath, copyResult.destination).replace(/\\/g, '/');
+    const relativePath = relative(
+      workspacePath,
+      copyResult.destination,
+    ).replace(/\\/g, '/');
 
     // Track file for ALL clients whose paths match (not just the first one)
     // This is important when multiple clients share the same skillsPath
@@ -846,15 +974,16 @@ export function collectSyncedPaths(
         }
       }
 
-
       // Check if file belongs to this client's paths
       if (
-        (mapping.commandsPath && relativePath.startsWith(mapping.commandsPath)) ||
+        (mapping.commandsPath &&
+          relativePath.startsWith(mapping.commandsPath)) ||
         (mapping.skillsPath && relativePath.startsWith(mapping.skillsPath)) ||
         (mapping.hooksPath && relativePath.startsWith(mapping.hooksPath)) ||
         (mapping.agentsPath && relativePath.startsWith(mapping.agentsPath)) ||
         relativePath === mapping.agentFile ||
-        (mapping.agentFileFallback && relativePath === mapping.agentFileFallback)
+        (mapping.agentFileFallback &&
+          relativePath === mapping.agentFileFallback)
       ) {
         result[client]?.push(relativePath);
         // Don't break - continue checking other clients that might share this path
@@ -945,7 +1074,8 @@ export function computeDeletedArtifacts(
       if (!artifact) continue;
 
       // Skip skills that still exist in installed plugins but are just disabled
-      if (artifact.type === 'skill' && availableSkillNames?.has(artifact.name)) continue;
+      if (artifact.type === 'skill' && availableSkillNames?.has(artifact.name))
+        continue;
 
       const key = `${client}:${artifact.type}:${artifact.name}`;
       if (!seen.has(key)) {
@@ -975,7 +1105,6 @@ async function collectAvailableSkillNames(
   }
   return names;
 }
-
 
 /**
  * Validate a single plugin by resolving its path without copying
@@ -1012,7 +1141,9 @@ async function validatePlugin(
       nativeClients: [],
       ...(resolved.pluginName && { pluginName: resolved.pluginName }),
       ...(resolved.registeredAs && { registeredAs: resolved.registeredAs }),
-      ...(resolved.marketplaceSource && { marketplaceSource: resolved.marketplaceSource }),
+      ...(resolved.marketplaceSource && {
+        marketplaceSource: resolved.marketplaceSource,
+      }),
     };
   }
 
@@ -1099,9 +1230,9 @@ export function buildPluginSyncPlans(
 
     for (const client of effectiveClients) {
       const clientEntry = normalizeClientEntry(
-        clientEntries.find((e) =>
-          (typeof e === 'string' ? e : e.name) === client
-        ) ?? client
+        clientEntries.find(
+          (e) => (typeof e === 'string' ? e : e.name) === client,
+        ) ?? client,
       );
       const mode = resolveInstallMode(plugin, clientEntry);
 
@@ -1112,7 +1243,9 @@ export function buildPluginSyncPlans(
           nativeClients.push(client);
         } else {
           fileClients.push(client);
-          warnings.push(`${client} native install only supports user scope, falling back to file copy`);
+          warnings.push(
+            `${client} native install only supports user scope, falling back to file copy`,
+          );
         }
       } else {
         fileClients.push(client);
@@ -1120,7 +1253,8 @@ export function buildPluginSyncPlans(
     }
 
     const exclude = getPluginExclude(plugin);
-    const pluginSkillsConfig = typeof plugin === 'string' ? undefined : plugin.skills;
+    const pluginSkillsConfig =
+      typeof plugin === 'string' ? undefined : plugin.skills;
     return {
       source,
       clients: fileClients,
@@ -1146,13 +1280,26 @@ export async function validateAllPlugins(
   offline: boolean,
 ): Promise<ValidatedPlugin[]> {
   return Promise.all(
-    plans.map(async ({ source, clients, nativeClients, exclude, pluginSkillsConfig }) => {
-      const validated = await validatePlugin(source, workspacePath, offline);
-      const result: ValidatedPlugin = { ...validated, clients, nativeClients };
-      if (exclude) result.exclude = exclude;
-      if (pluginSkillsConfig !== undefined) result.pluginSkillsConfig = pluginSkillsConfig;
-      return result;
-    }),
+    plans.map(
+      async ({
+        source,
+        clients,
+        nativeClients,
+        exclude,
+        pluginSkillsConfig,
+      }) => {
+        const validated = await validatePlugin(source, workspacePath, offline);
+        const result: ValidatedPlugin = {
+          ...validated,
+          clients,
+          nativeClients,
+        };
+        if (exclude) result.exclude = exclude;
+        if (pluginSkillsConfig !== undefined)
+          result.pluginSkillsConfig = pluginSkillsConfig;
+        return result;
+      },
+    ),
   );
 }
 
@@ -1186,7 +1333,10 @@ async function copyValidatedPlugin(
   syncMode: SyncMode = 'symlink',
 ): Promise<PluginSyncResult> {
   const copyResults: CopyResult[] = [];
-  const mappings = resolveClientMappings(clients, clientMappings ?? CLIENT_MAPPINGS);
+  const mappings = resolveClientMappings(
+    clients,
+    clientMappings ?? CLIENT_MAPPINGS,
+  );
   const clientList = clients;
 
   const exclude = validatedPlugin.exclude;
@@ -1198,7 +1348,10 @@ async function copyValidatedPlugin(
     //
     // Phase 1: Copy skills to canonical location using deduplication
     // This ensures canonical is only copied once, and tracked under the universal client
-    const { representativeClients } = deduplicateClientsByPath(clientList, mappings);
+    const { representativeClients } = deduplicateClientsByPath(
+      clientList,
+      mappings,
+    );
 
     // Phase 2: Copy for each representative client
     for (const representative of representativeClients) {
@@ -1237,7 +1390,10 @@ async function copyValidatedPlugin(
     }
   } else {
     // No universal client or copy mode: copy directly to each client's path
-    const { representativeClients } = deduplicateClientsByPath(clientList, mappings);
+    const { representativeClients } = deduplicateClientsByPath(
+      clientList,
+      mappings,
+    );
 
     for (const client of representativeClients) {
       const results = await copyPluginToWorkspace(
@@ -1396,7 +1552,10 @@ function generateVscodeWorkspaceFile(
   return contentStr;
 }
 
-function failedSyncResult(error: string, overrides?: Partial<SyncResult>): SyncResult {
+function failedSyncResult(
+  error: string,
+  overrides?: Partial<SyncResult>,
+): SyncResult {
   return {
     success: false,
     pluginResults: [],
@@ -1409,11 +1568,15 @@ function failedSyncResult(error: string, overrides?: Partial<SyncResult>): SyncR
   };
 }
 
-
 function countCopyResults(
   pluginResults: PluginSyncResult[],
   workspaceFileResults: CopyResult[],
-): { totalCopied: number; totalFailed: number; totalSkipped: number; totalGenerated: number } {
+): {
+  totalCopied: number;
+  totalFailed: number;
+  totalSkipped: number;
+  totalGenerated: number;
+} {
   let totalCopied = 0;
   let totalFailed = 0;
   let totalSkipped = 0;
@@ -1471,13 +1634,17 @@ async function syncNativePlugins(
 
   const previousNativeClients = previousState?.nativePlugins
     ? (Object.keys(previousState.nativePlugins) as ClientType[]).filter(
-        (c) => (previousState.nativePlugins?.[c]?.length ?? 0) > 0
+        (c) => (previousState.nativePlugins?.[c]?.length ?? 0) > 0,
       )
     : [];
-  const hasNativeWork = nativePluginsByClient.size > 0 || previousNativeClients.length > 0;
+  const hasNativeWork =
+    nativePluginsByClient.size > 0 || previousNativeClients.length > 0;
 
   if (hasNativeWork && !dryRun) {
-    const allClients = new Set([...nativePluginsByClient.keys(), ...previousNativeClients]);
+    const allClients = new Set([
+      ...nativePluginsByClient.keys(),
+      ...previousNativeClients,
+    ]);
     const perClientResults: NativeSyncResult[] = [];
 
     for (const clientType of allClients) {
@@ -1485,7 +1652,9 @@ async function syncNativePlugins(
       if (!nativeClient) {
         const sources = nativePluginsByClient.get(clientType);
         if (sources && sources.length > 0) {
-          warnings.push(`Native install: no native client for ${clientType}, skipping`);
+          warnings.push(
+            `Native install: no native client for ${clientType}, skipping`,
+          );
         }
         continue;
       }
@@ -1494,7 +1663,9 @@ async function syncNativePlugins(
       if (!cliAvailable) {
         const sources = nativePluginsByClient.get(clientType);
         if (sources && sources.length > 0) {
-          messages.push(`Native install: ${clientType} CLI not found, skipping native plugin installation`);
+          messages.push(
+            `Native install: ${clientType} CLI not found, skipping native plugin installation`,
+          );
         }
         continue;
       }
@@ -1514,22 +1685,30 @@ async function syncNativePlugins(
       const currentSpecs = currentSources
         .map((s) => nativeClient.toPluginSpec(s))
         .filter((s): s is string => s !== null);
-      const previousPlugins = getPreviouslySyncedNativePlugins(previousState, clientType);
+      const previousPlugins = getPreviouslySyncedNativePlugins(
+        previousState,
+        clientType,
+      );
       const removed = previousPlugins.filter((p) => !currentSpecs.includes(p));
       for (const plugin of removed) {
         try {
           if (scope === 'project') {
-            await nativeClient.uninstallPlugin(plugin, 'project', { cwd: workspacePath });
+            await nativeClient.uninstallPlugin(plugin, 'project', {
+              cwd: workspacePath,
+            });
           } else {
             await nativeClient.uninstallPlugin(plugin, 'user');
           }
         } catch (err) {
-          warnings.push(`Native uninstall failed for ${plugin}: ${err instanceof Error ? err.message : String(err)}`);
+          warnings.push(
+            `Native uninstall failed for ${plugin}: ${err instanceof Error ? err.message : String(err)}`,
+          );
         }
       }
 
       if (currentSources.length > 0) {
-        const syncOpts = scope === 'project' ? { cwd: workspacePath } : undefined;
+        const syncOpts =
+          scope === 'project' ? { cwd: workspacePath } : undefined;
         perClientResults.push(
           attachNativeClientContext(
             await nativeClient.syncPlugins(currentSources, scope, syncOpts),
@@ -1547,9 +1726,10 @@ async function syncNativePlugins(
     for (const [clientType, sources] of nativePluginsByClient) {
       const nativeClient = getNativeClient(clientType);
       if (nativeClient && sources.length > 0) {
-        const syncOpts = scope === 'project'
-          ? { cwd: workspacePath, dryRun: true }
-          : { dryRun: true };
+        const syncOpts =
+          scope === 'project'
+            ? { cwd: workspacePath, dryRun: true }
+            : { dryRun: true };
         perClientResults.push(
           attachNativeClientContext(
             await nativeClient.syncPlugins(sources, scope, syncOpts),
@@ -1575,7 +1755,10 @@ async function syncVscodeWorkspaceFile(
 ): Promise<{ config: WorkspaceConfig; hash?: string; repos?: string[] }> {
   // Reconcile .code-workspace -> workspace.yaml if the file was externally modified
   let updatedConfig = config;
-  if (previousState?.vscodeWorkspaceHash && previousState?.vscodeWorkspaceRepos) {
+  if (
+    previousState?.vscodeWorkspaceHash &&
+    previousState?.vscodeWorkspaceRepos
+  ) {
     const outputPath = getWorkspaceOutputPath(workspacePath, config.vscode);
     if (existsSync(outputPath)) {
       const existingContent = readFileSync(outputPath, 'utf-8');
@@ -1584,7 +1767,9 @@ async function syncVscodeWorkspaceFile(
       if (currentHash !== previousState.vscodeWorkspaceHash) {
         try {
           const existingWorkspace = JSON.parse(existingContent);
-          const folders = Array.isArray(existingWorkspace.folders) ? existingWorkspace.folders : [];
+          const folders = Array.isArray(existingWorkspace.folders)
+            ? existingWorkspace.folders
+            : [];
 
           const reconciled = reconcileVscodeWorkspaceFolders(
             workspacePath,
@@ -1598,25 +1783,37 @@ async function syncVscodeWorkspaceFile(
             reconciled.removed.length > 0 ||
             reconciled.renamed.length > 0
           ) {
-            const updateResult = reconciled.renamed.length > 0
-              ? await setRepositories(reconciled.updatedRepos, workspacePath)
-              : await updateRepositories(
-                  { remove: reconciled.removed, add: reconciled.added.map(p => ({ path: p })) },
-                  workspacePath,
-                );
+            const updateResult =
+              reconciled.renamed.length > 0
+                ? await setRepositories(reconciled.updatedRepos, workspacePath)
+                : await updateRepositories(
+                    {
+                      remove: reconciled.removed,
+                      add: reconciled.added.map((p) => ({ path: p })),
+                    },
+                    workspacePath,
+                  );
             if (!updateResult.success) {
-              throw new Error(updateResult.error ?? 'Failed to update repositories');
+              throw new Error(
+                updateResult.error ?? 'Failed to update repositories',
+              );
             }
             updatedConfig = await parseWorkspaceConfig(configPath);
 
             if (reconciled.removed.length > 0) {
-              messages.push(`Repositories removed (from .code-workspace): ${reconciled.removed.join(', ')}`);
+              messages.push(
+                `Repositories removed (from .code-workspace): ${reconciled.removed.join(', ')}`,
+              );
             }
             if (reconciled.added.length > 0) {
-              messages.push(`Repositories added (from .code-workspace): ${reconciled.added.join(', ')}`);
+              messages.push(
+                `Repositories added (from .code-workspace): ${reconciled.added.join(', ')}`,
+              );
             }
             if (reconciled.renamed.length > 0) {
-              messages.push(`Repository names updated (from .code-workspace): ${reconciled.renamed.join(', ')}`);
+              messages.push(
+                `Repository names updated (from .code-workspace): ${reconciled.renamed.join(', ')}`,
+              );
             }
           }
         } catch {
@@ -1627,10 +1824,13 @@ async function syncVscodeWorkspaceFile(
   }
 
   // Generate .code-workspace (always, even after reconciliation)
-  const writtenContent = generateVscodeWorkspaceFile(workspacePath, updatedConfig);
+  const writtenContent = generateVscodeWorkspaceFile(
+    workspacePath,
+    updatedConfig,
+  );
   const hash = computeWorkspaceHash(writtenContent);
-  const repos = updatedConfig.repositories.map(
-    r => resolve(workspacePath, r.path).replace(/\\/g, '/'),
+  const repos = updatedConfig.repositories.map((r) =>
+    resolve(workspacePath, r.path).replace(/\\/g, '/'),
   );
 
   return { config: updatedConfig, hash, repos };
@@ -1657,11 +1857,18 @@ async function persistSyncState(
 
   const mappings = extra?.clientMappings ?? CLIENT_MAPPINGS;
   const resolvedMappings = resolveClientMappings(syncClients, mappings);
-  const syncedFiles = collectSyncedPaths(allCopyResults, workspacePath, syncClients, resolvedMappings);
+  const syncedFiles = collectSyncedPaths(
+    allCopyResults,
+    workspacePath,
+    syncClients,
+    resolvedMappings,
+  );
 
   // Build native plugin tracking per-client
   const nativePluginsState: Partial<Record<ClientType, string[]>> = {};
-  const installedSet = new Set((nativeResult?.pluginsInstalled ?? []).map((p) => p.plugin));
+  const installedSet = new Set(
+    (nativeResult?.pluginsInstalled ?? []).map((p) => p.plugin),
+  );
   for (const [client, sources] of nativePluginsByClient) {
     const nativeClient = getNativeClient(client);
     if (!nativeClient) continue;
@@ -1675,11 +1882,18 @@ async function persistSyncState(
 
   await saveSyncState(workspacePath, {
     files: syncedFiles,
-    ...(Object.keys(nativePluginsState).length > 0 && { nativePlugins: nativePluginsState }),
-    ...(extra?.vscodeState?.hash && { vscodeWorkspaceHash: extra.vscodeState.hash }),
-    ...(extra?.vscodeState?.repos && { vscodeWorkspaceRepos: extra.vscodeState.repos }),
+    ...(Object.keys(nativePluginsState).length > 0 && {
+      nativePlugins: nativePluginsState,
+    }),
+    ...(extra?.vscodeState?.hash && {
+      vscodeWorkspaceHash: extra.vscodeState.hash,
+    }),
+    ...(extra?.vscodeState?.repos && {
+      vscodeWorkspaceRepos: extra.vscodeState.repos,
+    }),
     ...(extra?.mcpTrackedServers && { mcpServers: extra.mcpTrackedServers }),
-    ...(extra?.skillsIndex && extra.skillsIndex.length > 0 && { skillsIndex: extra.skillsIndex }),
+    ...(extra?.skillsIndex &&
+      extra.skillsIndex.length > 0 && { skillsIndex: extra.skillsIndex }),
   });
 }
 
@@ -1703,7 +1917,13 @@ export async function syncWorkspace(
   // MIGRATION: v1→v2 - remove after v3 release
   await migrateWorkspaceSkillsV1toV2(workspacePath);
 
-  const { offline = false, dryRun = false, workspaceSourceBase, skipAgentFiles = false, skipManaged = false } = options;
+  const {
+    offline = false,
+    dryRun = false,
+    workspaceSourceBase,
+    skipAgentFiles = false,
+    skipManaged = false,
+  } = options;
   const sw = new Stopwatch();
   const configDir = join(workspacePath, CONFIG_DIR);
   const configPath = join(configDir, WORKSPACE_CONFIG_FILE);
@@ -1733,12 +1953,18 @@ export async function syncWorkspace(
     getProjectRegistryPath(workspacePath),
   );
   for (const name of overrides) {
-    console.warn(`Warning: Workspace marketplace '${name}' overrides user marketplace of the same name.`);
+    console.warn(
+      `Warning: Workspace marketplace '${name}' overrides user marketplace of the same name.`,
+    );
   }
 
   // Step 0a: Process managed repositories (clone/pull) before anything else
   const managedRepoResults = await sw.measure('managed-repos', () =>
-    processManagedRepos(config.repositories ?? [], workspacePath, { offline, skipManaged, dryRun }),
+    processManagedRepos(config.repositories ?? [], workspacePath, {
+      offline,
+      skipManaged,
+      dryRun,
+    }),
   );
   const managedWarnings = managedRepoResults
     .filter((r) => r.error)
@@ -1754,7 +1980,9 @@ export async function syncWorkspace(
     'project',
   );
   const workspaceClients = config.clients;
-  const filteredPlans = pluginPlans.filter((plan) => plan.clients.length > 0 || plan.nativeClients.length > 0);
+  const filteredPlans = pluginPlans.filter(
+    (plan) => plan.clients.length > 0 || plan.nativeClients.length > 0,
+  );
   const syncClients = collectSyncClients(workspaceClients, filteredPlans);
 
   // Warn when no clients are configured — the sync will succeed but create no artifacts
@@ -1767,7 +1995,7 @@ export async function syncWorkspace(
       totalSkipped: 0,
       totalGenerated: 0,
       warnings: [
-        'No clients configured in workspace.yaml — no artifacts were synced. Add clients to workspace.yaml or run \'allagents workspace init\' to configure.',
+        "No clients configured in workspace.yaml — no artifacts were synced. Add clients to workspace.yaml or run 'allagents workspace init' to configure.",
       ],
     };
   }
@@ -1781,8 +2009,9 @@ export async function syncWorkspace(
   await seedFetchCacheFromMarketplaces(marketplaceResults);
 
   // Step 1: Validate all plugins before any destructive action
-  const validatedPlugins = await sw.measure('plugin-validation', () =>
-    validateAllPlugins(filteredPlans, workspacePath, offline),
+  const validatedPlugins = await sw.measure(
+    'plugin-validation',
+    () => validateAllPlugins(filteredPlans, workspacePath, offline),
     `${filteredPlans.length} plugin(s)`,
   );
 
@@ -1803,9 +2032,7 @@ export async function syncWorkspace(
       validatedWorkspaceSource = wsSourceResult;
     } else {
       // Non-blocking: warn but continue syncing plugins
-      workspaceSourceWarnings.push(
-        `Workspace source: ${wsSourceResult.error}`,
-      );
+      workspaceSourceWarnings.push(`Workspace source: ${wsSourceResult.error}`);
     }
     sw.stop('workspace-source-validation');
   }
@@ -1854,8 +2081,13 @@ export async function syncWorkspace(
   // Pass 1: Collect all skills from all plugins (excluding disabled/non-enabled skills)
   // v1 fallback: only use top-level disabledSkills/enabledSkills for configs that haven't migrated
   const isV1Fallback = config.version === undefined || config.version < 2;
-  const disabledSkillsSet = isV1Fallback ? new Set(config.disabledSkills ?? []) : undefined;
-  const enabledSkillsSet = isV1Fallback && config.enabledSkills ? new Set(config.enabledSkills) : undefined;
+  const disabledSkillsSet = isV1Fallback
+    ? new Set(config.disabledSkills ?? [])
+    : undefined;
+  const enabledSkillsSet =
+    isV1Fallback && config.enabledSkills
+      ? new Set(config.enabledSkills)
+      : undefined;
   const allSkills = await sw.measure('skill-collection', () =>
     collectAllSkills(validPlugins, disabledSkillsSet, enabledSkillsSet),
   );
@@ -1867,28 +2099,38 @@ export async function syncWorkspace(
   // Pass 2: Copy skills using resolved names
   // Use syncMode from config (defaults to 'symlink')
   const syncMode = config.syncMode ?? 'symlink';
-  const pluginResults = await sw.measure('plugin-copy', () =>
-    Promise.all(
-      validPlugins.map(async (validatedPlugin) => {
-        const skillNameMap = pluginSkillMaps.get(validatedPlugin.resolved);
-        const result = await copyValidatedPlugin(
-          validatedPlugin,
-          workspacePath,
-          validatedPlugin.clients,
-          dryRun,
-          skillNameMap,
-          undefined, // clientMappings
-          syncMode,
-        );
-        return { ...result, scope: 'project' as const };
-      }),
-    ),
+  const pluginResults = await sw.measure(
+    'plugin-copy',
+    () =>
+      Promise.all(
+        validPlugins.map(async (validatedPlugin) => {
+          const skillNameMap = pluginSkillMaps.get(validatedPlugin.resolved);
+          const result = await copyValidatedPlugin(
+            validatedPlugin,
+            workspacePath,
+            validatedPlugin.clients,
+            dryRun,
+            skillNameMap,
+            undefined, // clientMappings
+            syncMode,
+          );
+          return { ...result, scope: 'project' as const };
+        }),
+      ),
     `${validPlugins.length} plugin(s)`,
   );
 
   // Step 4b: Native CLI installations
   const nativeResult = await sw.measure('native-plugin-sync', () =>
-    syncNativePlugins(validPlugins, previousState, 'project', workspacePath, dryRun, warnings, messages),
+    syncNativePlugins(
+      validPlugins,
+      previousState,
+      'project',
+      workspacePath,
+      dryRun,
+      warnings,
+      messages,
+    ),
   );
 
   // Step 5: Copy workspace files if configured
@@ -1896,7 +2138,8 @@ export async function syncWorkspace(
   // Skip when workspace.source was configured but validation failed (plugins still synced above)
   let workspaceFileResults: CopyResult[] = [];
   let writtenSkillsIndexFiles: string[] = [];
-  const skipWorkspaceFiles = !!config.workspace?.source && !validatedWorkspaceSource;
+  const skipWorkspaceFiles =
+    !!config.workspace?.source && !validatedWorkspaceSource;
   if (config.workspace && !skipWorkspaceFiles) {
     sw.start('workspace-files');
     const sourcePath = validatedWorkspaceSource?.resolved;
@@ -1930,7 +2173,11 @@ export async function syncWorkspace(
     }
 
     // Step 5b: Validate all file sources exist before copying
-    const fileValidationErrors = validateFileSources(filesToCopy, sourcePath, githubCache);
+    const fileValidationErrors = validateFileSources(
+      filesToCopy,
+      sourcePath,
+      githubCache,
+    );
     if (fileValidationErrors.length > 0) {
       return failedSyncResult(
         `File source validation failed (workspace unchanged):\n${fileValidationErrors.map((e) => `  - ${e}`).join('\n')}`,
@@ -1939,9 +2186,14 @@ export async function syncWorkspace(
     }
 
     // Step 5c: Discover skills from workspace repositories
-    const repoSkills = hasRepositories && !dryRun
-      ? await discoverWorkspaceSkills(workspacePath, config.repositories, syncClients as string[])
-      : [];
+    const repoSkills =
+      hasRepositories && !dryRun
+        ? await discoverWorkspaceSkills(
+            workspacePath,
+            config.repositories,
+            syncClients as string[],
+          )
+        : [];
 
     // Step 5c.1: Write skills-index files and clean up stale ones
     let skillsIndexRefs: { repoName: string; indexPath: string }[] = [];
@@ -1962,18 +2214,32 @@ export async function syncWorkspace(
       sourcePath,
       workspacePath,
       filesToCopy,
-      { dryRun, githubCache, repositories: config.repositories, skillsIndexRefs },
+      {
+        dryRun,
+        githubCache,
+        repositories: config.repositories,
+        skillsIndexRefs,
+      },
     );
 
     // If claude is a client and CLAUDE.md doesn't exist, copy AGENTS.md to CLAUDE.md
     // Skip when repositories is empty (no agent files should be created)
-    if (hasRepositories && !dryRun && syncClients.includes('claude') && sourcePath) {
+    if (
+      hasRepositories &&
+      !dryRun &&
+      syncClients.includes('claude') &&
+      sourcePath
+    ) {
       const claudePath = join(workspacePath, 'CLAUDE.md');
       const agentsPath = join(workspacePath, 'AGENTS.md');
       const claudeExistsInSource = existsSync(join(sourcePath, 'CLAUDE.md'));
 
       // Only copy if CLAUDE.md wasn't in source and AGENTS.md exists
-      if (!claudeExistsInSource && existsSync(agentsPath) && !existsSync(claudePath)) {
+      if (
+        !claudeExistsInSource &&
+        existsSync(agentsPath) &&
+        !existsSync(claudePath)
+      ) {
         await copyFile(agentsPath, claudePath);
       }
     }
@@ -1992,7 +2258,13 @@ export async function syncWorkspace(
   let vscodeState: { hash: string; repos: string[] } | undefined;
   if (syncClients.includes('vscode') && !dryRun) {
     const result = await sw.measure('vscode-workspace-file', () =>
-      syncVscodeWorkspaceFile(workspacePath, config, configPath, previousState, messages),
+      syncVscodeWorkspaceFile(
+        workspacePath,
+        config,
+        configPath,
+        previousState,
+        messages,
+      ),
     );
     config = result.config;
     if (result.hash && result.repos) {
@@ -2012,38 +2284,65 @@ export async function syncWorkspace(
     syncClients,
     { dryRun },
   );
-  const mcpResults: Record<string, McpMergeResult> = { ...mcpSyncResult.mcpResults };
+  const mcpResults: Record<string, McpMergeResult> = {
+    ...mcpSyncResult.mcpResults,
+  };
   warnings.push(...mcpSyncResult.warnings);
   sw.stop('mcp-sync');
 
   // Count results
-  const { totalCopied, totalFailed, totalSkipped, totalGenerated } = countCopyResults(pluginResults, workspaceFileResults);
+  const { totalCopied, totalFailed, totalSkipped, totalGenerated } =
+    countCopyResults(pluginResults, workspaceFileResults);
   const hasFailures = pluginResults.some((r) => !r.success) || totalFailed > 0;
 
   // Compute deleted artifacts: compare previous state vs what was just synced
   // Collect all skill names from installed plugins (including disabled) so that
   // skills that are still available but just not synced are not reported as deleted.
   const availableSkillNames = await collectAvailableSkillNames(validPlugins);
-  const allCopyResultsForState = [...pluginResults.flatMap((r) => r.copyResults), ...workspaceFileResults];
+  const allCopyResultsForState = [
+    ...pluginResults.flatMap((r) => r.copyResults),
+    ...workspaceFileResults,
+  ];
   const resolvedMappings = resolveClientMappings(syncClients, CLIENT_MAPPINGS);
-  const newStatePaths = collectSyncedPaths(allCopyResultsForState, workspacePath, syncClients, resolvedMappings);
-  const deletedArtifacts = computeDeletedArtifacts(previousState, newStatePaths, syncClients, resolvedMappings, availableSkillNames);
+  const newStatePaths = collectSyncedPaths(
+    allCopyResultsForState,
+    workspacePath,
+    syncClients,
+    resolvedMappings,
+  );
+  const deletedArtifacts = computeDeletedArtifacts(
+    previousState,
+    newStatePaths,
+    syncClients,
+    resolvedMappings,
+    availableSkillNames,
+  );
 
   // Persist sync state (skip in dry-run mode)
-  const { pluginsByClient: nativePluginsByClient } = collectNativePluginSources(validPlugins);
+  const { pluginsByClient: nativePluginsByClient } =
+    collectNativePluginSources(validPlugins);
   if (!dryRun) {
     await sw.measure('persist-state', () =>
       persistSyncState(
-        workspacePath, pluginResults, workspaceFileResults, syncClients,
-        nativePluginsByClient, nativeResult,
+        workspacePath,
+        pluginResults,
+        workspaceFileResults,
+        syncClients,
+        nativePluginsByClient,
+        nativeResult,
         {
           ...(vscodeState && { vscodeState }),
           ...(Object.keys(mcpResults).length > 0 && {
             mcpTrackedServers: Object.fromEntries(
-              Object.entries(mcpResults).map(([scope, r]) => [scope, r.trackedServers]),
+              Object.entries(mcpResults).map(([scope, r]) => [
+                scope,
+                r.trackedServers,
+              ]),
             ),
           }),
-          ...(writtenSkillsIndexFiles.length > 0 && { skillsIndex: writtenSkillsIndexFiles }),
+          ...(writtenSkillsIndexFiles.length > 0 && {
+            skillsIndex: writtenSkillsIndexFiles,
+          }),
         },
       ),
     );
@@ -2140,7 +2439,8 @@ export async function syncUserWorkspace(
   const workspaceClients = config.clients;
   const { offline = false, dryRun = false, force = false } = options;
 
-  const { plans: allPluginPlans, warnings: planWarnings } = buildPluginSyncPlans(config.plugins, workspaceClients, 'user');
+  const { plans: allPluginPlans, warnings: planWarnings } =
+    buildPluginSyncPlans(config.plugins, workspaceClients, 'user');
   const pluginPlans = allPluginPlans.filter(
     (plan) => plan.clients.length > 0 || plan.nativeClients.length > 0,
   );
@@ -2155,8 +2455,9 @@ export async function syncUserWorkspace(
   await seedFetchCacheFromMarketplaces(marketplaceResults);
 
   // Validate all plugins
-  const validatedPlugins = await sw.measure('plugin-validation', () =>
-    validateAllPlugins(pluginPlans, homeDir, offline),
+  const validatedPlugins = await sw.measure(
+    'plugin-validation',
+    () => validateAllPlugins(pluginPlans, homeDir, offline),
     `${pluginPlans.length} plugin(s)`,
   );
   const failedValidations = validatedPlugins.filter((v) => !v.success);
@@ -2188,8 +2489,13 @@ export async function syncUserWorkspace(
   // Two-pass skill name resolution (excluding disabled/non-enabled skills)
   // v1 fallback: only use top-level disabledSkills/enabledSkills for configs that haven't migrated
   const isV1FallbackUser = config.version === undefined || config.version < 2;
-  const disabledSkillsSet = isV1FallbackUser ? new Set(config.disabledSkills ?? []) : undefined;
-  const enabledSkillsSet = isV1FallbackUser && config.enabledSkills ? new Set(config.enabledSkills) : undefined;
+  const disabledSkillsSet = isV1FallbackUser
+    ? new Set(config.disabledSkills ?? [])
+    : undefined;
+  const enabledSkillsSet =
+    isV1FallbackUser && config.enabledSkills
+      ? new Set(config.enabledSkills)
+      : undefined;
   const allSkills = await sw.measure('skill-collection', () =>
     collectAllSkills(validPlugins, disabledSkillsSet, enabledSkillsSet),
   );
@@ -2198,31 +2504,38 @@ export async function syncUserWorkspace(
   // Copy plugins using USER_CLIENT_MAPPINGS
   // Use syncMode from config (defaults to 'symlink')
   const syncMode = config.syncMode ?? 'symlink';
-  const pluginResults = await sw.measure('plugin-copy', () =>
-    Promise.all(
-      validPlugins.map(async (vp) => {
-        const skillNameMap = pluginSkillMaps.get(vp.resolved);
-        const resolvedUserMappings = resolveClientMappings(vp.clients, USER_CLIENT_MAPPINGS);
-        const result = await copyValidatedPlugin(vp, homeDir, vp.clients, dryRun, skillNameMap, resolvedUserMappings, syncMode);
-        return { ...result, scope: 'user' as const };
-      }),
-    ),
+  const pluginResults = await sw.measure(
+    'plugin-copy',
+    () =>
+      Promise.all(
+        validPlugins.map(async (vp) => {
+          const skillNameMap = pluginSkillMaps.get(vp.resolved);
+          const resolvedUserMappings = resolveClientMappings(
+            vp.clients,
+            USER_CLIENT_MAPPINGS,
+          );
+          const result = await copyValidatedPlugin(
+            vp,
+            homeDir,
+            vp.clients,
+            dryRun,
+            skillNameMap,
+            resolvedUserMappings,
+            syncMode,
+          );
+          return { ...result, scope: 'user' as const };
+        }),
+      ),
     `${validPlugins.length} plugin(s)`,
   );
 
   // Count results
-  const { totalCopied, totalFailed, totalSkipped, totalGenerated } = countCopyResults(pluginResults, []);
+  const { totalCopied, totalFailed, totalSkipped, totalGenerated } =
+    countCopyResults(pluginResults, []);
 
   // MCP Proxy: prepare transform if configured (user-scoped)
   const userMcpProxyConfig = config.mcpProxy;
   const userWorkspaceMcpServers = config.mcpServers;
-  let userProxyMetadataPath: string | undefined;
-  if (userMcpProxyConfig) {
-    if (!dryRun) {
-      ensureProxyMetadata();
-    }
-    userProxyMetadataPath = getProxyMetadataPath();
-  }
 
   // Emit collection warnings once across all user-scoped client syncs.
   let userCollectWarningsEmitted = false;
@@ -2236,8 +2549,8 @@ export async function syncUserWorkspace(
       warnings.push(...collectWarnings);
       userCollectWarningsEmitted = true;
     }
-    if (userMcpProxyConfig && userProxyMetadataPath) {
-      return applyMcpProxy(servers, client, userMcpProxyConfig, userProxyMetadataPath);
+    if (userMcpProxyConfig) {
+      return applyMcpProxy(servers, client, userMcpProxyConfig);
     }
     return servers;
   }
@@ -2246,7 +2559,10 @@ export async function syncUserWorkspace(
   sw.start('mcp-sync');
   const mcpResults: Record<string, McpMergeResult> = {};
   if (syncClients.includes('vscode')) {
-    const trackedMcpServers = getPreviouslySyncedMcpServers(previousState, 'vscode');
+    const trackedMcpServers = getPreviouslySyncedMcpServers(
+      previousState,
+      'vscode',
+    );
     const vscodeMcpOverrides = getUserServersForClient('vscode');
     const vscodeMcp = syncVscodeMcpConfig(validPlugins, {
       dryRun,
@@ -2262,7 +2578,10 @@ export async function syncUserWorkspace(
 
   // Sync MCP servers to Codex CLI if codex client is configured
   if (syncClients.includes('codex')) {
-    const trackedMcpServers = getPreviouslySyncedMcpServers(previousState, 'codex');
+    const trackedMcpServers = getPreviouslySyncedMcpServers(
+      previousState,
+      'codex',
+    );
     const codexMcpOverrides = getUserServersForClient('codex');
     const codexMcp = await syncCodexMcpServers(validPlugins, {
       dryRun,
@@ -2277,7 +2596,10 @@ export async function syncUserWorkspace(
 
   // Sync MCP servers to Claude Code via CLI if claude client is configured
   if (syncClients.includes('claude')) {
-    const trackedMcpServers = getPreviouslySyncedMcpServers(previousState, 'claude');
+    const trackedMcpServers = getPreviouslySyncedMcpServers(
+      previousState,
+      'claude',
+    );
     const claudeMcpOverrides = getUserServersForClient('claude');
     const claudeMcp = await syncClaudeMcpServersViaCli(validPlugins, {
       dryRun,
@@ -2292,7 +2614,10 @@ export async function syncUserWorkspace(
 
   // Sync MCP servers to Copilot CLI config if copilot client is configured
   if (syncClients.includes('copilot')) {
-    const trackedMcpServers = getPreviouslySyncedMcpServers(previousState, 'copilot');
+    const trackedMcpServers = getPreviouslySyncedMcpServers(
+      previousState,
+      'copilot',
+    );
     const copilotMcpPath = getCopilotMcpConfigPath();
     const copilotMcpOverrides = getUserServersForClient('copilot');
     const copilotMcp = syncClaudeMcpConfig(validPlugins, {
@@ -2311,40 +2636,82 @@ export async function syncUserWorkspace(
   sw.stop('mcp-sync');
 
   // Warn about clients that don't support user-scoped MCP sync
-  const USER_MCP_CLIENTS = new Set(['claude', 'codex', 'vscode', 'copilot', 'universal']);
-  const allUserMcpServers = collectMcpServers(validPlugins, userWorkspaceMcpServers).servers;
+  const USER_MCP_CLIENTS = new Set([
+    'claude',
+    'codex',
+    'vscode',
+    'copilot',
+    'universal',
+  ]);
+  const allUserMcpServers = collectMcpServers(
+    validPlugins,
+    userWorkspaceMcpServers,
+  ).servers;
   if (allUserMcpServers.size > 0) {
     for (const client of syncClients) {
       if (!USER_MCP_CLIENTS.has(client)) {
-        warnings.push(`MCP servers not synced for ${client} (not supported at user scope)`);
+        warnings.push(
+          `MCP servers not synced for ${client} (not supported at user scope)`,
+        );
       }
     }
   }
 
   // Run native CLI installations for user scope
   const nativeResult = await sw.measure('native-plugin-sync', () =>
-    syncNativePlugins(validPlugins, previousState, 'user', homeDir, dryRun, warnings, messages),
+    syncNativePlugins(
+      validPlugins,
+      previousState,
+      'user',
+      homeDir,
+      dryRun,
+      warnings,
+      messages,
+    ),
   );
 
   // Compute deleted artifacts: compare previous state vs what was just synced
-  const availableUserSkillNames = await collectAvailableSkillNames(validPlugins);
+  const availableUserSkillNames =
+    await collectAvailableSkillNames(validPlugins);
   const allCopyResultsForState = pluginResults.flatMap((r) => r.copyResults);
-  const resolvedUserMappings = resolveClientMappings(syncClients, USER_CLIENT_MAPPINGS);
-  const newStatePaths = collectSyncedPaths(allCopyResultsForState, homeDir, syncClients, resolvedUserMappings);
-  const deletedArtifacts = computeDeletedArtifacts(previousState, newStatePaths, syncClients, resolvedUserMappings, availableUserSkillNames);
+  const resolvedUserMappings = resolveClientMappings(
+    syncClients,
+    USER_CLIENT_MAPPINGS,
+  );
+  const newStatePaths = collectSyncedPaths(
+    allCopyResultsForState,
+    homeDir,
+    syncClients,
+    resolvedUserMappings,
+  );
+  const deletedArtifacts = computeDeletedArtifacts(
+    previousState,
+    newStatePaths,
+    syncClients,
+    resolvedUserMappings,
+    availableUserSkillNames,
+  );
 
   // Save sync state (including MCP servers and native plugins)
   if (!dryRun) {
-    const { pluginsByClient: nativePluginsByClient } = collectNativePluginSources(validPlugins);
+    const { pluginsByClient: nativePluginsByClient } =
+      collectNativePluginSources(validPlugins);
     await sw.measure('persist-state', () =>
       persistSyncState(
-        homeDir, pluginResults, [], syncClients,
-        nativePluginsByClient, nativeResult,
+        homeDir,
+        pluginResults,
+        [],
+        syncClients,
+        nativePluginsByClient,
+        nativeResult,
         {
           clientMappings: USER_CLIENT_MAPPINGS,
           ...(Object.keys(mcpResults).length > 0 && {
             mcpTrackedServers: Object.fromEntries(
-              Object.entries(mcpResults).map(([scope, r]) => [scope, r.trackedServers]),
+              Object.entries(mcpResults).map(([scope, r]) => [
+                scope,
+                r.trackedServers,
+              ]),
             ),
           }),
         },

--- a/src/models/workspace-config.ts
+++ b/src/models/workspace-config.ts
@@ -125,40 +125,38 @@ export type InstallMode = z.infer<typeof InstallModeSchema>;
  * { name, install } → explicit object form
  */
 export const ClientEntrySchema = z.union([
-  z
-    .string()
-    .transform((s, ctx) => {
-      const colonIdx = s.indexOf(':');
-      if (colonIdx === -1) {
-        // Bare string — validate as client type
-        const result = ClientTypeSchema.safeParse(s);
-        if (!result.success) {
-          for (const issue of result.error.issues) ctx.addIssue(issue);
-          return z.NEVER;
-        }
-        return result.data;
-      }
-      // Colon shorthand — split on first colon
-      const name = s.slice(0, colonIdx);
-      const mode = s.slice(colonIdx + 1);
-      const nameResult = ClientTypeSchema.safeParse(name);
-      if (!nameResult.success) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: `Invalid client type: '${name}'`,
-        });
+  z.string().transform((s, ctx) => {
+    const colonIdx = s.indexOf(':');
+    if (colonIdx === -1) {
+      // Bare string — validate as client type
+      const result = ClientTypeSchema.safeParse(s);
+      if (!result.success) {
+        for (const issue of result.error.issues) ctx.addIssue(issue);
         return z.NEVER;
       }
-      const modeResult = InstallModeSchema.safeParse(mode);
-      if (!modeResult.success) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: `Invalid install mode: '${mode}'. Valid modes: ${InstallModeSchema.options.join(', ')}`,
-        });
-        return z.NEVER;
-      }
-      return { name: nameResult.data, install: modeResult.data };
-    }),
+      return result.data;
+    }
+    // Colon shorthand — split on first colon
+    const name = s.slice(0, colonIdx);
+    const mode = s.slice(colonIdx + 1);
+    const nameResult = ClientTypeSchema.safeParse(name);
+    if (!nameResult.success) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Invalid client type: '${name}'`,
+      });
+      return z.NEVER;
+    }
+    const modeResult = InstallModeSchema.safeParse(mode);
+    if (!modeResult.success) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Invalid install mode: '${mode}'. Valid modes: ${InstallModeSchema.options.join(', ')}`,
+      });
+      return z.NEVER;
+    }
+    return { name: nameResult.data, install: modeResult.data };
+  }),
   z.object({
     name: ClientTypeSchema,
     install: InstallModeSchema.default('file'),
@@ -205,14 +203,18 @@ export function getPluginSource(plugin: PluginEntry): string {
 /**
  * Resolve optional plugin-level clients from plugin entry
  */
-export function getPluginClients(plugin: PluginEntry): ClientType[] | undefined {
+export function getPluginClients(
+  plugin: PluginEntry,
+): ClientType[] | undefined {
   return typeof plugin === 'string' ? undefined : plugin.clients;
 }
 
 /**
  * Get plugin-level install mode override (if any)
  */
-export function getPluginInstallMode(plugin: PluginEntry): InstallMode | undefined {
+export function getPluginInstallMode(
+  plugin: PluginEntry,
+): InstallMode | undefined {
   return typeof plugin === 'string' ? undefined : plugin.install;
 }
 
@@ -227,7 +229,10 @@ export function getPluginExclude(plugin: PluginEntry): string[] | undefined {
 /**
  * Normalize a client entry to { name, install } form.
  */
-export function normalizeClientEntry(entry: ClientEntry): { name: ClientType; install: InstallMode } {
+export function normalizeClientEntry(entry: ClientEntry): {
+  name: ClientType;
+  install: InstallMode;
+} {
   if (typeof entry === 'string') {
     return { name: entry, install: 'file' };
   }
@@ -245,7 +250,10 @@ export function getClientTypes(entries: ClientEntry[]): ClientType[] {
  * Get install mode for a specific client from entries.
  * Returns 'file' if client not found.
  */
-export function getClientInstallMode(entries: ClientEntry[], client: ClientType): InstallMode {
+export function getClientInstallMode(
+  entries: ClientEntry[],
+  client: ClientType,
+): InstallMode {
   for (const entry of entries) {
     const normalized = normalizeClientEntry(entry);
     if (normalized.name === client) return normalized.install;
@@ -292,7 +300,8 @@ export const McpProxyServerSchema = z.object({
 });
 
 /**
- * MCP proxy configuration — rewrites HTTP MCP servers to stdio via mcp-remote
+ * MCP proxy configuration — rewrites HTTP MCP servers to stdio via the
+ * built-in AllAgents HTTP proxy helper
  */
 export const McpProxyConfigSchema = z.object({
   clients: z.array(z.string()),

--- a/src/types/micromatch.d.ts
+++ b/src/types/micromatch.d.ts
@@ -1,0 +1,12 @@
+declare module 'micromatch' {
+  interface Micromatch {
+    (
+      list: readonly string[],
+      patterns: readonly string[],
+    ): string[];
+    isMatch(input: string, patterns: readonly string[]): boolean;
+  }
+
+  const micromatch: Micromatch;
+  export default micromatch;
+}

--- a/tests/e2e/mcp-add-proxy.test.ts
+++ b/tests/e2e/mcp-add-proxy.test.ts
@@ -91,30 +91,25 @@ clients:
       },
     });
 
-    const metadataPath = join(homeDir, '.allagents', 'mcp-remote', 'mcp-metadata-settings.json');
-    expect(existsSync(metadataPath)).toBe(true);
-
     const claudeConfig = JSON.parse(readFileSync(join(workspaceDir, '.mcp.json'), 'utf-8'));
-    expect(claudeConfig.mcpServers.deepwiki.command).toBe('npx');
+    expect(claudeConfig.mcpServers.deepwiki.command).toBe('allagents');
     expect(claudeConfig.mcpServers.deepwiki.args).toEqual([
-      'mcp-remote',
+      'mcp',
+      'proxy-stdio',
       'https://mcp.deepwiki.com/mcp',
-      '--http',
-      '--static-oauth-client-metadata',
-      `@${metadataPath}`,
     ]);
 
     const codexConfig = readFileSync(join(workspaceDir, '.codex', 'config.toml'), 'utf-8');
-    expect(codexConfig).toContain('mcp-remote');
+    expect(codexConfig).toContain('proxy-stdio');
     expect(codexConfig).toContain('https://mcp.deepwiki.com/mcp');
 
     const vscodeConfig = JSON.parse(readFileSync(join(workspaceDir, '.vscode', 'mcp.json'), 'utf-8'));
-    expect(vscodeConfig.servers.deepwiki.command).toBe('npx');
-    expect(vscodeConfig.servers.deepwiki.args[0]).toBe('mcp-remote');
+    expect(vscodeConfig.servers.deepwiki.command).toBe('allagents');
+    expect(vscodeConfig.servers.deepwiki.args[0]).toBe('mcp');
 
     const copilotConfig = JSON.parse(readFileSync(join(workspaceDir, '.copilot', 'mcp-config.json'), 'utf-8'));
-    expect(copilotConfig.mcpServers.deepwiki.command).toBe('npx');
-    expect(copilotConfig.mcpServers.deepwiki.args[0]).toBe('mcp-remote');
+    expect(copilotConfig.mcpServers.deepwiki.command).toBe('allagents');
+    expect(copilotConfig.mcpServers.deepwiki.args[0]).toBe('mcp');
 
     const rerun = runCli(workspaceDir, homeDir, ['mcp', 'update']);
     expect(rerun.exitCode).toBe(0);
@@ -142,8 +137,8 @@ clients:
     const result = runCli(workspaceDir, homeDir, [
       'mcp',
       'add',
-      'wtgkb',
-      'https://knowledge.mcp.wtg.zone',
+      'secure-api',
+      'https://api.example.com/mcp',
       '--proxy',
       '--client',
       'claude,codex',
@@ -153,16 +148,16 @@ clients:
 
     const workspace = readWorkspaceConfig(workspaceDir);
     expect(workspace.mcpServers).toEqual({
-      wtgkb: {
+      'secure-api': {
         type: 'http',
-        url: 'https://knowledge.mcp.wtg.zone',
+        url: 'https://api.example.com/mcp',
         clients: ['claude', 'codex'],
       },
     });
     expect(workspace.mcpProxy).toEqual({
       clients: [],
       servers: {
-        wtgkb: {
+        'secure-api': {
           proxy: ['claude', 'codex'],
         },
       },

--- a/tests/e2e/mcp-add-proxy.test.ts
+++ b/tests/e2e/mcp-add-proxy.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { load } from 'js-yaml';
+
+interface CliResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+function runCli(workdir: string, homeDir: string, args: string[]): CliResult {
+  const cliEntry = join(import.meta.dir, '..', '..', 'src', 'cli', 'index.ts');
+  const proc = Bun.spawnSync(['bun', 'run', cliEntry, '--json', ...args], {
+    cwd: workdir,
+    env: {
+      ...process.env,
+      HOME: homeDir,
+    },
+    stderr: 'pipe',
+    stdout: 'pipe',
+  });
+
+  return {
+    exitCode: proc.exitCode,
+    stdout: new TextDecoder().decode(proc.stdout),
+    stderr: new TextDecoder().decode(proc.stderr),
+  };
+}
+
+function readWorkspaceConfig(workspaceDir: string): Record<string, unknown> {
+  return load(readFileSync(join(workspaceDir, '.allagents', 'workspace.yaml'), 'utf-8')) as Record<
+    string,
+    unknown
+  >;
+}
+
+describe('mcp add --proxy e2e', () => {
+  let workspaceDir: string;
+  let homeDir: string;
+
+  beforeEach(() => {
+    workspaceDir = join(tmpdir(), `allagents-e2e-mcp-add-proxy-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    homeDir = join(tmpdir(), `allagents-e2e-home-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(join(workspaceDir, '.allagents'), { recursive: true });
+    mkdirSync(homeDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(workspaceDir, { recursive: true, force: true });
+    rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  test('adds deepwiki with proxy enabled for all configured MCP clients', () => {
+    writeFileSync(
+      join(workspaceDir, '.allagents', 'workspace.yaml'),
+      `repositories: []
+plugins: []
+clients:
+  - claude
+  - codex
+  - vscode
+  - copilot
+`,
+      'utf-8',
+    );
+
+    const result = runCli(workspaceDir, homeDir, [
+      'mcp',
+      'add',
+      'deepwiki',
+      'https://mcp.deepwiki.com/mcp',
+      '--proxy',
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    const payload = JSON.parse(result.stdout);
+    expect(payload.success).toBe(true);
+
+    const workspace = readWorkspaceConfig(workspaceDir);
+    expect(workspace.mcpServers).toEqual({
+      deepwiki: { type: 'http', url: 'https://mcp.deepwiki.com/mcp' },
+    });
+    expect(workspace.mcpProxy).toEqual({
+      clients: [],
+      servers: {
+        deepwiki: {
+          proxy: ['claude', 'codex', 'vscode', 'copilot'],
+        },
+      },
+    });
+
+    const metadataPath = join(homeDir, '.allagents', 'mcp-remote', 'mcp-metadata-settings.json');
+    expect(existsSync(metadataPath)).toBe(true);
+
+    const claudeConfig = JSON.parse(readFileSync(join(workspaceDir, '.mcp.json'), 'utf-8'));
+    expect(claudeConfig.mcpServers.deepwiki.command).toBe('npx');
+    expect(claudeConfig.mcpServers.deepwiki.args).toEqual([
+      'mcp-remote',
+      'https://mcp.deepwiki.com/mcp',
+      '--http',
+      '--static-oauth-client-metadata',
+      `@${metadataPath}`,
+    ]);
+
+    const codexConfig = readFileSync(join(workspaceDir, '.codex', 'config.toml'), 'utf-8');
+    expect(codexConfig).toContain('mcp-remote');
+    expect(codexConfig).toContain('https://mcp.deepwiki.com/mcp');
+
+    const vscodeConfig = JSON.parse(readFileSync(join(workspaceDir, '.vscode', 'mcp.json'), 'utf-8'));
+    expect(vscodeConfig.servers.deepwiki.command).toBe('npx');
+    expect(vscodeConfig.servers.deepwiki.args[0]).toBe('mcp-remote');
+
+    const copilotConfig = JSON.parse(readFileSync(join(workspaceDir, '.copilot', 'mcp-config.json'), 'utf-8'));
+    expect(copilotConfig.mcpServers.deepwiki.command).toBe('npx');
+    expect(copilotConfig.mcpServers.deepwiki.args[0]).toBe('mcp-remote');
+
+    const rerun = runCli(workspaceDir, homeDir, ['mcp', 'update']);
+    expect(rerun.exitCode).toBe(0);
+    const rerunPayload = JSON.parse(rerun.stdout);
+    expect(rerunPayload.success).toBe(true);
+    expect(rerunPayload.data.mcpResults.claude.added).toBe(0);
+    expect(rerunPayload.data.mcpResults.codex.added).toBe(0);
+    expect(rerunPayload.data.mcpResults.vscode.added).toBe(0);
+    expect(rerunPayload.data.mcpResults.copilot.added).toBe(0);
+  });
+
+  test('scopes proxying to selected clients with --client', () => {
+    writeFileSync(
+      join(workspaceDir, '.allagents', 'workspace.yaml'),
+      `repositories: []
+plugins: []
+clients:
+  - claude
+  - codex
+  - vscode
+`,
+      'utf-8',
+    );
+
+    const result = runCli(workspaceDir, homeDir, [
+      'mcp',
+      'add',
+      'wtgkb',
+      'https://knowledge.mcp.wtg.zone',
+      '--proxy',
+      '--client',
+      'claude,codex',
+    ]);
+
+    expect(result.exitCode).toBe(0);
+
+    const workspace = readWorkspaceConfig(workspaceDir);
+    expect(workspace.mcpServers).toEqual({
+      wtgkb: {
+        type: 'http',
+        url: 'https://knowledge.mcp.wtg.zone',
+        clients: ['claude', 'codex'],
+      },
+    });
+    expect(workspace.mcpProxy).toEqual({
+      clients: [],
+      servers: {
+        wtgkb: {
+          proxy: ['claude', 'codex'],
+        },
+      },
+    });
+
+    expect(existsSync(join(workspaceDir, '.mcp.json'))).toBe(true);
+    expect(existsSync(join(workspaceDir, '.codex', 'config.toml'))).toBe(true);
+    expect(existsSync(join(workspaceDir, '.vscode', 'mcp.json'))).toBe(false);
+  });
+});

--- a/tests/unit/core/mcp-proxy-cli.test.ts
+++ b/tests/unit/core/mcp-proxy-cli.test.ts
@@ -9,25 +9,18 @@ import { applyMcpProxy } from '../../../src/core/mcp-proxy.js';
 import type { McpProxyConfig } from '../../../src/models/workspace-config.js';
 
 describe('CLI args with proxy transform', () => {
-  const metadataPath = '/home/user/.allagents/mcp-remote/mcp-metadata-settings.json';
-
   test('buildClaudeMcpAddArgs handles proxied HTTP config', () => {
     const servers = new Map<string, unknown>([
       ['deepwiki', { url: 'https://mcp.deepwiki.com/mcp' }],
     ]);
     const config: McpProxyConfig = { clients: ['claude'] };
-    const proxied = applyMcpProxy(servers, 'claude', config, metadataPath);
+    const proxied = applyMcpProxy(servers, 'claude', config);
     const proxiedConfig = proxied.get('deepwiki') as Record<string, unknown>;
 
     const args = buildClaudeMcpAddArgs('deepwiki', proxiedConfig);
     expect(args).toEqual([
-      'mcp', 'add', '--scope', 'user',
-      'deepwiki', '--', 'npx',
-      'mcp-remote',
-      'https://mcp.deepwiki.com/mcp',
-      '--http',
-      '--static-oauth-client-metadata',
-      `@${metadataPath}`,
+      'mcp', 'add', '--scope', 'user', 'deepwiki', '--', 'allagents',
+      'mcp', 'proxy-stdio', 'https://mcp.deepwiki.com/mcp',
     ]);
   });
 
@@ -36,18 +29,13 @@ describe('CLI args with proxy transform', () => {
       ['deepwiki', { url: 'https://mcp.deepwiki.com/mcp' }],
     ]);
     const config: McpProxyConfig = { clients: ['codex'] };
-    const proxied = applyMcpProxy(servers, 'codex', config, metadataPath);
+    const proxied = applyMcpProxy(servers, 'codex', config);
     const proxiedConfig = proxied.get('deepwiki') as Record<string, unknown>;
 
     const args = buildCodexMcpAddArgs('deepwiki', proxiedConfig);
     expect(args).toEqual([
-      'mcp', 'add',
-      'deepwiki', '--', 'npx',
-      'mcp-remote',
-      'https://mcp.deepwiki.com/mcp',
-      '--http',
-      '--static-oauth-client-metadata',
-      `@${metadataPath}`,
+      'mcp', 'add', 'deepwiki', '--', 'allagents',
+      'mcp', 'proxy-stdio', 'https://mcp.deepwiki.com/mcp',
     ]);
   });
 });
@@ -67,12 +55,10 @@ describe('syncVscodeMcpConfig with serverOverrides', () => {
   });
 
   test('writes proxied stdio config when serverOverrides is provided', () => {
-    const metadataPath = '/home/user/.allagents/mcp-remote/mcp-metadata-settings.json';
     const proxiedServers = new Map<string, unknown>([
       ['deepwiki', {
-        command: 'npx',
-        args: ['mcp-remote', 'https://mcp.deepwiki.com/mcp', '--http',
-          '--static-oauth-client-metadata', `@${metadataPath}`],
+        command: 'allagents',
+        args: ['mcp', 'proxy-stdio', 'https://mcp.deepwiki.com/mcp'],
       }],
     ]);
 
@@ -82,7 +68,7 @@ describe('syncVscodeMcpConfig with serverOverrides', () => {
     expect(result.addedServers).toEqual(['deepwiki']);
 
     const written = JSON.parse(readFileSync(configPath, 'utf-8'));
-    expect(written.servers.deepwiki.command).toBe('npx');
-    expect(written.servers.deepwiki.args[0]).toBe('mcp-remote');
+    expect(written.servers.deepwiki.command).toBe('allagents');
+    expect(written.servers.deepwiki.args[0]).toBe('mcp');
   });
 });

--- a/tests/unit/core/mcp-proxy.test.ts
+++ b/tests/unit/core/mcp-proxy.test.ts
@@ -1,11 +1,10 @@
 import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
 import { join } from 'node:path';
-import { mkdirSync, rmSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import {
   shouldProxy,
   applyMcpProxy,
-  ensureProxyMetadata,
 } from '../../../src/core/mcp-proxy.js';
 import type { McpProxyConfig } from '../../../src/models/workspace-config.js';
 
@@ -53,23 +52,15 @@ describe('shouldProxy', () => {
 });
 
 describe('applyMcpProxy', () => {
-  const metadataPath = '/home/testuser/.allagents/mcp-remote/mcp-metadata-settings.json';
-
   test('rewrites HTTP server config to stdio for proxied client', () => {
     const servers = new Map<string, unknown>([
       ['deepwiki', { url: 'https://mcp.deepwiki.com/mcp' }],
     ]);
     const config: McpProxyConfig = { clients: ['claude'] };
-    const result = applyMcpProxy(servers, 'claude', config, metadataPath);
+    const result = applyMcpProxy(servers, 'claude', config);
     expect(result.get('deepwiki')).toEqual({
-      command: 'npx',
-      args: [
-        'mcp-remote',
-        'https://mcp.deepwiki.com/mcp',
-        '--http',
-        '--static-oauth-client-metadata',
-        `@${metadataPath}`,
-      ],
+      command: 'allagents',
+      args: ['mcp', 'proxy-stdio', 'https://mcp.deepwiki.com/mcp'],
     });
   });
 
@@ -78,7 +69,7 @@ describe('applyMcpProxy', () => {
       ['deepwiki', { url: 'https://mcp.deepwiki.com/mcp' }],
     ]);
     const config: McpProxyConfig = { clients: ['claude'] };
-    const result = applyMcpProxy(servers, 'codex', config, metadataPath);
+    const result = applyMcpProxy(servers, 'codex', config);
     expect(result.get('deepwiki')).toEqual({ url: 'https://mcp.deepwiki.com/mcp' });
   });
 
@@ -87,7 +78,7 @@ describe('applyMcpProxy', () => {
       ['local-server', { command: 'node', args: ['server.js'] }],
     ]);
     const config: McpProxyConfig = { clients: ['claude'] };
-    const result = applyMcpProxy(servers, 'claude', config, metadataPath);
+    const result = applyMcpProxy(servers, 'claude', config);
     expect(result.get('local-server')).toEqual({ command: 'node', args: ['server.js'] });
   });
 
@@ -97,8 +88,8 @@ describe('applyMcpProxy', () => {
       ['stdio-server', { command: 'npx', args: ['some-mcp'] }],
     ]);
     const config: McpProxyConfig = { clients: ['copilot'] };
-    const result = applyMcpProxy(servers, 'copilot', config, metadataPath);
-    expect((result.get('http-server') as Record<string, unknown>).command).toBe('npx');
+    const result = applyMcpProxy(servers, 'copilot', config);
+    expect((result.get('http-server') as Record<string, unknown>).command).toBe('allagents');
     expect((result.get('stdio-server') as Record<string, unknown>).command).toBe('npx');
     expect((result.get('stdio-server') as Record<string, unknown>).args).toEqual(['some-mcp']);
   });
@@ -112,39 +103,34 @@ describe('applyMcpProxy', () => {
       clients: ['claude'],
       servers: { 'my-api': { proxy: ['codex'] } },
     };
-    const result = applyMcpProxy(servers, 'codex', config, metadataPath);
-    expect((result.get('my-api') as Record<string, unknown>).command).toBe('npx');
+    const result = applyMcpProxy(servers, 'codex', config);
+    expect((result.get('my-api') as Record<string, unknown>).command).toBe('allagents');
     expect(result.get('other-api')).toEqual({ url: 'https://other.example.com/mcp' });
   });
-});
 
-describe('ensureProxyMetadata', () => {
-  let tempDir: string;
-
-  beforeEach(() => {
-    tempDir = makeTempDir();
-  });
-
-  afterEach(() => {
-    rmSync(tempDir, { recursive: true, force: true });
-  });
-
-  test('creates metadata file if it does not exist', () => {
-    const metadataPath = join(tempDir, 'mcp-remote', 'mcp-metadata-settings.json');
-    ensureProxyMetadata(metadataPath);
-    expect(existsSync(metadataPath)).toBe(true);
-    const content = JSON.parse(readFileSync(metadataPath, 'utf-8'));
-    expect(content).toEqual({ client_uri: 'http://localhost' });
-  });
-
-  test('does not overwrite existing metadata file', () => {
-    const dir = join(tempDir, 'mcp-remote');
-    mkdirSync(dir, { recursive: true });
-    const metadataPath = join(dir, 'mcp-metadata-settings.json');
-    writeFileSync(metadataPath, JSON.stringify({ client_uri: 'http://custom' }));
-
-    ensureProxyMetadata(metadataPath);
-    const content = JSON.parse(readFileSync(metadataPath, 'utf-8'));
-    expect(content).toEqual({ client_uri: 'http://custom' });
+  test('forwards HTTP headers through the proxy helper args', () => {
+    const servers = new Map<string, unknown>([
+      [
+        'secure-api',
+        {
+          url: 'https://api.example.com/mcp',
+          headers: { Authorization: 'Bearer token', 'X-Test': '1' },
+        },
+      ],
+    ]);
+    const config: McpProxyConfig = { clients: ['claude'] };
+    const result = applyMcpProxy(servers, 'claude', config);
+    expect(result.get('secure-api')).toEqual({
+      command: 'allagents',
+      args: [
+        'mcp',
+        'proxy-stdio',
+        'https://api.example.com/mcp',
+        '--header',
+        'Authorization=Bearer token',
+        '--header',
+        'X-Test=1',
+      ],
+    });
   });
 });

--- a/tests/unit/core/mcp-servers.test.ts
+++ b/tests/unit/core/mcp-servers.test.ts
@@ -6,6 +6,7 @@ import { load } from 'js-yaml';
 import {
   addWorkspaceMcpServer,
   buildMcpServerConfigFromFlags,
+  clearWorkspaceMcpServerProxy,
   getWorkspaceMcpServer,
   listWorkspaceMcpServers,
   parseKeyValuePairs,
@@ -140,6 +141,37 @@ mcpProxy:
       servers: {
         wtgkb: { proxy: ['claude'] },
       },
+    });
+  });
+
+  test('clears server-scoped proxy intent without removing workspace-wide defaults', async () => {
+    writeFileSync(
+      join(dir, '.allagents', 'workspace.yaml'),
+      `repositories: []
+plugins: []
+clients:
+  - claude
+  - codex
+mcpProxy:
+  clients:
+    - codex
+`,
+      'utf-8',
+    );
+
+    await addWorkspaceMcpServer(
+      'wtgkb',
+      { type: 'http', url: 'https://knowledge.mcp.wtg.zone' },
+      dir,
+    );
+    await setWorkspaceMcpServerProxy('wtgkb', dir, ['claude']);
+
+    const result = await clearWorkspaceMcpServerProxy('wtgkb', dir);
+    expect(result.success).toBe(true);
+
+    const cfg = readWorkspace(dir);
+    expect(cfg.mcpProxy).toEqual({
+      clients: ['codex'],
     });
   });
 });

--- a/tests/unit/core/mcp-servers.test.ts
+++ b/tests/unit/core/mcp-servers.test.ts
@@ -10,6 +10,7 @@ import {
   listWorkspaceMcpServers,
   parseKeyValuePairs,
   removeWorkspaceMcpServer,
+  setWorkspaceMcpServerProxy,
 } from '../../../src/core/mcp-servers.js';
 
 function makeTempWorkspace(): string {
@@ -89,6 +90,58 @@ describe('addWorkspaceMcpServer', () => {
     expect(cfg.plugins).toEqual([]);
     expect(cfg.clients).toEqual(['claude']);
   });
+
+  test('persists server-scoped proxy intent without widening global proxy clients', async () => {
+    await addWorkspaceMcpServer(
+      'wtgkb',
+      { type: 'http', url: 'https://knowledge.mcp.wtg.zone' },
+      dir,
+    );
+
+    const result = await setWorkspaceMcpServerProxy('wtgkb', dir);
+    expect(result.success).toBe(true);
+    expect(result.proxyClients).toEqual(['claude']);
+
+    const cfg = readWorkspace(dir);
+    expect(cfg.mcpProxy).toEqual({
+      clients: [],
+      servers: {
+        wtgkb: { proxy: ['claude'] },
+      },
+    });
+  });
+
+  test('preserves existing workspace-wide proxy defaults when adding server-scoped proxy intent', async () => {
+    writeFileSync(
+      join(dir, '.allagents', 'workspace.yaml'),
+      `repositories: []
+plugins: []
+clients:
+  - claude
+  - codex
+mcpProxy:
+  clients:
+    - codex
+`,
+      'utf-8',
+    );
+
+    await addWorkspaceMcpServer(
+      'wtgkb',
+      { type: 'http', url: 'https://knowledge.mcp.wtg.zone' },
+      dir,
+    );
+    const result = await setWorkspaceMcpServerProxy('wtgkb', dir, ['claude']);
+    expect(result.success).toBe(true);
+
+    const cfg = readWorkspace(dir);
+    expect(cfg.mcpProxy).toEqual({
+      clients: ['codex'],
+      servers: {
+        wtgkb: { proxy: ['claude'] },
+      },
+    });
+  });
 });
 
 describe('removeWorkspaceMcpServer', () => {
@@ -112,6 +165,21 @@ describe('removeWorkspaceMcpServer', () => {
     const result = await removeWorkspaceMcpServer('nonexistent', dir);
     expect(result.success).toBe(false);
     expect(result.error).toContain('not found');
+  });
+
+  test('removes server-scoped proxy intent when removing a server', async () => {
+    await addWorkspaceMcpServer(
+      'wtgkb',
+      { type: 'http', url: 'https://knowledge.mcp.wtg.zone' },
+      dir,
+    );
+    await setWorkspaceMcpServerProxy('wtgkb', dir, ['claude']);
+
+    const result = await removeWorkspaceMcpServer('wtgkb', dir);
+    expect(result.success).toBe(true);
+
+    const cfg = readWorkspace(dir);
+    expect(cfg.mcpProxy).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary
- replace the hardcoded `mcp-remote` rewrite behind `allagents mcp add --proxy` with a first-party `allagents mcp proxy-stdio` helper
- add a built-in HTTP-to-stdio MCP bridge using the MCP TypeScript SDK, including loopback OAuth handling, client registration persistence, and header forwarding
- update proxy tests and e2e coverage to validate the new generated client config shape

## Validation
- `bun run typecheck`
- `bun test tests/unit/core/mcp-proxy.test.ts tests/unit/core/mcp-proxy-cli.test.ts tests/e2e/mcp-add-proxy.test.ts`
- manual Claude connection check via `mcp proxy-stdio` against DeepWiki
- manual Claude connection check via `mcp proxy-stdio` against an OAuth-protected remote MCP after browser auth