### PR TITLE
fix(cli): resolve deprecated 'workspace status' alias in --agent-help

### DIFF
--- a/src/cli/agent-help.ts
+++ b/src/cli/agent-help.ts
@@ -72,14 +72,24 @@ function formatForAgent(meta: AgentCommandMeta) {
   return result;
 }
 
+/** Maps deprecated command paths to their current canonical equivalents. */
+const commandAliases: Record<string, string> = {
+  'workspace status': 'status',
+};
+
+function resolveAlias(commandPath: string): string {
+  return commandAliases[commandPath] ?? commandPath;
+}
+
 /**
  * Look up a meta by the runtime command path (e.g. "skills list").
+ * Resolves deprecated aliases (e.g. "workspace status" -> "status").
  * Used by index.ts to validate `--json=<fields>` against the per-command
  * allowlist before dispatching.
  */
 export function findMetaByCommand(commandPath: string): AgentCommandMeta | undefined {
   if (!commandPath) return undefined;
-  return allCommands.find((c) => c.command === commandPath);
+  return allCommands.find((c) => c.command === resolveAlias(commandPath));
 }
 
 export function printAgentHelp(args: string[], version: string): void {
@@ -98,16 +108,17 @@ export function printAgentHelp(args: string[], version: string): void {
     };
     console.log(JSON.stringify(tree, null, 2));
   } else {
+    const resolved = resolveAlias(commandPath);
     // Find exact matching command
-    const match = allCommands.find(c => c.command === commandPath);
+    const match = allCommands.find(c => c.command === resolved);
     if (match) {
       console.log(JSON.stringify(formatForAgent(match), null, 2));
     } else {
       // Try prefix match for subcommand groups
-      const matches = allCommands.filter(c => c.command.startsWith(`${commandPath} `));
+      const matches = allCommands.filter(c => c.command.startsWith(`${resolved} `));
       if (matches.length > 0) {
         const group = {
-          name: commandPath,
+          name: resolved,
           commands: matches.map(formatForAgent),
         };
         console.log(JSON.stringify(group, null, 2));

--- a/tests/unit/cli/agent-help.test.ts
+++ b/tests/unit/cli/agent-help.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test';
-import { extractAgentHelpFlag } from '../../../src/cli/agent-help.js';
+import { extractAgentHelpFlag, findMetaByCommand } from '../../../src/cli/agent-help.js';
 import { initMeta, syncMeta, statusMeta } from '../../../src/cli/metadata/workspace.js';
 import {
   marketplaceListMeta,
@@ -135,5 +135,27 @@ describe('agent command metadata', () => {
     const statusCmd = allCommands.find((c) => c.command === 'status')!;
     expect(statusCmd.positionals).toBeUndefined();
     expect(statusCmd.options).toBeUndefined();
+  });
+});
+
+describe('findMetaByCommand', () => {
+  test('resolves canonical "status" path', () => {
+    const meta = findMetaByCommand('status');
+    expect(meta).toBeDefined();
+    expect(meta!.command).toBe('status');
+  });
+
+  test('resolves deprecated "workspace status" alias to status meta', () => {
+    const meta = findMetaByCommand('workspace status');
+    expect(meta).toBeDefined();
+    expect(meta!.command).toBe('status');
+  });
+
+  test('returns undefined for unknown command', () => {
+    expect(findMetaByCommand('workspace frobnicate')).toBeUndefined();
+  });
+
+  test('returns undefined for empty string', () => {
+    expect(findMetaByCommand('')).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

- `--agent-help workspace status` errored with "Unknown command" after `statusMeta.command` was renamed from `workspace status` to `status` in #415
- Adds a `commandAliases` map and `resolveAlias()` helper in `src/cli/agent-help.ts` so both `findMetaByCommand` and `printAgentHelp` transparently redirect the old path to the new canonical one
- Adds 4 unit tests in `tests/unit/cli/agent-help.test.ts` covering `status`, `workspace status`, unknown command, and empty string

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun test` — 1310 pass, 0 fail
- [x] E2E: `./dist/index.js --agent-help workspace status` returns the status meta JSON (previously exited 1 with "Unknown command")
- [x] E2E: `./dist/index.js --agent-help status` continues to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)