### PR TITLE
fix(cli): hide plugin sync implementation details

### DIFF
--- a/src/cli/tui/actions/plugins.ts
+++ b/src/cli/tui/actions/plugins.ts
@@ -123,9 +123,9 @@ export async function installSelectedPlugin(
       p.note(result.error ?? 'Unknown error', 'Error');
       return false;
     }
-    s.message('Syncing...');
+    s.message('Updating...');
     syncResult = await syncWorkspace(workspacePath);
-    s.stop('Installed and synced');
+    s.stop('Installed');
   } else {
     const result = await addUserPlugin(pluginRef);
     if (!result.success) {
@@ -133,9 +133,9 @@ export async function installSelectedPlugin(
       p.note(result.error ?? 'Unknown error', 'Error');
       return false;
     }
-    s.message('Syncing...');
+    s.message('Updating...');
     syncResult = await syncUserWorkspace();
-    s.stop('Installed and synced');
+    s.stop('Installed');
   }
 
   cache?.invalidate();
@@ -446,13 +446,13 @@ async function runPluginDetail(
       }
 
       // Sync
-      s.message('Syncing...');
+      s.message('Updating...');
       if (scope === 'project' && context.workspacePath) {
         await syncWorkspace(context.workspacePath);
       } else {
         await syncUserWorkspace();
       }
-      s.stop('Mode updated and synced');
+      s.stop('Updated');
       cache?.invalidate();
 
       const newMode = currentMode === 'allowlist' ? 'ON' : 'OFF';
@@ -484,9 +484,9 @@ async function runPluginDetail(
           p.note(result.error ?? 'Unknown error', 'Error');
           continue;
         }
-        s.message('Syncing...');
+        s.message('Updating...');
         await syncWorkspace(context.workspacePath);
-        s.stop('Removed and synced');
+        s.stop('Removed');
       } else {
         const result = await removeUserPlugin(pluginSource);
         if (!result.success) {
@@ -494,9 +494,9 @@ async function runPluginDetail(
           p.note(result.error ?? 'Unknown error', 'Error');
           continue;
         }
-        s.message('Syncing...');
+        s.message('Updating...');
         await syncUserWorkspace();
-        s.stop('Removed and synced');
+        s.stop('Removed');
       }
 
       cache?.invalidate();
@@ -590,13 +590,13 @@ export async function runBrowsePluginSkills(
     }
 
     // Auto-sync
-    s.message('Syncing...');
+    s.message('Updating...');
     if (scope === 'project' && context.workspacePath) {
       await syncWorkspace(context.workspacePath);
     } else if (scope === 'user') {
       await syncUserWorkspace();
     }
-    s.stop('Skills updated and synced');
+    s.stop('Updated');
     cache?.invalidate();
 
     const changes: string[] = [];

--- a/src/cli/tui/actions/plugins.ts
+++ b/src/cli/tui/actions/plugins.ts
@@ -171,7 +171,7 @@ async function runUpdatePlugin(
   }
 
   // Sync after update
-  s.message('Syncing...');
+  s.message('Updating...');
   if (scope === 'project' && context.workspacePath) {
     await syncWorkspace(context.workspacePath);
   } else {
@@ -242,7 +242,7 @@ export async function runUpdateAllPlugins(
 
   // Sync if any plugins were updated
   if (needsProjectSync || needsUserSync) {
-    s.message('Syncing...');
+    s.message('Updating...');
     if (needsProjectSync && context.workspacePath) {
       await syncWorkspace(context.workspacePath);
     }


### PR DESCRIPTION
## Summary

Interactive plugin actions now describe workspace refreshes as part of the user-requested operation instead of exposing a separate “Syncing…” implementation phase.

- Use “Updating…” throughout plugin install, update, mode, removal, and skill-selection flows.
- Keep completion messages action-focused: “Installed”, “Updated”, or “Removed”.
- Remove every user-facing “Syncing…” and “...and synced” message from the TUI plugin actions.

## Validation

- `bun run build`
- `bun run typecheck`
- `bun run lint`
- `bun test` — 1,326 passed, 5 skipped
- `bun run test:e2e` — 116 passed, 4 skipped
- Built `dist/index.js`, created a temporary workspace, installed `code-review@anthropics/claude-plugins-official`, and exercised **Plugins → Update all** with `agent-tui`; the update completed successfully without exposing a separate sync phase.
- Confirmed `src/cli/tui/actions/plugins.ts` contains no user-facing `Syncing` or `synced` labels.

## Post-Deploy Monitoring & Validation

No additional operational monitoring is required because this changes interactive copy only. After release, exercise plugin actions in the TUI and confirm their progress remains action-focused; any visible “Syncing…” phase is the rollback trigger.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
