### PR TITLE
fix(cli): align skill search UX with gh

### DIFF
--- a/src/cli/commands/plugin-skills.ts
+++ b/src/cli/commands/plugin-skills.ts
@@ -1365,9 +1365,13 @@ const addCmd = command({
 // skill search (GitHub Code Search)
 // =============================================================================
 
+export function formatSkillSearchSummary(count: number, query: string, truncated: boolean): string {
+  return `Showing ${count} skill${count !== 1 ? 's' : ''} matching "${query}"${truncated ? ' (truncated)' : ''}`;
+}
+
 /** Print results in gh-compatible tabular format: repo, skillName, description, stars. */
 function printSearchResults(items: SkillSearchItem[], query: string, truncated: boolean): void {
-  console.log(`\nShowing ${items.length} result${items.length !== 1 ? 's' : ''} for "${query}"${truncated ? ' (truncated)' : ''}\n`);
+  console.log(`\n${formatSkillSearchSummary(items.length, query, truncated)}\n`);
   for (const item of items) {
     const repoCol = item.repo.padEnd(30);
     const nameCol = qualifiedName(item).padEnd(24);
@@ -1522,9 +1526,9 @@ const searchCmd = command({
       }
 
       // Interactive mode: filter-as-you-type select with install support
-      const { autocomplete, isCancel } = await import('@clack/prompts');
+      const { autocomplete, isCancel, log } = await import('@clack/prompts');
 
-      printSearchResults(result.items, query, result.truncated);
+      log.success(formatSkillSearchSummary(result.items.length, query, result.truncated));
 
       const options = result.items.map((item) => ({
         label: `${qualifiedName(item)}  ${chalk.dim(item.repo)}`,
@@ -1534,7 +1538,7 @@ const searchCmd = command({
       options.push({ label: 'Cancel', value: '__cancel__', hint: '' });
 
       const selected = await autocomplete({
-        message: `Select a skill to install (type to filter ${result.items.length} results)`,
+        message: 'Select a skill to install',
         options,
         placeholder: 'Type to filter...',
       });

--- a/tests/unit/cli/skill-search-summary.test.ts
+++ b/tests/unit/cli/skill-search-summary.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'bun:test';
+import { formatSkillSearchSummary } from '../../../src/cli/commands/plugin-skills.js';
+
+describe('formatSkillSearchSummary', () => {
+  it('uses singular skill wording for one match', () => {
+    expect(formatSkillSearchSummary(1, 'skill-source-mapping', false)).toBe(
+      'Showing 1 skill matching "skill-source-mapping"',
+    );
+  });
+
+  it('uses plural skills wording for multiple matches', () => {
+    expect(formatSkillSearchSummary(2, 'mapping', false)).toBe(
+      'Showing 2 skills matching "mapping"',
+    );
+  });
+
+  it('includes truncated marker when applicable', () => {
+    expect(formatSkillSearchSummary(15, 'mapping', true)).toBe(
+      'Showing 15 skills matching "mapping" (truncated)',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- rename `skill search` summary output from result/results to skill/skills
- remove the redundant top results table in interactive TTY mode
- keep non-interactive tabular output and add a unit test for the summary wording

## E2E
### Red
```bash
cd /tmp/<empty-dir>
node /home/christso/projects/EntityProcess/allagents.worktrees/fix-skill-search-ux/dist/index.js skill search skill-source-mapping
```
Observed the old interactive UX showed both:
- `Showing 1 result for "skill-source-mapping"`
- a duplicated top results block above the install picker

### Green
```bash
cd /tmp/<empty-dir>
node /home/christso/projects/EntityProcess/allagents.worktrees/fix-skill-search-ux/dist/index.js skill search skill-source-mapping
```
Observed the updated interactive UX now shows:
- `Showing 1 skill matching "skill-source-mapping"`
- only the install picker list, without the duplicated top results block
