### PR TITLE
fix(release): skip already published npm versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -188,14 +188,6 @@ jobs:
       - name: Upgrade npm
         run: npm install -g npm@latest
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version-file: package.json
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
       - name: Validate publish checkout
         run: |
           set -euo pipefail
@@ -224,7 +216,65 @@ jobs:
 
           echo "Publishing $RELEASE_TAG with ${{ needs.prepare.outputs.publish_action }}"
 
+      - name: Check npm package state
+        id: npm_state
+        env:
+          NPM_TAG: ${{ needs.prepare.outputs.publish_action == 'publish-next' && 'next' || 'latest' }}
+        run: |
+          set -euo pipefail
+
+          NAME=$(node -p "require('./package.json').name")
+          VERSION=$(node -p "require('./package.json').version")
+          VERSION_ERROR=$(mktemp)
+          TAGS_ERROR=$(mktemp)
+          trap 'rm -f "$VERSION_ERROR" "$TAGS_ERROR"' EXIT
+
+          if ! PUBLISHED_VERSION=$(npm view "${NAME}@${VERSION}" version 2>"$VERSION_ERROR"); then
+            if grep -q "E404" "$VERSION_ERROR"; then
+              PUBLISHED_VERSION=""
+            else
+              cat "$VERSION_ERROR" >&2
+              exit 1
+            fi
+          fi
+
+          if ! DIST_TAGS=$(npm view "$NAME" dist-tags --json 2>"$TAGS_ERROR"); then
+            if grep -q "E404" "$TAGS_ERROR"; then
+              DIST_TAGS='{}'
+            else
+              cat "$TAGS_ERROR" >&2
+              exit 1
+            fi
+          fi
+
+          CURRENT_TAG=$(node -e 'const fs = require("fs"); const tags = JSON.parse(fs.readFileSync(0, "utf8") || "{}"); console.log(tags[process.env.NPM_TAG] || "");' <<< "$DIST_TAGS")
+
+          if [ "$PUBLISHED_VERSION" = "$VERSION" ]; then
+            if [ "$CURRENT_TAG" != "$VERSION" ]; then
+              echo "::error::${NAME}@${VERSION} is already published, but ${NPM_TAG} points to ${CURRENT_TAG:-nothing}. Publish a newer version or update the npm dist-tag manually."
+              exit 1
+            fi
+
+            echo "${NAME}@${VERSION} is already published and ${NPM_TAG} points to it"
+            echo "already_done=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "${NAME}@${VERSION} has not been published; continuing with npm publish --tag ${NPM_TAG}"
+          echo "already_done=false" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Bun
+        if: steps.npm_state.outputs.already_done != 'true'
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: package.json
+
+      - name: Install dependencies
+        if: steps.npm_state.outputs.already_done != 'true'
+        run: bun install --frozen-lockfile
+
       - name: Publish to npm
+        if: steps.npm_state.outputs.already_done != 'true'
         env:
           NPM_CONFIG_PROVENANCE: true
         run: |


### PR DESCRIPTION
## Summary
- add a workflow-level npm registry state check before invoking tag-local publish scripts
- skip publish when the package version is already published and the requested dist-tag already points to it
- fail clearly if an immutable published version has the wrong dist-tag instead of retrying npm publish

## Testing
- `bun install --frozen-lockfile`
- `bun run lint`
- `bun run typecheck`
- pre-push hook: lint, typecheck, test
- parsed workflow YAML with Python/PyYAML
- executed the new npm state guard locally with `NPM_TAG=next`; verified `allagents@1.12.0-next.1` is already published and `next` points to it

## Post-merge validation
- rerun `Publish` with `channel=existing` and `ref=v1.12.0-next.1`