### PR TITLE
feat(skill-search): namespace-aware parsing, ranking, and dedup

### DIFF
--- a/src/core/skill-search.ts
+++ b/src/core/skill-search.ts
@@ -15,6 +15,13 @@ const OWNER_REGEX = /^[A-Za-z0-9-]{1,39}$/;
 export interface SkillSearchItem {
   /** Skill folder name (parent directory of SKILL.md). */
   name: string;
+  /**
+   * Optional namespace segment from `skills/<namespace>/<name>/SKILL.md`.
+   * Empty string when the path is `skills/<name>/SKILL.md` or otherwise
+   * non-namespaced. Two repos with the same skill name in different
+   * namespaces (`kynan/commit` vs `will/commit`) stay distinct.
+   */
+  namespace: string;
   /** `owner/repo` */
   repo: string;
   /** Path to SKILL.md inside the repo. */
@@ -107,12 +114,71 @@ function buildQueryString(query: string, owner: string | undefined): string {
 }
 
 /**
+ * Render the namespace-qualified skill name (`<namespace>/<name>`) when a
+ * namespace is set, or just `<name>` otherwise. Used both for ranking
+ * (so `kynan/commit` matches the query "kynan/commit") and as the dedup
+ * key together with the repo full name.
+ */
+export function qualifiedName(item: Pick<SkillSearchItem, 'name' | 'namespace'>): string {
+  return item.namespace ? `${item.namespace}/${item.name}` : item.name;
+}
+
+/**
+ * Extract `(namespace, name)` from a Code Search `path` entry.
+ *
+ * Layouts handled:
+ *   - `skills/<ns>/<name>/SKILL.md`   → { namespace: <ns>, name: <name> }
+ *   - `<prefix>/skills/<ns>/<name>/SKILL.md` (plugin subdir)
+ *                                     → { namespace: <ns>, name: <name> }
+ *   - `skills/<name>/SKILL.md`        → { namespace: '',   name: <name> }
+ *   - `<name>/SKILL.md`               → { namespace: '',   name: <name> }
+ *   - `SKILL.md` at repo root         → { namespace: '',   name: <repoFallback> }
+ *
+ * Anything that doesn't fit drops to the bare parent-directory fallback.
+ */
+function parseSkillPath(
+  path: string,
+  repoFallback: string,
+): { namespace: string; name: string } {
+  const parts = path.split('/').filter(Boolean);
+
+  // Find the last `skills` segment so nested layouts
+  // (e.g., `plugins/foo/skills/<ns>/<name>/SKILL.md`) still parse.
+  const skillsIdx = parts.lastIndexOf('skills');
+  if (skillsIdx !== -1) {
+    const afterSkills = parts.slice(skillsIdx + 1);
+    // Drop a trailing `SKILL.md` segment if present.
+    const meaningful =
+      afterSkills[afterSkills.length - 1] === 'SKILL.md'
+        ? afterSkills.slice(0, -1)
+        : afterSkills;
+    if (meaningful.length >= 2) {
+      const namespace = meaningful[0] ?? '';
+      const name = meaningful[1] ?? '';
+      if (namespace && name) return { namespace, name };
+    }
+    if (meaningful.length === 1 && meaningful[0]) {
+      return { namespace: '', name: meaningful[0] };
+    }
+  }
+
+  // No `skills` segment — use the parent directory of SKILL.md as the name.
+  if (parts.length >= 2) {
+    const parent = parts[parts.length - 2];
+    if (parent) return { namespace: '', name: parent };
+  }
+
+  return { namespace: '', name: repoFallback };
+}
+
+/**
  * Run the GitHub Code Search request. Network/auth comes from the environment
  * via fetch + GITHUB_TOKEN; no extra deps.
  *
- * Items are returned in upstream relevance order. The handler may apply
- * name-match-first re-ranking on top of this — kept separate so the wire
- * format stays close to the gh-skill reference impl.
+ * Items are returned in upstream relevance order, then re-ranked by
+ * qualified-name match against the query and deduped by
+ * `repo + qualifiedName`. Dedup matters because Code Search will sometimes
+ * return the same skill folder twice via different match contexts.
  */
 export async function searchSkills(
   query: string,
@@ -159,32 +225,58 @@ export async function searchSkills(
       repository?: { full_name?: string; description?: string };
     }>;
   };
+
   const items: SkillSearchItem[] = (parsed.items ?? []).map((item) => {
     const path = item.path ?? '';
-    // Skill name = parent dir of SKILL.md. For `skills/<name>/SKILL.md` this is
-    // <name>; for repo-root `SKILL.md` the parent is the repo name.
-    const parts = path.split('/');
-    const name = parts.length >= 2 ? parts[parts.length - 2] ?? '' : item.repository?.full_name?.split('/').pop() ?? '';
+    const repo = item.repository?.full_name ?? '';
+    const repoFallback = repo.split('/').pop() ?? '';
+    const { namespace, name } = parseSkillPath(path, repoFallback);
     return {
       name,
-      repo: item.repository?.full_name ?? '',
+      namespace,
+      repo,
       path,
       description: item.repository?.description ?? '',
       sha: item.sha ?? '',
     };
   });
 
+  const deduped = dedupeItems(items);
+
   return {
     query,
-    items: rankItems(items, query),
-    total: parsed.total_count ?? items.length,
+    items: rankItems(deduped, query),
+    total: parsed.total_count ?? deduped.length,
     truncated: Boolean(parsed.incomplete_results),
   };
 }
 
 /**
- * Rank items: exact name match first, then prefix-match, then upstream order.
- * Mirrors gh-skill's relevance heuristic so users see the obvious hits up top.
+ * Drop duplicate hits by `repo + qualifiedName`. The Code Search API can
+ * return the same skill folder more than once when multiple lines in
+ * SKILL.md match the query; the user only cares about the folder.
+ *
+ * Preserves the first occurrence so upstream relevance order is respected
+ * before re-ranking.
+ */
+function dedupeItems(items: SkillSearchItem[]): SkillSearchItem[] {
+  const seen = new Set<string>();
+  const out: SkillSearchItem[] = [];
+  for (const item of items) {
+    const key = `${item.repo}#${qualifiedName(item)}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(item);
+  }
+  return out;
+}
+
+/**
+ * Rank items: exact qualified-name match first, then prefix-match, then
+ * substring, then upstream order. Using `qualifiedName` means a query like
+ * `kynan/commit` matches the namespaced skill exactly while a query like
+ * `commit` still falls through to substring matches on both
+ * `kynan/commit` and `will/commit`.
  */
 function rankItems(items: SkillSearchItem[], query: string): SkillSearchItem[] {
   const q = query.toLowerCase();
@@ -196,9 +288,9 @@ function rankItems(items: SkillSearchItem[], query: string): SkillSearchItem[] {
 }
 
 function score(item: SkillSearchItem, q: string): number {
-  const name = item.name.toLowerCase();
-  if (name === q) return 3;
-  if (name.startsWith(q)) return 2;
-  if (name.includes(q)) return 1;
+  const qn = qualifiedName(item).toLowerCase();
+  if (qn === q) return 3;
+  if (qn.startsWith(q)) return 2;
+  if (qn.includes(q)) return 1;
   return 0;
 }

--- a/tests/unit/core/skill-search.test.ts
+++ b/tests/unit/core/skill-search.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'bun:test';
 import {
   SkillSearchError,
+  qualifiedName,
   searchSkills,
   validateSkillSearchArgs,
 } from '../../../src/core/skill-search.js';
@@ -26,6 +27,16 @@ describe('validateSkillSearchArgs', () => {
 
   it('accepts valid arguments', () => {
     expect(() => validateSkillSearchArgs('docs', { page: 2, limit: 50, owner: 'github' })).not.toThrow();
+  });
+});
+
+describe('qualifiedName', () => {
+  it('returns `<namespace>/<name>` when a namespace is set', () => {
+    expect(qualifiedName({ namespace: 'kynan', name: 'commit' })).toBe('kynan/commit');
+  });
+
+  it('returns just `<name>` when namespace is empty', () => {
+    expect(qualifiedName({ namespace: '', name: 'commit' })).toBe('commit');
   });
 });
 
@@ -91,5 +102,182 @@ describe('searchSkills error mapping', () => {
     expect(result.items.length).toBe(2);
     expect(result.items.map((i) => i.name)).toContain('docs-writer');
     expect(result.items.map((i) => i.name)).toContain('api-docs');
+    // Non-namespaced paths get empty namespace strings.
+    for (const item of result.items) {
+      expect(item.namespace).toBe('');
+    }
+  });
+});
+
+describe('namespace extraction', () => {
+  it('parses skills/<ns>/<name>/SKILL.md into namespace + name', async () => {
+    const fakeFetch = (async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        total_count: 2,
+        incomplete_results: false,
+        items: [
+          {
+            path: 'skills/kynan/commit/SKILL.md',
+            sha: 'a1',
+            repository: { full_name: 'org/skills', description: '' },
+          },
+          {
+            path: 'skills/will/commit/SKILL.md',
+            sha: 'b2',
+            repository: { full_name: 'org/skills', description: '' },
+          },
+        ],
+      }),
+    })) as unknown as typeof fetch;
+
+    const result = await searchSkills('commit', {}, { fetch: fakeFetch });
+    expect(result.items.length).toBe(2);
+    const byKey = new Map(result.items.map((i) => [`${i.namespace}/${i.name}`, i]));
+    expect(byKey.has('kynan/commit')).toBe(true);
+    expect(byKey.has('will/commit')).toBe(true);
+    expect(byKey.get('kynan/commit')?.namespace).toBe('kynan');
+    expect(byKey.get('kynan/commit')?.name).toBe('commit');
+  });
+
+  it('parses non-namespaced skills/<name>/SKILL.md with empty namespace', async () => {
+    const fakeFetch = (async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        total_count: 1,
+        incomplete_results: false,
+        items: [
+          {
+            path: 'skills/brainstorming/SKILL.md',
+            sha: 'cc',
+            repository: { full_name: 'obra/superpowers', description: '' },
+          },
+        ],
+      }),
+    })) as unknown as typeof fetch;
+
+    const result = await searchSkills('brainstorming', {}, { fetch: fakeFetch });
+    expect(result.items[0]?.namespace).toBe('');
+    expect(result.items[0]?.name).toBe('brainstorming');
+  });
+
+  it('parses nested plugin layouts like plugins/foo/skills/<ns>/<name>/SKILL.md', async () => {
+    const fakeFetch = (async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        total_count: 1,
+        incomplete_results: false,
+        items: [
+          {
+            path: 'plugins/foo/skills/team-a/deploy/SKILL.md',
+            sha: 'cc',
+            repository: { full_name: 'org/repo', description: '' },
+          },
+        ],
+      }),
+    })) as unknown as typeof fetch;
+
+    const result = await searchSkills('deploy', {}, { fetch: fakeFetch });
+    expect(result.items[0]?.namespace).toBe('team-a');
+    expect(result.items[0]?.name).toBe('deploy');
+  });
+});
+
+describe('dedup + ranking', () => {
+  it('deduplicates hits by repo + qualifiedName', async () => {
+    const fakeFetch = (async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        total_count: 3,
+        incomplete_results: false,
+        items: [
+          {
+            path: 'skills/kynan/commit/SKILL.md',
+            sha: 'first-match',
+            repository: { full_name: 'org/skills', description: '' },
+          },
+          {
+            path: 'skills/kynan/commit/SKILL.md',
+            sha: 'duplicate-match',
+            repository: { full_name: 'org/skills', description: '' },
+          },
+          {
+            path: 'skills/will/commit/SKILL.md',
+            sha: 'distinct',
+            repository: { full_name: 'org/skills', description: '' },
+          },
+        ],
+      }),
+    })) as unknown as typeof fetch;
+
+    const result = await searchSkills('commit', {}, { fetch: fakeFetch });
+    expect(result.items.length).toBe(2);
+    const qnames = result.items.map((i) => `${i.namespace}/${i.name}`);
+    expect(qnames).toContain('kynan/commit');
+    expect(qnames).toContain('will/commit');
+    // First-occurrence preservation: the surviving kynan/commit entry has the
+    // first match's sha.
+    const kynan = result.items.find((i) => i.namespace === 'kynan' && i.name === 'commit');
+    expect(kynan?.sha).toBe('first-match');
+  });
+
+  it('keeps same-name skills in different repos as separate hits', async () => {
+    const fakeFetch = (async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        total_count: 2,
+        incomplete_results: false,
+        items: [
+          {
+            path: 'skills/commit/SKILL.md',
+            sha: 'r1',
+            repository: { full_name: 'orgA/repo', description: '' },
+          },
+          {
+            path: 'skills/commit/SKILL.md',
+            sha: 'r2',
+            repository: { full_name: 'orgB/repo', description: '' },
+          },
+        ],
+      }),
+    })) as unknown as typeof fetch;
+
+    const result = await searchSkills('commit', {}, { fetch: fakeFetch });
+    expect(result.items.length).toBe(2);
+    expect(new Set(result.items.map((i) => i.repo)).size).toBe(2);
+  });
+
+  it('ranks an exact qualified-name match above a substring match', async () => {
+    const fakeFetch = (async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        total_count: 2,
+        incomplete_results: false,
+        items: [
+          // Substring match on the bare name.
+          {
+            path: 'skills/will/commit-helper/SKILL.md',
+            sha: 's1',
+            repository: { full_name: 'org/skills', description: '' },
+          },
+          // Exact match on the qualified name.
+          {
+            path: 'skills/kynan/commit/SKILL.md',
+            sha: 's2',
+            repository: { full_name: 'org/skills', description: '' },
+          },
+        ],
+      }),
+    })) as unknown as typeof fetch;
+
+    const result = await searchSkills('kynan/commit', {}, { fetch: fakeFetch });
+    expect(result.items[0]?.namespace).toBe('kynan');
+    expect(result.items[0]?.name).toBe('commit');
   });
 });


### PR DESCRIPTION
## Summary

Two skills called `commit` in different namespaces (`skills/kynan/commit` vs `skills/will/commit`) previously fought for the same slot in `skill search` results — ranking compared bare folder names and there was no dedup step, so a future caller keying on `(repo, name)` could silently lose one of them.

Adds:
- `namespace` field on `SkillSearchItem`, populated by a new `parseSkillPath` helper. Handles `skills/<ns>/<name>/SKILL.md`, nested plugin layouts (`<prefix>/skills/<ns>/<name>/SKILL.md`), flat `skills/<name>/SKILL.md` (empty namespace), bare `<name>/SKILL.md`, and the repo-root `SKILL.md` fallback.
- Exported `qualifiedName()` helper — returns `<namespace>/<name>` when a namespace is set, just `<name>` otherwise.
- `rankItems` / `score` switched to `qualifiedName` so `kynan/commit` exact-matches the namespaced skill while a bare query like `commit` still substring-matches both `kynan/commit` and `will/commit`.
- `dedupeItems` step drops repeats by `repo + qualifiedName` before ranking. Code Search sometimes returns the same skill folder more than once for separate match contexts. First-occurrence wins so upstream relevance order is preserved.

`namespace` shows up in the `--json` envelope automatically — it's a field on the interface that `data.items[]` already emits. Per the task brief I didn't touch the metadata file's `outputSchema` (documentation only).

## Test plan

- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `bun test tests/unit/core/skill-search.test.ts` — 16 pass / 0 fail
- [x] `bun test` — 1217 pass / 0 fail across the whole suite
- [x] Eight new test cases cover:
  - `qualifiedName()` for both namespaced and bare items
  - `skills/<ns>/<name>/SKILL.md` → `{ namespace, name }`
  - `skills/<name>/SKILL.md` → `{ namespace: '', name }`
  - `<prefix>/skills/<ns>/<name>/SKILL.md` (nested plugin layout)
  - Same `qualifiedName` in the same repo → deduped (first occurrence wins)
  - Same folder name in two different repos → kept as separate hits
  - Query `kynan/commit` ranks the exact namespaced match above a substring match on the bare name

Closes #390
