### PR TITLE
feat(json): per-command field allowlist + --jq filter

### DIFF
--- a/src/cli/agent-help.ts
+++ b/src/cli/agent-help.ts
@@ -63,7 +63,20 @@ function formatForAgent(meta: AgentCommandMeta) {
   if (meta.outputSchema) {
     result.output_schema = meta.outputSchema;
   }
+  if (meta.jsonFields && meta.jsonFields.length > 0) {
+    result.json_fields = [...meta.jsonFields];
+  }
   return result;
+}
+
+/**
+ * Look up a meta by the runtime command path (e.g. "skills list").
+ * Used by index.ts to validate `--json=<fields>` against the per-command
+ * allowlist before dispatching.
+ */
+export function findMetaByCommand(commandPath: string): AgentCommandMeta | undefined {
+  if (!commandPath) return undefined;
+  return allCommands.find((c) => c.command === commandPath);
 }
 
 export function printAgentHelp(args: string[], version: string): void {

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -31,6 +31,15 @@ export interface AgentCommandMeta extends CommandMeta {
   positionals?: CommandPositional[];
   options?: CommandOption[];
   outputSchema?: Record<string, unknown>;
+  /**
+   * Allowlist of fields that may be requested via `--json=<f1>,<f2>`.
+   *
+   * When the data envelope contains a single top-level array of objects,
+   * the listed fields select which keys remain on each array item. Otherwise
+   * the fields are pulled from the top-level data object. Unknown fields are
+   * rejected with a sorted suggestion list and exit code 2.
+   */
+  jsonFields?: readonly string[];
 }
 
 /**

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -7,8 +7,17 @@ import { pluginCmd } from './commands/plugin.js';
 import { mcpCmd } from './commands/mcp.js';
 import { selfCmd } from './commands/self.js';
 import { skillsCmd } from './commands/plugin-skills.js';
-import { extractJsonFlag, setJsonMode } from './json-output.js';
-import { extractAgentHelpFlag, printAgentHelp } from './agent-help.js';
+import {
+  extractJsonFlag,
+  extractJqFlag,
+  setJsonMode,
+  validateJsonFields,
+} from './json-output.js';
+import {
+  extractAgentHelpFlag,
+  findMetaByCommand,
+  printAgentHelp,
+} from './agent-help.js';
 import { getUpdateNotice } from './update-check.js';
 import packageJson from '../../package.json';
 
@@ -29,15 +38,37 @@ const app = conciseSubcommands({
 });
 
 const rawArgs = process.argv.slice(2);
-const { args: argsNoJson, json } = extractJsonFlag(rawArgs);
-const { args: argsWithSkillAlias, agentHelp } = extractAgentHelpFlag(argsNoJson);
+const { args: argsNoJson, json, jsonFields } = extractJsonFlag(rawArgs);
+const { args: argsNoJq, jqExpr } = extractJqFlag(argsNoJson);
+const { args: argsWithSkillAlias, agentHelp } = extractAgentHelpFlag(argsNoJq);
 // `skills` is a permanent alias for the canonical singular `skill`. Normalize
 // up-front so cmd-ts only ever dispatches the singular and both invocations
 // produce byte-identical help/output.
 const finalArgs = argsWithSkillAlias[0] === 'skills'
   ? ['skill', ...argsWithSkillAlias.slice(1)]
   : argsWithSkillAlias;
-setJsonMode(json);
+
+// `--jq` requires `--json` so we have an envelope to pipe through.
+if (jqExpr && !json) {
+  process.stderr.write('Error: --jq requires --json.\n');
+  process.exit(2);
+}
+
+// Validate `--json=<fields>` against the meta allowlist for the invoked command.
+// `findMetaByCommand` looks up by the canonical command path (singular form),
+// matching what's in the metas after the rename.
+let validatedFields: string[] | undefined;
+if (jsonFields) {
+  const commandPath = finalArgs.filter((a) => !a.startsWith('-')).join(' ');
+  const meta = findMetaByCommand(commandPath);
+  const result = validateJsonFields(jsonFields, meta);
+  validatedFields = result ? [...result] : undefined;
+}
+
+setJsonMode(json, {
+  ...(validatedFields && { fields: validatedFields }),
+  ...(jqExpr && { jqExpr }),
+});
 
 // Kick off update check for non-json, non-agent-help invocations.
 // Reads from local cache (fast), spawns a detached child to refresh if stale.

--- a/src/cli/json-output.ts
+++ b/src/cli/json-output.ts
@@ -1,11 +1,22 @@
+import { spawnSync } from 'node:child_process';
+import type { AgentCommandMeta } from './help.js';
+
 let jsonMode = false;
+let jsonFields: string[] | null = null;
+let jqExpr: string | null = null;
 
 export function isJsonMode(): boolean {
   return jsonMode;
 }
 
-export function setJsonMode(value: boolean): void {
+export function setJsonMode(value: boolean, options?: { fields?: string[]; jqExpr?: string }): void {
   jsonMode = value;
+  jsonFields = options?.fields ?? null;
+  jqExpr = options?.jqExpr ?? null;
+}
+
+export function getJsonFields(): readonly string[] | null {
+  return jsonFields;
 }
 
 export interface JsonEnvelope {
@@ -15,15 +26,140 @@ export interface JsonEnvelope {
   error?: string;
 }
 
-export function jsonOutput(envelope: JsonEnvelope): void {
-  console.log(JSON.stringify(envelope, null, 2));
+/**
+ * Apply the active `--json=<fields>` filter to an envelope. When `data` has a
+ * single top-level array of objects (e.g. `{ skills: [...] }`), the filter
+ * narrows each item to the requested fields. Otherwise the filter is applied
+ * to the top-level `data` object directly.
+ */
+function applyFieldFilter(envelope: JsonEnvelope, fields: string[]): JsonEnvelope {
+  if (!envelope.data || typeof envelope.data !== 'object') return envelope;
+  const data = envelope.data as Record<string, unknown>;
+  const keys = Object.keys(data);
+
+  // Single top-level array of objects → filter each item.
+  const arrayKey = keys.find(
+    (k) => Array.isArray(data[k]) && (data[k] as unknown[]).every((it) => it !== null && typeof it === 'object' && !Array.isArray(it)),
+  );
+  if (arrayKey && keys.length >= 1) {
+    const items = data[arrayKey] as Array<Record<string, unknown>>;
+    const filteredItems = items.map((item) => projectFields(item, fields));
+    return { ...envelope, data: { ...data, [arrayKey]: filteredItems } };
+  }
+
+  // Otherwise project the top-level data object.
+  return { ...envelope, data: projectFields(data, fields) };
+}
+
+function projectFields(obj: Record<string, unknown>, fields: string[]): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const f of fields) {
+    if (f in obj) out[f] = obj[f];
+  }
+  return out;
 }
 
 /**
- * Strip --json from args so cmd-ts doesn't see it.
+ * Run an envelope through the system `jq` binary. Returns the stdout string.
+ * On any failure, exits with a clear error rather than dumping a raw stderr.
  */
