### PR TITLE
chore(workspace): clarify Beads ignore rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,7 @@ temp/
 .worktrees/
 allagents.worktrees/
 
-# Beads external workspace (never initialized inside this source repo)
+# Beads local Dolt database and runtime files
 .beads/
 
 # Ralph runtime files (not config)


### PR DESCRIPTION
## Summary
The Beads ignore comment now reflects the actual storage model: `.beads/` contains local Dolt database/runtime files, not repo-tracked task state or an external workspace.

## Verification
- Push hook: `Lint`, `Typecheck`, and `Test` passed

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)