### PR TITLE
fix(terminology): change "syncing plugins" to "updating plugins"

### DIFF
--- a/src/core/sync.ts
+++ b/src/core/sync.ts
@@ -2090,7 +2090,7 @@ export async function syncWorkspace(
     if (wsSourceResult.success) {
       validatedWorkspaceSource = wsSourceResult;
     } else {
-      // Non-blocking: warn but continue syncing plugins
+      // Non-blocking: warn but continue updating plugins
       workspaceSourceWarnings.push(`Workspace source: ${wsSourceResult.error}`);
     }
     sw.stop('workspace-source-validation');

--- a/src/core/workspace.ts
+++ b/src/core/workspace.ts
@@ -323,7 +323,7 @@ export async function initWorkspace(
 
     // Auto-sync plugins
     // Pass sourceDir so relative paths in workspace.source resolve correctly
-    console.log('\nSyncing plugins...');
+    console.log('\nUpdating plugins...');
     const syncResult = await syncWorkspace(absoluteTarget, {
       ...(sourceDir && { workspaceSourceBase: sourceDir }),
     });


### PR DESCRIPTION
## Summary
- Replace "Syncing plugins..." console log in `workspace.ts` with "Updating plugins..."
- Replace inline comment "continue syncing plugins" in `sync.ts` with "continue updating plugins"
- Ensures consistent use of "updating" terminology across the codebase

## Test plan
- [ ] Verify no remaining occurrences of "syncing plugins" in source files
- [ ] Lint, typecheck, and tests pass (confirmed via pre-push hooks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)