### PR TITLE
fix(status): match branch-qualified cache for GitHub plugins

### DIFF
--- a/src/core/status.ts
+++ b/src/core/status.ts
@@ -102,7 +102,7 @@ function getPluginStatus(parsed: ParsedPluginSource): PluginStatus {
     // Check if cached
     const cachePath =
       parsed.owner && parsed.repo
-        ? getPluginCachePath(parsed.owner, parsed.repo)
+        ? getPluginCachePath(parsed.owner, parsed.repo, parsed.branch)
         : '';
     const available = cachePath ? existsSync(cachePath) : false;
 

--- a/src/utils/plugin-path.ts
+++ b/src/utils/plugin-path.ts
@@ -48,6 +48,7 @@ export interface ParsedPluginSource {
   normalized: string;
   owner?: string;
   repo?: string;
+  branch?: string;
 }
 
 /**
@@ -282,6 +283,7 @@ export function parsePluginSource(
       normalized: source,
       ...(parsed?.owner && { owner: parsed.owner }),
       ...(parsed?.repo && { repo: parsed.repo }),
+      ...(parsed?.branch && { branch: parsed.branch }),
     };
   }
 

--- a/tests/unit/core/status-both-scopes.test.ts
+++ b/tests/unit/core/status-both-scopes.test.ts
@@ -142,4 +142,37 @@ describe('workspace status - both scopes', () => {
 
     await rm(separateHome, { recursive: true, force: true });
   });
+
+  it('should mark GitHub plugin as cached when cache is branch-qualified', async () => {
+    // Regression: `skills add <github-blob-url>` clones into `<owner>-<repo>@<branch>`,
+    // but `workspace status` looked up `<owner>-<repo>` and reported "not cached".
+    const homeDir = await mkdtemp(join(tmpdir(), 'allagents-status-home-'));
+    process.env.HOME = homeDir;
+
+    const branchedCache = join(
+      homeDir,
+      '.allagents',
+      'plugins',
+      'marketplaces',
+      'NousResearch-hermes-agent@main',
+    );
+    await mkdir(branchedCache, { recursive: true });
+
+    await writeProjectConfig({
+      repositories: [],
+      plugins: [
+        'https://github.com/NousResearch/hermes-agent/blob/main/skills/research/llm-wiki',
+      ],
+      clients: ['claude'],
+    });
+
+    const result = await getWorkspaceStatus(testDir);
+    expect(result.success).toBe(true);
+    expect(result.plugins.length).toBe(1);
+    expect(result.plugins[0]?.type).toBe('github');
+    expect(result.plugins[0]?.available).toBe(true);
+    expect(result.plugins[0]?.path).toBe(branchedCache);
+
+    await rm(homeDir, { recursive: true, force: true });
+  });
 });

--- a/tests/unit/utils/plugin-path.test.ts
+++ b/tests/unit/utils/plugin-path.test.ts
@@ -243,7 +243,26 @@ describe('parsePluginSource', () => {
     expect(result.type).toBe('github');
     expect(result.owner).toBe('owner');
     expect(result.repo).toBe('repo');
+    expect(result.branch).toBeUndefined();
     expect(result.original).toBe('https://github.com/owner/repo');
+  });
+
+  it('should preserve branch from /blob/ URLs so the cache lookup is branch-qualified', () => {
+    const result = parsePluginSource(
+      'https://github.com/owner/repo/blob/main/skills/research/llm-wiki',
+    );
+    expect(result.type).toBe('github');
+    expect(result.owner).toBe('owner');
+    expect(result.repo).toBe('repo');
+    expect(result.branch).toBe('main');
+  });
+
+  it('should preserve branch from owner/repo@ref shorthand', () => {
+    const result = parsePluginSource('owner/repo@v1.2.0');
+    expect(result.type).toBe('github');
+    expect(result.owner).toBe('owner');
+    expect(result.repo).toBe('repo');
+    expect(result.branch).toBe('v1.2.0');
   });
 
   it('should parse local absolute paths', () => {


### PR DESCRIPTION
## Summary
- `workspace status` reported `✗ not cached` for any GitHub plugin whose source pins a branch (e.g. `/blob/main/...` or `owner/repo@v1`), even immediately after a successful `skills add`.
- Root cause: `parsePluginSource` discarded the `branch` field returned by `parseGitHubUrl`, so `getPluginStatus` called `getPluginCachePath(owner, repo)` without it and looked at `~/.allagents/plugins/marketplaces/<owner>-<repo>`. But `fetchPlugin` (`src/core/plugin.ts:102,160`) and `seedCacheFromClone` (`src/core/workspace.ts:381`) write to `<owner>-<repo>@<branch>`, so the existence check always missed.
- Fix: add `branch?: string` to `ParsedPluginSource`, populate it in `parsePluginSource`, and pass it through to `getPluginCachePath` in `getPluginStatus`. No other call sites needed changes — they already pass branch directly.

## Repro (before)
```
$ npx allagents skills add https://github.com/NousResearch/hermes-agent/blob/main/skills/research/llm-wiki
✓ Enabled skill: llm-wiki (llm-wiki)
$ npx allagents workspace status
Project Plugins (1):
  ✗ https://github.com/.../llm-wiki (not cached)
```
After the fix, the same command reports `✓ ... (cached)`.

## Test plan
- [x] `bun test tests/unit/utils/plugin-path.test.ts tests/unit/core/status-both-scopes.test.ts` — added one test for `parsePluginSource` returning `branch` from a `/blob/` URL, one for `owner/repo@ref` shorthand, and one regression test asserting status reports `available: true` against a branch-qualified cache dir.
- [x] `bun test` — full suite (1285 pass, 4 skip, 0 fail).
- [x] `bun run typecheck` — clean.
- [x] End-to-end: built CLI against an existing workspace with a `/blob/main/...` source — status flipped from `✗ not cached` to `✓ cached`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)