### PR TITLE
fix(sync-state): drop per-skill content hash, use git ref for identity

### DIFF
--- a/src/cli/commands/plugin-skills.ts
+++ b/src/cli/commands/plugin-skills.ts
@@ -38,11 +38,7 @@ import {
 import { getHomeDir, CONFIG_DIR, WORKSPACE_CONFIG_FILE } from '../../constants.js';
 import { isGitHubUrl, parseGitHubUrl, stripGitRef } from '../../utils/plugin-path.js';
 import { fetchPlugin, getPluginName, seedFetchCache } from '../../core/plugin.js';
-import {
-  computeSkillFolderHash,
-  upsertSyncStateSource,
-  upsertSyncStateSkill,
-} from '../../core/sync-state.js';
+import { upsertSyncStateSource } from '../../core/sync-state.js';
 import { parseSkillMetadata } from '../../validators/skill.js';
 import {
   addMarketplace,
@@ -72,25 +68,10 @@ function resolveScope(cwd: string): 'user' | 'project' {
 }
 
 /**
- * Resolve the on-disk skill folder for a given plugin cache path and skill name.
- * Mirrors `resolveSkillMdPath` further down but returns the *folder* containing
- * the SKILL.md rather than the file itself.
- */
-function resolveSkillFolder(pluginPath: string, skillName: string): string | null {
-  const candidates = [
-    join(pluginPath, 'skills', skillName),
-    join(pluginPath, skillName),
-    pluginPath,
-  ];
-  for (const candidate of candidates) {
-    if (existsSync(join(candidate, 'SKILL.md'))) return candidate;
-  }
-  return null;
-}
-
-/**
- * Record per-source provenance (resolvedRef + resolvedSha + optional pin) and
- * per-skill content hash + timestamps into sync-state for the given install.
+ * Record per-source provenance (resolvedRef + resolvedSha + optional pin)
+ * into sync-state for the given install. Identity for git-based plugins is
+ * `url + ref`; `resolvedSha` (from `git rev-parse HEAD` after fetch) gives
+ * content identity, so per-skill content hashing is unnecessary.
  *
  * The source key is the spec with any `@<ref>` suffix stripped so all installs
  * of `owner/repo` map to one entry regardless of pin.
@@ -98,14 +79,13 @@ function resolveSkillFolder(pluginPath: string, skillName: string): string | nul
  * No-op for non-GitHub sources (local paths, marketplace shorthand) since we
  * can't resolve a SHA from them.
  */
-async function recordContentProvenance(opts: {
+async function recordSourceProvenance(opts: {
   from: string;
-  skills: string[];
   pinnedRef?: string | undefined;
   workspacePath: string;
   isUser: boolean;
 }): Promise<void> {
-  const { from, skills, pinnedRef, workspacePath, isUser } = opts;
+  const { from, pinnedRef, workspacePath, isUser } = opts;
   if (!isGitHubUrl(from)) return;
   const parsed = parseGitHubUrl(from);
   if (!parsed) return;
@@ -124,24 +104,6 @@ async function recordContentProvenance(opts: {
     resolvedSha: fetchResult.resolvedSha,
     ...(pinnedRef && { pinnedRef }),
   });
-
-  // Resolve the plugin root inside the cached repo (handle subpath layouts).
-  const pluginRoot = parsed.subpath
-    ? join(fetchResult.cachePath, parsed.subpath)
-    : fetchResult.cachePath;
-
-  const now = new Date().toISOString();
-  for (const skillName of skills) {
-    const folder = resolveSkillFolder(pluginRoot, skillName);
-    if (!folder) continue;
-    const hash = await computeSkillFolderHash(folder);
-    if (!hash) continue;
-    await upsertSyncStateSkill(stateRoot, key, skillName, {
-      contentHash: hash,
-      installedAt: now,
-      updatedAt: now,
-    });
-  }
 }
 
 /**
@@ -1162,12 +1124,9 @@ const addCmd = command({
           process.exit(1);
         }
 
-        // Record provenance (resolved ref/SHA + optional pin + per-skill
-        // content hashes) for every skill installed via --all.
-        const everySkill = installResult.installed.flatMap((i) => i.skills);
-        await recordContentProvenance({
+        // Record per-source ref/SHA + optional pin for the --all install path.
+        await recordSourceProvenance({
           from: fromArg,
-          skills: everySkill,
           pinnedRef,
           workspacePath: workspacePathAll,
           isUser: isUserAll,
@@ -1267,11 +1226,9 @@ const addCmd = command({
             process.exit(1);
           }
 
-          // Record per-source ref/SHA + optional pin + per-skill content
-          // hash for drift detection on subsequent syncs.
-          await recordContentProvenance({
+          // Record per-source ref/SHA + optional pin in sync-state.
+          await recordSourceProvenance({
             from,
-            skills: [skill],
             pinnedRef,
             workspacePath,
             isUser,

--- a/src/core/sync-state.ts
+++ b/src/core/sync-state.ts
@@ -1,13 +1,11 @@
-import { readFile, writeFile, mkdir, readdir } from 'node:fs/promises';
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
-import { createHash } from 'node:crypto';
-import { join, dirname, relative } from 'node:path';
+import { join, dirname } from 'node:path';
 import { CONFIG_DIR, SYNC_STATE_FILE } from '../constants.js';
 import {
   SyncStateSchema,
   type SyncState,
   type SyncStateSource,
-  type SyncStateSkill,
 } from '../models/sync-state.js';
 import type { ClientType } from '../models/workspace-config.js';
 import { ensureConfigGitignore } from './config-gitignore.js';
@@ -150,49 +148,6 @@ export function getPreviouslySyncedNativePlugins(
 }
 
 /**
- * Compute a deterministic content hash of a skill folder.
- *
- * Algorithm: for every regular file under `skillDir` (recursive),
- * compute `sha256(content)`. Sort by relative path (POSIX-style slashes) and
- * fold each as `relPath + ":" + sha + "\n"` into a final sha256. The result is
- * `"sha256:<hex>"`.
- *
- * Excludes file mtimes / inode metadata so the hash is reproducible across
- * machines and re-clones.
- *
- * Returns null if the directory does not exist or is empty.
- */
-export async function computeSkillFolderHash(skillDir: string): Promise<string | null> {
-  if (!existsSync(skillDir)) return null;
-  const entries: Array<{ rel: string; sha: string }> = [];
-
-  async function walk(dir: string): Promise<void> {
-    const dirEntries = await readdir(dir, { withFileTypes: true });
-    for (const entry of dirEntries) {
-      const full = join(dir, entry.name);
-      if (entry.isDirectory()) {
-        await walk(full);
-      } else if (entry.isFile()) {
-        const content = await readFile(full);
-        const sha = createHash('sha256').update(content).digest('hex');
-        const rel = relative(skillDir, full).split(/[\\/]/).join('/');
-        entries.push({ rel, sha });
-      }
-    }
-  }
-
-  await walk(skillDir);
-  if (entries.length === 0) return null;
-
-  entries.sort((a, b) => (a.rel < b.rel ? -1 : a.rel > b.rel ? 1 : 0));
-  const outer = createHash('sha256');
-  for (const { rel, sha } of entries) {
-    outer.update(`${rel}:${sha}\n`);
-  }
-  return `sha256:${outer.digest('hex')}`;
-}
-
-/**
  * Upsert a source provenance record into sync-state, preserving all other
  * fields. Use when recording the resolved ref/SHA after a fetch.
  */
@@ -203,37 +158,7 @@ export async function upsertSyncStateSource(
 ): Promise<void> {
   const existing = await loadSyncState(workspacePath);
   const sources = { ...(existing?.sources ?? {}), [key]: source };
-  await persistMergedSyncState(workspacePath, existing, sources);
-}
 
-/**
- * Upsert per-skill provenance (contentHash + timestamps) under the given
- * source key. Creates the source entry if it doesn't exist yet (with
- * placeholder ref/sha — callers usually call upsertSyncStateSource first).
- */
-export async function upsertSyncStateSkill(
-  workspacePath: string,
-  sourceKey: string,
-  skillName: string,
-  skill: SyncStateSkill,
-): Promise<void> {
-  const existing = await loadSyncState(workspacePath);
-  const currentSources = { ...(existing?.sources ?? {}) };
-  const currentSource: SyncStateSource = currentSources[sourceKey] ?? {
-    pluginSpec: sourceKey,
-    resolvedRef: 'HEAD',
-    resolvedSha: '',
-  };
-  const updatedSkills = { ...(currentSource.skills ?? {}), [skillName]: skill };
-  currentSources[sourceKey] = { ...currentSource, skills: updatedSkills };
-  await persistMergedSyncState(workspacePath, existing, currentSources);
-}
-
-async function persistMergedSyncState(
-  workspacePath: string,
-  existing: SyncState | null,
-  sources: Record<string, SyncStateSource>,
-): Promise<void> {
   await saveSyncState(workspacePath, {
     files: (existing?.files ?? {}) as Partial<Record<ClientType, string[]>>,
     ...(existing?.mcpServers && {

--- a/src/models/sync-state.ts
+++ b/src/models/sync-state.ts
@@ -2,38 +2,24 @@ import { z } from 'zod';
 import { ClientTypeSchema } from './workspace-config.js';
 
 /**
- * Per-skill content provenance: deterministic hash of the skill folder
- * contents at install time, plus install/update timestamps.
+ * Per-plugin source provenance.
  *
- * `contentHash` is `"sha256:<hex>"` where <hex> is sha256 over a sorted list
- * of per-file `sha256(content)` digests. Excludes file mtimes so the value is
- * reproducible across machines and clones.
+ * Identity for git-based plugins is `url + ref`. `resolvedSha` is the commit
+ * SHA returned by `git rev-parse HEAD` after the fetch and is what actually
+ * uniquely identifies the installed content; `resolvedRef` is the symbolic
+ * name (branch/tag) that was asked for. `pinnedRef` records the user's
+ * explicit pin (via `@<ref>` or `--pin`), distinct from whatever the resolver
+ * settled on.
  *
- * Field name `contentHash` is intentionally a strict subset of gh-skill's
- * `skillFolderHash` so a future migration to `.skill-lock.json` is mechanical.
- */
-export const SyncStateSkillSchema = z.object({
-  contentHash: z.string(),
-  installedAt: z.string(),
-  updatedAt: z.string(),
-});
-
-export type SyncStateSkill = z.infer<typeof SyncStateSkillSchema>;
-
-/**
- * Per-plugin source provenance: which ref was resolved when the plugin was
- * installed, optional explicit pin, and a map of per-skill content hashes.
- * Keys are indexed by canonical plugin spec (e.g., "owner/repo").
- *
- * Field names are a strict subset of the gh-skill lockfile so a future
- * migration to `.skill-lock.json` is mechanical.
+ * Per-skill content hashing was removed in #388 — `git rev-parse HEAD`
+ * already gives content identity for free, and recomputing per-skill
+ * sha256 trees on every sync was overhead without practical benefit.
  */
 export const SyncStateSourceSchema = z.object({
   pluginSpec: z.string(),
   resolvedRef: z.string(),
   resolvedSha: z.string(),
   pinnedRef: z.string().optional(),
-  skills: z.record(z.string(), SyncStateSkillSchema).optional(),
 });
 
 export type SyncStateSource = z.infer<typeof SyncStateSourceSchema>;
@@ -56,7 +42,7 @@ export const SyncStateSchema = z.object({
   vscodeWorkspaceRepos: z.array(z.string()).optional(),
   // Skills-index files tracked for cleanup (relative to .allagents/)
   skillsIndex: z.array(z.string()).optional(),
-  // Per-source resolved ref + SHA + optional pin + per-skill content hashes.
+  // Per-source resolved ref + SHA + optional pin.
   sources: z.record(z.string(), SyncStateSourceSchema).optional(),
 });
 


### PR DESCRIPTION
## Summary

Reverts the per-skill content-hash machinery from #382. Identity for git-based plugins is already provided by `url + ref` — `git rev-parse HEAD` after each fetch returns the commit SHA, which `resolvedSha` already records on the source entry. Hashing every installed skill folder on every install was CPU work for no win over what `resolvedSha` gives for free.

Mapping the issue's naming to this codebase:
- "lock file" = `.allagents/sync-state.json`'s `sources` block
- "LockFileEntry" = `SyncStateSourceSchema`
- "contentHash" = `SyncStateSkillSchema.contentHash` (per-skill, removed)
- "ref" = `resolvedRef` + `resolvedSha`
- "lastSynced" = top-level `lastSync` (already there)

## Changes

- **`src/models/sync-state.ts`** — remove `SyncStateSkillSchema` and the `skills` map on `SyncStateSourceSchema`. Each lock entry is now just `{ pluginSpec, resolvedRef, resolvedSha, pinnedRef? }`.
- **`src/core/sync-state.ts`** — drop `computeSkillFolderHash`, `upsertSyncStateSkill`, and the unused `crypto.createHash` / `readdir` / `relative` imports. The private `persistMergedSyncState` helper folds back into `upsertSyncStateSource`.
- **`src/cli/commands/plugin-skills.ts`** — rename `recordContentProvenance` → `recordSourceProvenance` and drop the now-unused `skills` param + skill-folder walk. Both callers (`--from <skill>` install and `--all`) updated.

There was no `needsSync` hash-comparison logic in the codebase — the only consumer of the hash was the `skill update` command, which was removed in #387.

## Test plan

- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `bun test` — 1209 pass / 0 fail
- [x] End-to-end: `skill add brainstorming --from obra/superpowers --pin v3.1.0` writes
  ```json
  {
    "obra/superpowers": {
      "pluginSpec": "obra/superpowers",
      "resolvedRef": "v3.1.0",
      "resolvedSha": "0bc5a5989d8cf140e9f671af14c76f6a6e6fae79",
      "pinnedRef": "v3.1.0"
    }
  }
  ```
  No `skills` map.
- [x] No remaining references to `computeSkillFolderHash`, `upsertSyncStateSkill`, `SyncStateSkill`, `contentHash`, or `skillFolderHash` anywhere in `src/` or `tests/`.

Closes #388
