### PR TITLE
fix(workspace): preserve git env for remote clones

### DIFF
--- a/src/core/git.ts
+++ b/src/core/git.ts
@@ -14,6 +14,14 @@ const CLONE_TIMEOUT_MS = (() => {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_CLONE_TIMEOUT_MS;
 })();
 
+export function createGitEnv(): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    GIT_TERMINAL_PROMPT: '0',
+    GIT_LFS_SKIP_SMUDGE: '1',
+  };
+}
+
 function createGit(baseDir?: string) {
   return simpleGit(baseDir, {
     timeout: { block: CLONE_TIMEOUT_MS },
@@ -23,10 +31,7 @@ function createGit(baseDir?: string) {
       'filter.lfs.clean=',
       'filter.lfs.process=',
     ],
-  }).env({
-    GIT_TERMINAL_PROMPT: '0',
-    GIT_LFS_SKIP_SMUDGE: '1',
-  });
+  }).env(createGitEnv());
 }
 
 /**

--- a/src/core/managed-repos.ts
+++ b/src/core/managed-repos.ts
@@ -4,6 +4,7 @@ import { dirname, resolve } from 'node:path';
 import simpleGit from 'simple-git';
 import type { Repository, ManagedMode } from '../models/workspace-config.js';
 import { getHomeDir } from '../constants.js';
+import { createGitEnv } from './git.js';
 
 const CLONE_TIMEOUT_MS = 120_000; // 2 minutes for full clone
 
@@ -80,7 +81,7 @@ export function buildCloneUrl(source: string, repo: string): string {
  */
 async function cloneRepo(url: string, dest: string, branch?: string): Promise<void> {
   await mkdir(dirname(dest), { recursive: true });
-  const git = simpleGit({ timeout: { block: CLONE_TIMEOUT_MS } });
+  const git = simpleGit({ timeout: { block: CLONE_TIMEOUT_MS } }).env(createGitEnv());
   const cloneOptions = branch ? ['--branch', branch] : [];
   await git.clone(url, dest, cloneOptions);
 }
@@ -90,7 +91,7 @@ async function cloneRepo(url: string, dest: string, branch?: string): Promise<vo
  * Returns a skip reason if pull is unsafe, or undefined on success.
  */
 async function pullRepo(repoPath: string, branch?: string): Promise<string | undefined> {
-  const git = simpleGit(repoPath, { timeout: { block: CLONE_TIMEOUT_MS } });
+  const git = simpleGit(repoPath, { timeout: { block: CLONE_TIMEOUT_MS } }).env(createGitEnv());
 
   // Check for uncommitted changes
   const status = await git.status();

--- a/tests/unit/core/git.test.ts
+++ b/tests/unit/core/git.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { createGitEnv } from '../../../src/core/git.js';
+
+describe('createGitEnv', () => {
+  const originalHome = process.env.HOME;
+  const originalPath = process.env.PATH;
+  const originalPrompt = process.env.GIT_TERMINAL_PROMPT;
+  const originalSkipSmudge = process.env.GIT_LFS_SKIP_SMUDGE;
+
+  beforeEach(() => {
+    process.env.HOME = '/tmp/test-home';
+    process.env.PATH = '/tmp/test-path';
+    process.env.GIT_TERMINAL_PROMPT = '1';
+    process.env.GIT_LFS_SKIP_SMUDGE = '0';
+  });
+
+  afterEach(() => {
+    process.env.HOME = originalHome;
+    process.env.PATH = originalPath;
+    process.env.GIT_TERMINAL_PROMPT = originalPrompt;
+    process.env.GIT_LFS_SKIP_SMUDGE = originalSkipSmudge;
+  });
+
+  it('preserves inherited git environment while applying allagents overrides', () => {
+    const gitEnv = createGitEnv();
+
+    expect(gitEnv).toMatchObject({
+      HOME: '/tmp/test-home',
+      PATH: '/tmp/test-path',
+      GIT_TERMINAL_PROMPT: '0',
+      GIT_LFS_SKIP_SMUDGE: '1',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- preserve the inherited process environment when allagents shells out to git
- keep non-interactive git safeguards while allowing user git config and credentials to remain available
- apply the same env handling to managed repository clone/pull paths and cover the helper with a unit test

## Reproduction
```bash
npx allagents@next workspace init ./cargowise-allagents-1 --from https://github.com/WiseTechGlobal/WTG.AI.Prompts/tree/main/scripts/allagents-setup/cargowise
```

Before this change, that failed with:
```
Error: Failed to initialize workspace: Authentication failed for WiseTechGlobal/WTG.AI.Prompts.
  Check your SSH keys or git credentials.
```

## E2E
```bash
cd /home/entity/projects/EntityProcess/allagents.worktrees/fix-workspace-init-auth
bun run build
node ./dist/index.js workspace init /tmp/cargowise-allagents-green --from https://github.com/WiseTechGlobal/WTG.AI.Prompts/tree/main/scripts/allagents-setup/cargowise
```
Verified the workspace initializes successfully and writes `/tmp/cargowise-allagents-green/.allagents/workspace.yaml`.

## Validation
```bash
bun run lint
bun test
bun run build
```