-export function extractJsonFlag(args: string[]): { args: string[]; json: boolean } {
-  const idx = args.indexOf('--json');
-  if (idx === -1) return { args, json: false };
-  return { args: [...args.slice(0, idx), ...args.slice(idx + 1)], json: true };
+function runJq(envelope: JsonEnvelope, expr: string): string {
+  const input = JSON.stringify(envelope);
+  const result = spawnSync('jq', [expr], { input, encoding: 'utf-8' });
+  if (result.error || result.status !== 0) {
+    const msg = result.stderr?.trim() || result.error?.message || 'jq invocation failed';
+    process.stderr.write(`Error: --jq failed: ${msg}\n`);
+    process.exit(1);
+  }
+  return result.stdout.trimEnd();
+}
+
+export function jsonOutput(envelope: JsonEnvelope): void {
+  let final = envelope;
+  if (jsonFields && jsonFields.length > 0) {
+    final = applyFieldFilter(envelope, jsonFields);
+  }
+  if (jqExpr) {
+    console.log(runJq(final, jqExpr));
+    return;
+  }
+  console.log(JSON.stringify(final, null, 2));
+}
+
+/**
+ * Parse `--json` and `--json=<fields>` out of the argv.
+ *
+ * Returns:
+ *   `json`        — boolean, true if the flag was present in either form.
+ *   `jsonFields`  — comma-split field list when `--json=<fields>` was supplied.
+ */
+export function extractJsonFlag(
+  args: string[],
+): { args: string[]; json: boolean; jsonFields?: string[] } {
+  const out: string[] = [];
+  let json = false;
+  let fields: string[] | undefined;
+
+  for (const a of args) {
+    if (a === '--json') {
+      json = true;
+      continue;
+    }
+    if (a.startsWith('--json=')) {
+      json = true;
+      const value = a.slice('--json='.length);
+      if (value.length > 0) {
+        fields = value.split(',').map((s) => s.trim()).filter(Boolean);
+      }
+      continue;
+    }
+    out.push(a);
+  }
+
+  return fields ? { args: out, json, jsonFields: fields } : { args: out, json };
+}
+
+/**
+ * Parse `--jq <expr>` out of the argv. The expression is the following arg.
+ *
+ * `--jq` without `--json` is rejected by the caller; this function only does
+ * lexical extraction so the args list passed to cmd-ts no longer contains it.
+ */
+export function extractJqFlag(args: string[]): { args: string[]; jqExpr?: string } {
+  const idx = args.indexOf('--jq');
+  if (idx === -1) return { args };
+  const expr = args[idx + 1];
+  if (expr === undefined) {
+    process.stderr.write('Error: --jq requires an expression argument.\n');
+    process.exit(2);
+  }
+  const next = [...args.slice(0, idx), ...args.slice(idx + 2)];
+  return { args: next, jqExpr: expr };
+}
+
+/**
+ * Validate requested `--json=<fields>` against a meta's allowlist. Exits with
+ * a sorted "Available fields" message on any unknown field.
+ *
+ * Returns the validated fields (echoed back) or null when nothing to do.
+ */
+export function validateJsonFields(
+  fields: readonly string[] | undefined,
+  meta: AgentCommandMeta | undefined,
+): readonly string[] | undefined {
+  if (!fields || fields.length === 0) return undefined;
+  const allow = meta?.jsonFields;
+  if (!allow || allow.length === 0) {
+    // No allowlist declared → accept any field (no validation).
+    return fields;
+  }
+  const unknown = fields.find((f) => !allow.includes(f));
+  if (unknown) {
+    const sorted = [...allow].sort();
+    process.stderr.write(`Error: Unknown JSON field: "${unknown}"\n`);
+    process.stderr.write('Available fields:\n');
+    for (const f of sorted) process.stderr.write(`  ${f}\n`);
+    process.exit(2);
+  }
+  return fields;
 }

--- a/src/cli/metadata/plugin-skills.ts
+++ b/src/cli/metadata/plugin-skills.ts
@@ -7,6 +7,7 @@ export const skillsListMeta: AgentCommandMeta = {
   examples: [
     'allagents skill list',
     'allagents skill list --scope user',
+    'allagents --json=name,plugin skill list',
   ],
   expectedOutput: 'Lists skills grouped by plugin with enabled/disabled status',
   options: [
@@ -15,6 +16,7 @@ export const skillsListMeta: AgentCommandMeta = {
   outputSchema: {
     skills: [{ name: 'string', plugin: 'string', disabled: 'boolean' }],
   },
+  jsonFields: ['name', 'plugin', 'disabled'] as const,
 };
 
 export const skillsRemoveMeta: AgentCommandMeta = {

--- a/src/core/skills.ts
+++ b/src/core/skills.ts
@@ -50,6 +50,7 @@ async function resolvePluginPath(
   if (isPluginSpec(pluginSource)) {
     const resolved = await resolvePluginSpecWithAutoRegister(pluginSource, {
       offline: true,
+      workspacePath,
     });
     if (!resolved.success || !resolved.path) return null;
     return {

--- a/src/core/workspace-modify.ts
+++ b/src/core/workspace-modify.ts
@@ -116,7 +116,7 @@ export async function addPlugin(
 
   // Handle plugin@marketplace format
   if (isPluginSpec(plugin)) {
-    const resolved = await resolvePluginSpecWithAutoRegister(plugin);
+    const resolved = await resolvePluginSpecWithAutoRegister(plugin, { workspacePath });
     if (!resolved.success) {
       return {
         success: false,


### PR DESCRIPTION
## Summary

Brings the gh-style `--json[=field1,field2] --jq <expr>` contract to `allagents`:

- `AgentCommandMeta.jsonFields` declares a per-command allowlist. `--json=<fields>` is validated against it at parse time; an unknown field exits 2 with a sorted `Available fields:` suggestion list.
- `--jq <expr>` pipes the envelope through the system `jq` binary (`spawnSync`, errors surfaced as `Error: --jq failed: <msg>` rather than raw stderr). `--jq` requires `--json`.
- Field projection is shape-aware: if `data` has a single top-level array of objects, the allowlist narrows each item; otherwise it projects the top-level `data` directly.
- `--agent-help` now emits `json_fields` when a meta declares an allowlist, so agents can discover the contract.
- Carries two prerequisite fixes the gate depends on:
  - The #371 metadata wiring + `command:` label correction, so the runtime command path (`skills list`) matches the meta path used for validation.
  - `addPlugin` / `getAllSkillsFromPlugins` now thread `workspacePath` to `resolvePluginSpecWithAutoRegister` — without it, project-scope marketplaces (used by `obra/superpowers`) are invisible and the install in the gate fails before list can return any skills.

## Test plan

- [x] `bun run build`, `bun run typecheck`
- [x] `bun test` — 1191 pass / 0 fail
- [x] Verification gate from #376 (using stable `obra/superpowers`):
  - Boolean `--json skills list` returns full envelope with `data.skills` array.
  - `--json=name,plugin skills list` → `.data.skills[0] | keys == ["name","plugin"]`.
  - `--json=bogus skills list` → exit 2, `Unknown JSON field` + `Available fields` printed.
  - `--json --jq '.data.skills | map(.name)' skills list` → pipes through jq, returns array.
  - `--jq` without `--json` → exit 2.
  - `--agent-help "skills list"` exposes `json_fields` as an array.

Closes #376
