### PR TITLE
feat(cli): rename skills → skill (plural alias kept)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ clients:
 | `allagents plugin install <spec>` | Install a plugin |
 | `allagents plugin uninstall <spec>` | Remove a plugin |
 | `allagents plugin list` | List available plugins |
-| `allagents skills add <name>` | Add a skill from a repo |
-| `allagents skills list` | List skills and status |
+| `allagents skill add <name>` | Add a skill from a repo (plural `skills` alias supported) |
+| `allagents skill list` | List skills and status |
 | `allagents mcp add <name> <commandOrUrl>` | Add an MCP server and sync to clients |
 | `allagents mcp list` | List workspace MCP servers |
 | `allagents workspace status` | Show workspace state |

--- a/docs/src/content/docs/docs/getting-started/quick-start.mdx
+++ b/docs/src/content/docs/docs/getting-started/quick-start.mdx
@@ -43,13 +43,13 @@ allagents update
 Install a specific skill from a GitHub repo without adding the full plugin:
 
 ```bash
-allagents skills add reddit --from ReScienceLab/opc-skills
+allagents skill add reddit --from ReScienceLab/opc-skills
 ```
 
 Or pass a GitHub URL directly:
 
 ```bash
-allagents skills add https://github.com/owner/repo/tree/main/skills/my-skill
+allagents skill add https://github.com/owner/repo/tree/main/skills/my-skill
 ```
 
 ## Install User-Scoped Plugins

--- a/docs/src/content/docs/docs/guides/plugins.mdx
+++ b/docs/src/content/docs/docs/guides/plugins.mdx
@@ -62,13 +62,13 @@ You can add a specific skill from a GitHub repo without installing the full plug
 
 ```bash
 # Add a skill by name, specifying the plugin source
-allagents skills add reddit --from ReScienceLab/opc-skills
+allagents skill add reddit --from ReScienceLab/opc-skills
 
 # Or pass a GitHub URL directly
-allagents skills add https://github.com/owner/repo/tree/main/skills/my-skill
+allagents skill add https://github.com/owner/repo/tree/main/skills/my-skill
 ```
 
