### PR TITLE
fix(mcp): use native Windows browser opener

### DIFF
--- a/src/core/mcp-http-stdio-proxy.ts
+++ b/src/core/mcp-http-stdio-proxy.ts
@@ -129,16 +129,22 @@ function findFreePort(): Promise<number> {
   });
 }
 
+export function getBrowserOpenCommands(
+  url: string,
+  platform: NodeJS.Platform = process.platform,
+): Array<{ command: string; args: string[] }> {
+  return platform === 'darwin'
+    ? [{ command: 'open', args: [url] }]
+    : platform === 'win32'
+      ? [{ command: 'explorer.exe', args: [url] }]
+      : [
+          { command: 'xdg-open', args: [url] },
+          { command: 'gio', args: ['open', url] },
+        ];
+}
+
 function tryOpenBrowser(url: string): Promise<void> {
-  const commands: Array<{ command: string; args: string[] }> =
-    process.platform === 'darwin'
-      ? [{ command: 'open', args: [url] }]
-      : process.platform === 'win32'
-        ? [{ command: 'cmd', args: ['/c', 'start', '', url] }]
-        : [
-            { command: 'xdg-open', args: [url] },
-            { command: 'gio', args: ['open', url] },
-          ];
+  const commands = getBrowserOpenCommands(url);
 
   return new Promise((resolve) => {
     const tryCommand = (index: number) => {

--- a/tests/unit/core/mcp-http-stdio-proxy.test.ts
+++ b/tests/unit/core/mcp-http-stdio-proxy.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from 'bun:test';
+import { getBrowserOpenCommands } from '../../../src/core/mcp-http-stdio-proxy.js';
+
+describe('getBrowserOpenCommands', () => {
+  test('uses explorer on Windows so OAuth URLs are not parsed by cmd', () => {
+    const url =
+      'https://idp.example/auth?response_type=code&client_id=test&state=abc';
+
+    expect(getBrowserOpenCommands(url, 'win32')).toEqual([
+      { command: 'explorer.exe', args: [url] },
+    ]);
+  });
+});


### PR DESCRIPTION
Closes #396\n\n## Summary\n- replace the Windows OAuth browser opener path with a direct native launcher\n- avoid passing auth URLs through cmd /c start\n- add a regression test for the Windows command selection\n\n## Validation\n- bun test tests/unit/core/mcp-http-stdio-proxy.test.ts\n- bun run build