### PR TITLE
fix(release): make npm publish retries idempotent

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "release:next": "bun run scripts/release.ts next",
     "release:finalize": "bun run scripts/release.ts finalize",
     "prepublishOnly": "test \"$ALLOW_PUBLISH\" = '1' || (echo 'ERROR: Use the GitHub Actions Publish workflow' && exit 1)",
-    "publish:latest": "bun run build && ALLOW_PUBLISH=1 npm publish",
-    "publish:next": "bun run build && ALLOW_PUBLISH=1 npm publish --tag next",
+    "publish:latest": "bun run build && bun scripts/publish.ts latest",
+    "publish:next": "bun run build && bun scripts/publish.ts next",
     "promote:latest": "bun scripts/tag-channel.ts latest"
   },
   "keywords": [

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -1,0 +1,122 @@
+#!/usr/bin/env bun
+/**
+ * Publish allagents to npm with retry-safe behavior.
+ *
+ * The GitHub Actions Publish workflow calls this script after checking out a
+ * release tag. If the package version is already on npm, the script skips the
+ * immutable publish step and only ensures the requested dist-tag points at it.
+ *
+ * Usage:
+ *   bun scripts/publish.ts next
+ *   bun scripts/publish.ts latest
+ */
+
+import { readFileSync } from "node:fs";
+import { $ } from "bun";
+
+type NpmTag = "next" | "latest";
+type DistTags = Record<string, string | undefined>;
+
+const VALID_TAGS = ["next", "latest"] as const;
+
+function parseTag(tag: string | undefined): NpmTag {
+  if (!tag || !VALID_TAGS.includes(tag as NpmTag)) {
+    throw new Error(`Invalid npm dist-tag: ${tag ?? "(missing)"}. Expected next or latest.`);
+  }
+
+  return tag as NpmTag;
+}
+
+function readPackageJson() {
+  return JSON.parse(readFileSync("package.json", "utf8")) as {
+    name: string;
+    version: string;
+  };
+}
+
+async function npmJson(args: string[], options: { allowNotFound?: boolean } = {}) {
+  const result = await $`npm ${args}`.quiet().nothrow();
+  const stdout = result.stdout.toString().trim();
+  const stderr = result.stderr.toString().trim();
+
+  if (result.exitCode === 0) {
+    return stdout ? JSON.parse(stdout) : undefined;
+  }
+
+  if (options.allowNotFound && (stdout.includes("E404") || stderr.includes("E404"))) {
+    return undefined;
+  }
+
+  throw new Error(`npm ${args.join(" ")} failed:\n${stderr || stdout}`);
+}
+
+async function getPublishedVersion(name: string, version: string): Promise<string | undefined> {
+  const publishedVersion = await npmJson(["view", `${name}@${version}`, "version", "--json"], {
+    allowNotFound: true,
+  });
+  return typeof publishedVersion === "string" ? publishedVersion : undefined;
+}
+
+async function getDistTags(name: string): Promise<DistTags> {
+  const tags = await npmJson(["view", name, "dist-tags", "--json"], { allowNotFound: true });
+  return tags && typeof tags === "object" ? (tags as DistTags) : {};
+}
+
+function assertVersionMatchesTag(name: string, version: string, npmTag: NpmTag) {
+  const isPrerelease = version.includes("-next.");
+
+  if (isPrerelease && npmTag !== "next") {
+    throw new Error(`Refusing to publish prerelease ${name}@${version} to ${npmTag}`);
+  }
+
+  if (!isPrerelease && npmTag === "next") {
+    throw new Error(`Refusing to publish stable ${name}@${version} to next`);
+  }
+}
+
+function assertNoDowngrade(name: string, currentVersion: string | undefined, nextVersion: string, npmTag: NpmTag) {
+  if (!currentVersion || currentVersion === nextVersion) {
+    return;
+  }
+
+  if (Bun.semver.order(nextVersion, currentVersion) < 0) {
+    throw new Error(`Refusing to move ${name}@${npmTag} backward from ${currentVersion} to ${nextVersion}`);
+  }
+}
+
+async function ensureDistTag(name: string, version: string, npmTag: NpmTag) {
+  const tags = await getDistTags(name);
+  assertNoDowngrade(name, tags[npmTag], version, npmTag);
+
+  if (tags[npmTag] === version) {
+    console.log(`   ✓ ${name}@${npmTag} already points to ${version}`);
+    return;
+  }
+
+  console.log(`   → Setting ${name}@${npmTag} to ${version}`);
+  await $`npm dist-tag add ${name}@${version} ${npmTag}`;
+}
+
+async function main() {
+  const npmTag = parseTag(process.argv[2]);
+  const { name, version } = readPackageJson();
+
+  assertVersionMatchesTag(name, version, npmTag);
+
+  console.log(`\n📦 Publishing ${name}@${version} (--tag ${npmTag})...`);
+  const publishedVersion = await getPublishedVersion(name, version);
+  if (publishedVersion === version) {
+    console.log(`   ✓ ${name}@${version} is already published`);
+  } else {
+    await $`npm publish --tag ${npmTag}`.env({ ...process.env, ALLOW_PUBLISH: "1" });
+  }
+
+  await ensureDistTag(name, version, npmTag);
+  console.log("\n✅ Package published.");
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`❌ ${message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Route `publish:next` and `publish:latest` through a retry-safe `scripts/publish.ts` wrapper.
- Skip immutable `npm publish` when `allagents@version` already exists.
- Ensure the requested npm dist-tag points at the release version without moving tags backwards.

## Testing
- `bun install --frozen-lockfile`
- `bun build scripts/publish.ts --target=bun --outfile=/tmp/allagents-publish-check.js`
- `bun run typecheck`
- `bun run lint`
- `bun run publish:next` on already-published `1.12.0-next.1` verified the idempotent skip path
- `bun test` (`1314 pass`, `4 skip`)
- pre-push hook passed lint, typecheck, and tests

## Post-Deploy Monitoring & Validation
- After merge, dispatch `Publish` with `channel=existing` and `ref=v1.12.0-next.1`.
- Healthy signal: workflow succeeds, reports package already published, and confirms `allagents@next` points to `1.12.0-next.1`.
- Failure signal: npm duplicate-version error or trusted-publishing auth error; rollback by reverting this PR and the publish workflow consolidation if needed.
- Validation window: immediate post-merge workflow run; owner: release operator.