### PR TITLE
fix(cli): revert plugin list heading to 'Installed plugins:'

### DIFF
--- a/src/cli/commands/plugin.ts
+++ b/src/cli/commands/plugin.ts
@@ -883,7 +883,7 @@ const pluginListCmd = command({
       const skillCount = plugins.filter((p) => p.kind === 'skill').length;
       const pluginCount = plugins.length - skillCount;
 
-      console.log('Installed:\n');
+      console.log('Installed plugins:\n');
       for (const p of plugins) {
         console.log(`  ❯ ${p.spec}`);
         console.log(`    Type: ${p.kind}`);


### PR DESCRIPTION
## Summary

- #415 renamed the `plugin list` text heading from `Installed plugins:` to `Installed:` as part of the skill-vs-plugin distinction work
- This breaks grep-based scrapers that key on the old heading string
- The per-entry `Type: skill|plugin` line already conveys the kind distinction without needing the heading change
- Revert heading to `Installed plugins:` to minimise churn for existing tooling

JSON output (`--json`) is stable and unaffected.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun test` — 1306 pass, 0 fail
- [x] No tests assert the heading string; confirmed by grep across `tests/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)