-This installs the plugin and enables only the specified skill. See the [CLI reference](/docs/reference/cli/#plugin-skills-add) for all source formats.
+This installs the plugin and enables only the specified skill. See the [CLI reference](/docs/reference/cli/#skill-add) for all source formats.
 
 ## Disabling Individual Skills
 

--- a/docs/src/content/docs/docs/reference/cli.mdx
+++ b/docs/src/content/docs/docs/reference/cli.mdx
@@ -104,9 +104,9 @@ allagents plugin marketplace add <source> [--name <name>] [--branch <branch>]
 allagents plugin marketplace list
 allagents plugin marketplace remove <name>
 allagents plugin marketplace update [name]
-allagents plugin skills list [--scope <scope>]
-allagents plugin skills remove <skill> [--plugin <plugin>] [--scope <scope>]
-allagents plugin skills add <skill> [--from <source>] [--plugin <plugin>] [--scope <scope>]
+allagents skill list [--scope <scope>]
+allagents skill remove <skill> [--plugin <plugin>] [--scope <scope>]
+allagents skill add <skill> [--from <source>] [--plugin <plugin>] [--scope <scope>]
 ```
 
 ### plugin install
@@ -126,9 +126,9 @@ Only enable specific skills from the plugin. Can be specified multiple times:
 allagents plugin install superpowers@marketplace --skill brainstorming --skill tdd
 ```
 
-When used, all other skills from the plugin are implicitly disabled. Skills can be added later with `plugin skills add`.
+When used, all other skills from the plugin are implicitly disabled. Skills can be added later with `skill add`.
 
-### plugin skills list
+### skill list
 
 List all skills from installed plugins with their enabled/disabled status.
 
@@ -136,7 +136,7 @@ List all skills from installed plugins with their enabled/disabled status.
 |------|-------------|
 | `-s, --scope <scope>` | Scope: `project` (default) or `user` |
 
-### plugin skills remove
+### skill remove
 
 Disable a skill, preventing it from being synced to the workspace.
 
@@ -147,7 +147,7 @@ Disable a skill, preventing it from being synced to the workspace.
 
 After disabling, the skill is added to `disabledSkills` in workspace.yaml and sync is run to remove it.
 
-### plugin skills add
+### skill add
 
 Add a skill from a plugin, or re-enable a previously disabled skill. The `<skill>` argument can be a skill name or a GitHub URL pointing to a skill.
 
@@ -163,10 +163,10 @@ Use `--from` to specify the plugin source when the skill isn't already installed
 
 ```bash
 # Add a specific skill from a GitHub repo
-allagents skills add reddit --from ReScienceLab/opc-skills
+allagents skill add reddit --from ReScienceLab/opc-skills
 
 # Or pass a GitHub URL directly — the skill name is extracted from the URL path
-allagents skills add https://github.com/owner/repo/tree/main/skills/my-skill
+allagents skill add https://github.com/owner/repo/tree/main/skills/my-skill
 ```
 
 **Source formats for `--from`:**
@@ -177,14 +177,15 @@ allagents skills add https://github.com/owner/repo/tree/main/skills/my-skill
 #### Re-enabling a disabled skill
 
 ```bash
-allagents skills add brainstorming
-allagents skills add brainstorming --plugin superpowers
+allagents skill add brainstorming
+allagents skill add brainstorming --plugin superpowers
 ```
 
 After enabling, the skill is removed from `disabledSkills` and sync is run to restore it.
 
 :::tip
-`allagents skills add` is a shorthand for `allagents plugin skills add`.
+`allagents skill ...` is the canonical singular form. The plural alias
+`allagents skills ...` is also accepted and produces identical output.
 :::
 
 ## MCP Commands

--- a/src/cli/agent-help.ts
+++ b/src/cli/agent-help.ts
@@ -13,6 +13,11 @@ import {
   pluginUninstallMeta,
 } from './metadata/plugin.js';
 import { updateMeta } from './metadata/self.js';
+import {
+  skillsListMeta,
+  skillsAddMeta,
+  skillsRemoveMeta,
+} from './metadata/plugin-skills.js';
 
 const allCommands: AgentCommandMeta[] = [
   initMeta,
@@ -27,6 +32,9 @@ const allCommands: AgentCommandMeta[] = [
   marketplaceBrowseMeta,
   pluginListMeta,
   pluginValidateMeta,
+  skillsListMeta,
+  skillsAddMeta,
+  skillsRemoveMeta,
   updateMeta,
 ];
 
@@ -59,8 +67,15 @@ function formatForAgent(meta: AgentCommandMeta) {
 }
 
 export function printAgentHelp(args: string[], version: string): void {
-  // Determine which command is being asked about by looking at remaining args
-  const commandPath = args.filter(a => !a.startsWith('-')).join(' ');
+  // Determine which command is being asked about by looking at remaining args.
+  // `skills` is a permanent alias for the canonical singular `skill`; normalize
+  // the lookup key so `--agent-help "skills list"` resolves to the `skill list`
+  // meta.
+  const positional = args.filter(a => !a.startsWith('-'));
+  const normalized = positional[0] === 'skills'
+    ? ['skill', ...positional.slice(1)]
+    : positional;
+  const commandPath = normalized.join(' ');
 
   if (!commandPath) {
     // Full tree

--- a/src/cli/commands/plugin-skills.ts
+++ b/src/cli/commands/plugin-skills.ts
@@ -170,7 +170,7 @@ const listCmd = command({
         const allSkills = [...userSkills, ...dedupedProjectSkills];
         jsonOutput({
           success: true,
-          command: 'plugin skills list',
+          command: 'skill list',
           data: {
             scope: effectiveScope,
             skills: allSkills.map((s) => ({
@@ -220,7 +220,7 @@ const listCmd = command({
     } catch (error) {
       if (error instanceof Error) {
         if (isJsonMode()) {
-          jsonOutput({ success: false, command: 'plugin skills list', error: error.message });
+          jsonOutput({ success: false, command: 'skill list', error: error.message });
           process.exit(1);
         }
         console.error(`Error: ${error.message}`);
@@ -266,7 +266,7 @@ const removeCmd = command({
         const skillNames = [...new Set(allSkills.map((s) => s.name))].join(', ');
         const error = `Skill '${skill}' not found in any installed plugin.\n\nAvailable skills: ${skillNames || 'none'}`;
         if (isJsonMode()) {
-          jsonOutput({ success: false, command: 'plugin skills remove', error });
+          jsonOutput({ success: false, command: 'skill remove', error });
           process.exit(1);
         }
         console.error(`Error: ${error}`);
@@ -282,9 +282,9 @@ const removeCmd = command({
       if (matches.length > 1) {
         if (!plugin) {
           const pluginList = matches.map((m) => `  - ${m.pluginName} (${m.pluginSource})`).join('\n');
-          const error = `'${skill}' exists in multiple plugins:\n${pluginList}\n\nUse --plugin to specify: allagents plugin skills remove ${skill} --plugin <name>`;
+          const error = `'${skill}' exists in multiple plugins:\n${pluginList}\n\nUse --plugin to specify: allagents skill remove ${skill} --plugin <name>`;
           if (isJsonMode()) {
-            jsonOutput({ success: false, command: 'plugin skills remove', error });
+            jsonOutput({ success: false, command: 'skill remove', error });
             process.exit(1);
           }
           console.error(`Error: ${error}`);
@@ -294,7 +294,7 @@ const removeCmd = command({
         if (!filtered) {
           const error = `Plugin '${plugin}' not found. Installed plugins: ${matches.map((m) => m.pluginName).join(', ')}`;
           if (isJsonMode()) {
-            jsonOutput({ success: false, command: 'plugin skills remove', error });
+            jsonOutput({ success: false, command: 'skill remove', error });
             process.exit(1);
           }
           console.error(`Error: ${error}`);
@@ -307,7 +307,7 @@ const removeCmd = command({
       if (targetSkill.disabled) {
         const msg = `Skill '${skill}' is already disabled.`;
         if (isJsonMode()) {
-          jsonOutput({ success: false, command: 'plugin skills remove', error: msg });
+          jsonOutput({ success: false, command: 'skill remove', error: msg });
           process.exit(1);
         }
         console.log(msg);
@@ -322,7 +322,7 @@ const removeCmd = command({
 
       if (!result.success) {
         if (isJsonMode()) {
-          jsonOutput({ success: false, command: 'plugin skills remove', error: result.error ?? 'Unknown error' });
+          jsonOutput({ success: false, command: 'skill remove', error: result.error ?? 'Unknown error' });
           process.exit(1);
         }
         console.error(`Error: ${result.error}`);
@@ -340,7 +340,7 @@ const removeCmd = command({
       if (isJsonMode()) {
         jsonOutput({
           success: syncResult.success,
-          command: 'plugin skills remove',
+          command: 'skill remove',
           data: {
             skill,
             plugin: targetSkill.pluginName,
@@ -358,7 +358,7 @@ const removeCmd = command({
     } catch (error) {
       if (error instanceof Error) {
         if (isJsonMode()) {
-          jsonOutput({ success: false, command: 'plugin skills remove', error: error.message });
+          jsonOutput({ success: false, command: 'skill remove', error: error.message });
           process.exit(1);
         }
         console.error(`Error: ${error.message}`);
@@ -527,7 +527,7 @@ async function installSkillDirect(opts: {
   if (!availableSkills.includes(skill)) {
     return {
       success: false,
-      error: `Skill '${skill}' not found in plugin '${from}'.\n\nAvailable skills: ${availableSkills.join(', ') || 'none'}\n\nTip: run \`allagents skills list\` to see all installed skills.`,
+      error: `Skill '${skill}' not found in plugin '${from}'.\n\nAvailable skills: ${availableSkills.join(', ') || 'none'}\n\nTip: run \`allagents skill list\` to see all installed skills.`,
     };
   }
 
@@ -922,7 +922,7 @@ const addCmd = command({
         if (skillArg) {
           const error = 'Cannot combine a skill argument with --list. Use --list alone to discover available skills.';
           if (isJsonMode()) {
-            jsonOutput({ success: false, command: 'plugin skills add', error });
+            jsonOutput({ success: false, command: 'skill add', error });
             process.exit(1);
           }
           console.error(`Error: ${error}`);
@@ -931,7 +931,7 @@ const addCmd = command({
         if (!fromArg) {
           const error = '--list requires --from to specify a plugin source.';
           if (isJsonMode()) {
-            jsonOutput({ success: false, command: 'plugin skills add', error });
+            jsonOutput({ success: false, command: 'skill add', error });
             process.exit(1);
           }
           console.error(`Error: ${error}`);
@@ -940,7 +940,7 @@ const addCmd = command({
         if (all) {
           const error = '--list and --all cannot be used together.';
           if (isJsonMode()) {
-            jsonOutput({ success: false, command: 'plugin skills add', error });
+            jsonOutput({ success: false, command: 'skill add', error });
             process.exit(1);
           }
           console.error(`Error: ${error}`);
@@ -950,7 +950,7 @@ const addCmd = command({
         const discovered = await discoverSkillsFromSource(fromArg);
         if (!discovered.success) {
           if (isJsonMode()) {
-            jsonOutput({ success: false, command: 'plugin skills add', error: discovered.error });
+            jsonOutput({ success: false, command: 'skill add', error: discovered.error });
             process.exit(1);
           }
           console.error(`Error: ${discovered.error}`);
@@ -960,7 +960,7 @@ const addCmd = command({
         if (isJsonMode()) {
           jsonOutput({
             success: true,
-            command: 'plugin skills add',
+            command: 'skill add',
             data: {
               source: fromArg,
               isMarketplace: discovered.isMarketplace,
@@ -994,7 +994,7 @@ const addCmd = command({
         if (!fromArg) {
           const error = '--all requires --from to specify a plugin source.';
           if (isJsonMode()) {
-            jsonOutput({ success: false, command: 'plugin skills add', error });
+            jsonOutput({ success: false, command: 'skill add', error });
             process.exit(1);
           }
           console.error(`Error: ${error}`);
@@ -1003,7 +1003,7 @@ const addCmd = command({
         if (skillArg) {
           const error = 'Cannot combine a skill argument with --all. Use --all alone to install every skill.';
           if (isJsonMode()) {
-            jsonOutput({ success: false, command: 'plugin skills add', error });
+            jsonOutput({ success: false, command: 'skill add', error });
             process.exit(1);
           }
           console.error(`Error: ${error}`);
@@ -1021,7 +1021,7 @@ const addCmd = command({
 
         if (!installResult.success) {
           if (isJsonMode()) {
-            jsonOutput({ success: false, command: 'plugin skills add', error: installResult.error });
+            jsonOutput({ success: false, command: 'skill add', error: installResult.error });
             process.exit(1);
           }
           console.error(`Error: ${installResult.error}`);
@@ -1031,7 +1031,7 @@ const addCmd = command({
         if (isJsonMode()) {
           jsonOutput({
             success: true,
-            command: 'plugin skills add',
+            command: 'skill add',
             data: {
               source: fromArg,
               installed: installResult.installed,
@@ -1061,7 +1061,7 @@ const addCmd = command({
       if (!skillArg) {
         const error = 'A skill name is required. Use --list to discover available skills or --all to install everything.';
         if (isJsonMode()) {
-          jsonOutput({ success: false, command: 'plugin skills add', error });
+          jsonOutput({ success: false, command: 'skill add', error });
           process.exit(1);
         }
         console.error(`Error: ${error}`);
@@ -1078,7 +1078,7 @@ const addCmd = command({
           const error =
             'Cannot use --from when the skill argument is a GitHub URL. The URL is used as the plugin source automatically.';
           if (isJsonMode()) {
-            jsonOutput({ success: false, command: 'plugin skills add', error });
+            jsonOutput({ success: false, command: 'skill add', error });
             process.exit(1);
           }
           console.error(`Error: ${error}`);
@@ -1114,7 +1114,7 @@ const addCmd = command({
 
           if (!installFromResult.success) {
             if (isJsonMode()) {
-              jsonOutput({ success: false, command: 'plugin skills add', error: installFromResult.error });
+              jsonOutput({ success: false, command: 'skill add', error: installFromResult.error });
               process.exit(1);
             }
             console.error(`Error: ${installFromResult.error}`);
@@ -1124,7 +1124,7 @@ const addCmd = command({
           if (isJsonMode()) {
             jsonOutput({
               success: true,
-              command: 'plugin skills add',
+              command: 'skill add',
               data: {
                 skill,
                 plugin: installFromResult.pluginName,
@@ -1142,7 +1142,7 @@ const addCmd = command({
         const skillNames = [...new Set(allSkills.map((s) => s.name))].join(', ');
         const error = `Skill '${skill}' not found in any installed plugin.\n\nAvailable skills: ${skillNames || 'none'}`;
         if (isJsonMode()) {
-          jsonOutput({ success: false, command: 'plugin skills add', error });
+          jsonOutput({ success: false, command: 'skill add', error });
           process.exit(1);
         }
         console.error(`Error: ${error}`);
@@ -1158,9 +1158,9 @@ const addCmd = command({
       if (matches.length > 1) {
         if (!plugin) {
           const pluginList = matches.map((m) => `  - ${m.pluginName} (${m.pluginSource})`).join('\n');
-          const error = `'${skill}' exists in multiple plugins:\n${pluginList}\n\nUse --plugin to specify: allagents plugin skills add ${skill} --plugin <name>`;
+          const error = `'${skill}' exists in multiple plugins:\n${pluginList}\n\nUse --plugin to specify: allagents skill add ${skill} --plugin <name>`;
           if (isJsonMode()) {
-            jsonOutput({ success: false, command: 'plugin skills add', error });
+            jsonOutput({ success: false, command: 'skill add', error });
             process.exit(1);
           }
           console.error(`Error: ${error}`);
@@ -1170,7 +1170,7 @@ const addCmd = command({
         if (!filtered) {
           const error = `Plugin '${plugin}' not found. Installed plugins: ${matches.map((m) => m.pluginName).join(', ')}`;
           if (isJsonMode()) {
-            jsonOutput({ success: false, command: 'plugin skills add', error });
+            jsonOutput({ success: false, command: 'skill add', error });
             process.exit(1);
           }
           console.error(`Error: ${error}`);
@@ -1183,7 +1183,7 @@ const addCmd = command({
       if (!targetSkill.disabled) {
         const msg = `Skill '${skill}' is already enabled.`;
         if (isJsonMode()) {
-          jsonOutput({ success: false, command: 'plugin skills add', error: msg });
+          jsonOutput({ success: false, command: 'skill add', error: msg });
           process.exit(1);
         }
         console.log(msg);
@@ -1198,7 +1198,7 @@ const addCmd = command({
 
       if (!result.success) {
         if (isJsonMode()) {
-          jsonOutput({ success: false, command: 'plugin skills add', error: result.error ?? 'Unknown error' });
+          jsonOutput({ success: false, command: 'skill add', error: result.error ?? 'Unknown error' });
           process.exit(1);
         }
         console.error(`Error: ${result.error}`);
@@ -1216,7 +1216,7 @@ const addCmd = command({
       if (isJsonMode()) {
         jsonOutput({
           success: syncResult.success,
-          command: 'plugin skills add',
+          command: 'skill add',
           data: {
             skill,
             plugin: targetSkill.pluginName,
@@ -1234,7 +1234,7 @@ const addCmd = command({
     } catch (error) {
       if (error instanceof Error) {
         if (isJsonMode()) {
-          jsonOutput({ success: false, command: 'plugin skills add', error: error.message });
+          jsonOutput({ success: false, command: 'skill add', error: error.message });
           process.exit(1);
         }
         console.error(`Error: ${error.message}`);
@@ -1246,11 +1246,11 @@ const addCmd = command({
 });
 
 // =============================================================================
-// plugin skills subcommands group
+// skill subcommands group (canonical singular; `skills` is a CLI alias)
 // =============================================================================
 
 export const skillsCmd = conciseSubcommands({
-  name: 'skills',
+  name: 'skill',
   description: 'Manage individual skills from plugins',
   cmds: {
     list: listCmd,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -24,13 +24,19 @@ const app = conciseSubcommands({
     plugin: pluginCmd,
     mcp: mcpCmd,
     self: selfCmd,
-    skills: skillsCmd,
+    skill: skillsCmd,
   },
 });
 
 const rawArgs = process.argv.slice(2);
 const { args: argsNoJson, json } = extractJsonFlag(rawArgs);
-const { args: finalArgs, agentHelp } = extractAgentHelpFlag(argsNoJson);
+const { args: argsWithSkillAlias, agentHelp } = extractAgentHelpFlag(argsNoJson);
+// `skills` is a permanent alias for the canonical singular `skill`. Normalize
+// up-front so cmd-ts only ever dispatches the singular and both invocations
+// produce byte-identical help/output.
+const finalArgs = argsWithSkillAlias[0] === 'skills'
+  ? ['skill', ...argsWithSkillAlias.slice(1)]
+  : argsWithSkillAlias;
 setJsonMode(json);
 
 // Kick off update check for non-json, non-agent-help invocations.

--- a/src/cli/metadata/plugin-skills.ts
+++ b/src/cli/metadata/plugin-skills.ts
@@ -1,12 +1,12 @@
 import type { AgentCommandMeta } from '../help.js';
 
 export const skillsListMeta: AgentCommandMeta = {
-  command: 'plugin skills list',
+  command: 'skill list',
   description: 'List all skills from installed plugins',
   whenToUse: 'To see available skills and their enabled/disabled status',
   examples: [
-    'allagents plugin skills list',
-    'allagents plugin skills list --scope user',
+    'allagents skill list',
+    'allagents skill list --scope user',
   ],
   expectedOutput: 'Lists skills grouped by plugin with enabled/disabled status',
   options: [
@@ -18,13 +18,13 @@ export const skillsListMeta: AgentCommandMeta = {
 };
 
 export const skillsRemoveMeta: AgentCommandMeta = {
-  command: 'plugin skills remove',
+  command: 'skill remove',
   description: 'Disable a skill (exclude from sync)',
   whenToUse: 'To prevent a specific skill from being synced to your workspace',
   examples: [
-    'allagents plugin skills remove brainstorming',
-    'allagents plugin skills remove brainstorming --plugin superpowers',
-    'allagents plugin skills remove brainstorming --scope user',
+    'allagents skill remove brainstorming',
+    'allagents skill remove brainstorming --plugin superpowers',
+    'allagents skill remove brainstorming --scope user',
   ],
   expectedOutput: 'Confirms skill was disabled and runs sync',
   positionals: [
@@ -42,17 +42,17 @@ export const skillsRemoveMeta: AgentCommandMeta = {
 };
 
 export const skillsAddMeta: AgentCommandMeta = {
-  command: 'plugin skills add',
+  command: 'skill add',
   description: 'Add a skill from a plugin, or re-enable a previously disabled skill',
   whenToUse:
     'To add a skill from a GitHub repo or marketplace plugin, or to re-enable a skill that was previously disabled',
   examples: [
-    'allagents skills add reddit --from ReScienceLab/opc-skills',
-    'allagents skills add https://github.com/owner/repo/tree/main/skills/my-skill',
-    'allagents skills add brainstorming',
-    'allagents skills add brainstorming --plugin superpowers',
-    'allagents skills add --list --from rstackjs/agent-skills',
-    'allagents skills add --all --from rstackjs/agent-skills',
+    'allagents skill add reddit --from ReScienceLab/opc-skills',
+    'allagents skill add https://github.com/owner/repo/tree/main/skills/my-skill',
+    'allagents skill add brainstorming',
+    'allagents skill add brainstorming --plugin superpowers',
+    'allagents skill add --list --from rstackjs/agent-skills',
+    'allagents skill add --all --from rstackjs/agent-skills',
   ],
   expectedOutput: 'Confirms skill was enabled and runs sync',
   positionals: [

--- a/tests/unit/cli/agent-help.test.ts
+++ b/tests/unit/cli/agent-help.test.ts
@@ -13,6 +13,11 @@ import {
   pluginUninstallMeta,
 } from '../../../src/cli/metadata/plugin.js';
 import { updateMeta } from '../../../src/cli/metadata/self.js';
+import {
+  skillsListMeta,
+  skillsAddMeta,
+  skillsRemoveMeta,
+} from '../../../src/cli/metadata/plugin-skills.js';
 import type { AgentCommandMeta } from '../../../src/cli/help.js';
 
 const allCommands: AgentCommandMeta[] = [
@@ -28,6 +33,9 @@ const allCommands: AgentCommandMeta[] = [
   marketplaceBrowseMeta,
   pluginListMeta,
   pluginValidateMeta,
+  skillsListMeta,
+  skillsAddMeta,
+  skillsRemoveMeta,
   updateMeta,
 ];
 
@@ -58,8 +66,8 @@ describe('extractAgentHelpFlag', () => {
 });
 
 describe('agent command metadata', () => {
-  test('contains exactly 13 commands', () => {
-    expect(allCommands.length).toBe(13);
+  test('contains exactly 16 commands', () => {
+    expect(allCommands.length).toBe(16);
   });
 
   test('all expected commands are present', () => {
@@ -75,6 +83,9 @@ describe('agent command metadata', () => {
       'plugin uninstall',
       'plugin validate',
       'self update',
+      'skill add',
+      'skill list',
+      'skill remove',
       'update',
       'workspace init',
       'workspace status',


### PR DESCRIPTION
## Summary

Adopt `allagents skill <subcommand>` as the canonical singular form, matching `gh skill` and the agentskills.io ecosystem. The plural `allagents skills <subcommand>` remains a permanent, byte-identical alias — no deprecation warning, no breaking change.

- Rewriting the leading `skills` arg to `skill` before cmd-ts dispatch makes both invocations share the same `hotPath`, so they produce identical help/output (gate 2).
- Metas, JSON envelopes, examples, README, and the docs site are switched to the singular. The plural is documented as a synonym.
- `--agent-help "skills X"` lookups are normalized so existing automation that uses the plural still resolves.

## Test plan

- [x] `bun run build`
- [x] `bun test` (1191 pass / 0 fail)
- [x] Verification gate from #373 (all five checks):
  - `allagents skill list >/dev/null` succeeds; `allagents skill --help | grep 'allagents skill'` matches.
  - `allagents skills list >/dev/null` succeeds; `diff <(allagents skill 2>&1) <(allagents skills 2>&1)` shows no diff.
  - `allagents --agent-help | jq '.commands | map(.command) | any(. == "skill list")'` → `true`.
  - `allagents --help | grep 'skill'` matches.
  - `grep -E '^\s*\$\s*allagents skills ' README.md` returns no matches.

Closes #373

> Note: overlaps with #371 on `src/cli/metadata/plugin-skills.ts`,
> `src/cli/agent-help.ts`, and `src/cli/commands/plugin-skills.ts`. Whichever
> lands second can be rebased trivially — same edits, singular vs plural.
