### PR TITLE
feat(cli): promote init to top-level command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ AllAgents keeps your AI tooling (skills, agents, hooks, MCP servers) in one work
 
 ```bash
 # Create a workspace from a shared template
-npx allagents workspace init my-workspace --from myorg/templates/nodejs
+npx allagents init my-workspace --from myorg/templates/nodejs
 cd my-workspace
 
 # Install plugins
@@ -89,7 +89,7 @@ clients:
 
 | Command | Description |
 |---|---|
-| `allagents workspace init <path>` | Create a workspace (optionally `--from owner/repo`) |
+| `allagents init <path>` | Create a workspace (optionally `--from owner/repo`) |
 | `allagents update` | Sync all plugins to workspace |
 | `allagents plugin install <spec>` | Install a plugin |
 | `allagents plugin uninstall <spec>` | Remove a plugin |

--- a/src/cli/commands/workspace.ts
+++ b/src/cli/commands/workspace.ts
@@ -675,7 +675,7 @@ const repoCmd = conciseSubcommands({
 // workspace subcommands group
 // =============================================================================
 
-export { syncCmd };
+export { syncCmd, initCmd };
 
 export const workspaceCmd = conciseSubcommands({
   name: 'workspace',

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,7 +2,7 @@
 
 import { run } from 'cmd-ts';
 import { conciseSubcommands } from './help.js';
-import { workspaceCmd, syncCmd } from './commands/workspace.js';
+import { workspaceCmd, syncCmd, initCmd } from './commands/workspace.js';
 import { pluginCmd } from './commands/plugin.js';
 import { mcpCmd } from './commands/mcp.js';
 import { selfCmd } from './commands/self.js';
@@ -28,6 +28,7 @@ const app = conciseSubcommands({
     'For AI agents: use --agent-help for machine-readable help, or --json for structured output',
   version: packageJson.version,
   cmds: {
+    init: initCmd,
     update: syncCmd,
     workspace: workspaceCmd,
     plugin: pluginCmd,

--- a/src/cli/metadata/workspace.ts
+++ b/src/cli/metadata/workspace.ts
@@ -1,14 +1,14 @@
 import type { AgentCommandMeta } from '../help.js';
 
 export const initMeta: AgentCommandMeta = {
-  command: 'workspace init',
+  command: 'init',
   description: 'Create new workspace and sync plugins',
   whenToUse: 'When starting a new project or adding allagents to an existing repo for the first time',
   examples: [
-    'allagents workspace init',
-    'allagents workspace init ./my-project',
-    'allagents workspace init --from ../template-workspace/.allagents/workspace.yaml',
-    'allagents workspace init --client claude,copilot,cursor',
+    'allagents init',
+    'allagents init ./my-project',
+    'allagents init --from ../template-workspace/.allagents/workspace.yaml',
+    'allagents init --client claude,copilot,cursor',
   ],
   expectedOutput:
     'Creates .allagents/workspace.yaml and syncs plugins. Shows sync results per plugin. Exit 0 on success, exit 1 on failure.',

--- a/tests/e2e/cli-enriched-help.test.ts
+++ b/tests/e2e/cli-enriched-help.test.ts
@@ -8,7 +8,7 @@ import { updateMeta } from '../../src/cli/metadata/self.js';
  * All command metadata objects that must have enriched help.
  */
 const allCommandMetas: { name: string; meta: CommandMeta }[] = [
-  { name: 'workspace init', meta: initMeta },
+  { name: 'init', meta: initMeta },
   { name: 'update', meta: syncMeta },
   { name: 'workspace status', meta: statusMeta },
   { name: 'plugin install', meta: pluginInstallMeta },

--- a/tests/unit/cli/agent-help.test.ts
+++ b/tests/unit/cli/agent-help.test.ts
@@ -75,6 +75,7 @@ describe('agent command metadata', () => {
   test('all expected commands are present', () => {
     const names = allCommands.map((c) => c.command).sort();
     expect(names).toEqual([
+      'init',
       'plugin install',
       'plugin list',
       'plugin marketplace add',
@@ -90,7 +91,6 @@ describe('agent command metadata', () => {
       'skill remove',
       'skill search',
       'update',
-      'workspace init',
       'workspace status',
     ]);
   });


### PR DESCRIPTION
## Summary

- `allagents init <path>` is now available as a top-level command
- `workspace init` is preserved as a backward-compatible alias
- Updated metadata, examples, and README to use the canonical `allagents init` form

## Changes

- `src/cli/index.ts` — register `init` at the root alongside `update`, `workspace`, etc.
- `src/cli/commands/workspace.ts` — export `initCmd` for use in the root
- `src/cli/metadata/workspace.ts` — update `command` field to `'init'` and examples to `allagents init`
- Tests and README updated to reflect the new canonical path

## E2E Test Plan

```bash
# Build
bun run build

# New top-level command
./dist/index.js init /tmp/test-new --client claude
# ✓ Workspace created at: /tmp/test-new

# Backward-compat alias still works
./dist/index.js workspace init /tmp/test-compat --client claude
# ✓ Workspace created at: /tmp/test-compat
```