### PR TITLE
fix(sync): harden skill scanning against bad paths, reject filesystem-root plugin sources

### DIFF
--- a/src/cli/commands/plugin.ts
+++ b/src/cli/commands/plugin.ts
@@ -224,6 +224,12 @@ async function runUserSyncAndPrint(): Promise<{ ok: boolean; syncData: ReturnTyp
       }
     }
 
+    if (result.warnings && result.warnings.length > 0) {
+      console.log('\nWarnings:');
+      for (const warning of result.warnings) {
+        console.log(`  ⚠ ${warning}`);
+      }
+    }
   }
 
   return { ok: result.success && result.totalFailed === 0, syncData };

--- a/src/core/skills.ts
+++ b/src/core/skills.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'node:fs';
+import { existsSync, lstatSync, type Dirent } from 'node:fs';
 import { readFile, readdir } from 'node:fs/promises';
 import { basename, join, relative, resolve } from 'node:path';
 import { load } from 'js-yaml';
@@ -101,28 +101,50 @@ async function resolvePluginPath(
 
 export async function discoverNestedSkillEntries(
   scanRoot: string,
+  warnings: string[] = [],
 ): Promise<DiscoveredSkillEntry[]> {
-  return walkForSkillMd(scanRoot, scanRoot);
+  return walkForSkillMd(scanRoot, scanRoot, warnings);
 }
 
 async function walkForSkillMd(
   scanRoot: string,
   currentDir: string,
+  warnings: string[],
 ): Promise<DiscoveredSkillEntry[]> {
-  const entries = await readdir(currentDir, { withFileTypes: true });
+  let entries: Dirent[];
+  try {
+    entries = await readdir(currentDir, { withFileTypes: true });
+  } catch (err) {
+    const code =
+      err && typeof err === 'object' && 'code' in err
+        ? String((err as NodeJS.ErrnoException).code)
+        : undefined;
+    warnings.push(
+      `Could not read '${currentDir}'${code ? ` (${code})` : ''} while scanning for skills. If this path looks unexpected (e.g. rooted near a drive root), check ~/.allagents/workspace.yaml for a stale plugin path, or rename ~/.allagents to ~/.allagents.bak and reinstall your plugins to reset it.`,
+    );
+    return [];
+  }
   const discovered: DiscoveredSkillEntry[] = [];
 
   for (const entry of entries) {
     if (!entry.isDirectory()) continue;
 
     const skillPath = join(currentDir, entry.name);
+
+    // Skip symlinks/junctions to avoid unbounded recursion through loops.
+    try {
+      if (lstatSync(skillPath).isSymbolicLink()) continue;
+    } catch {
+      continue;
+    }
+
     if (existsSync(join(skillPath, 'SKILL.md'))) {
       const subpath = relative(scanRoot, skillPath).split(/[\\/]/).join('/');
       discovered.push({ name: entry.name, subpath, skillPath });
       continue;
     }
 
-    discovered.push(...(await walkForSkillMd(scanRoot, skillPath)));
+    discovered.push(...(await walkForSkillMd(scanRoot, skillPath, warnings)));
   }
 
   return discovered;

--- a/src/core/sync.ts
+++ b/src/core/sync.ts
@@ -1098,10 +1098,19 @@ export function computeDeletedArtifacts(
  */
 async function collectAvailableSkillNames(
   validPlugins: ValidatedPlugin[],
+  warnings?: string[],
 ): Promise<Set<string>> {
   const names = new Set<string>();
   for (const plugin of validPlugins) {
-    const skills = await collectPluginSkills(plugin.resolved, plugin.plugin);
+    const skills = await collectPluginSkills(
+      plugin.resolved,
+      plugin.plugin,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      warnings,
+    );
     for (const skill of skills) {
       names.add(skill.folderName);
     }
@@ -1458,6 +1467,7 @@ async function collectAllSkills(
   validatedPlugins: ValidatedPlugin[],
   disabledSkills?: Set<string>,
   enabledSkills?: Set<string>,
+  warnings?: string[],
 ): Promise<CollectedSkillEntry[]> {
   const allSkills: CollectedSkillEntry[] = [];
 
@@ -1470,6 +1480,7 @@ async function collectAllSkills(
       pluginName,
       enabledSkills,
       plugin.pluginSkillsConfig,
+      warnings,
     );
 
     for (const skill of skills) {
@@ -2154,7 +2165,7 @@ export async function syncWorkspace(
       ? new Set(config.enabledSkills)
       : undefined;
   const allSkills = await sw.measure('skill-collection', () =>
-    collectAllSkills(validPlugins, disabledSkillsSet, enabledSkillsSet),
+    collectAllSkills(validPlugins, disabledSkillsSet, enabledSkillsSet, warnings),
   );
 
   // Build per-plugin skill name maps (handles conflicts automatically)
@@ -2373,7 +2384,10 @@ export async function syncWorkspace(
   // Compute deleted artifacts: compare previous state vs what was just synced
   // Collect all skill names from installed plugins (including disabled) so that
   // skills that are still available but just not synced are not reported as deleted.
-  const availableSkillNames = await collectAvailableSkillNames(validPlugins);
+  const availableSkillNames = await collectAvailableSkillNames(
+    validPlugins,
+    warnings,
+  );
   const allCopyResultsForState = [
     ...pluginResults.flatMap((r) => r.copyResults),
     ...workspaceFileResults,
@@ -2428,6 +2442,7 @@ export async function syncWorkspace(
     );
   }
 
+  const uniqueWarnings = [...new Set(warnings)];
   return {
     success: !hasFailures,
     pluginResults,
@@ -2437,7 +2452,7 @@ export async function syncWorkspace(
     totalGenerated,
     purgedPaths,
     ...(deletedArtifacts.length > 0 && { deletedArtifacts }),
-    ...(warnings.length > 0 && { warnings }),
+    ...(uniqueWarnings.length > 0 && { warnings: uniqueWarnings }),
     ...(messages.length > 0 && { messages }),
     ...(Object.keys(mcpResults).length > 0 && { mcpResults }),
     ...(nativeResult && { nativeResult }),
@@ -2577,7 +2592,7 @@ export async function syncUserWorkspace(
       ? new Set(config.enabledSkills)
       : undefined;
   const allSkills = await sw.measure('skill-collection', () =>
-    collectAllSkills(validPlugins, disabledSkillsSet, enabledSkillsSet),
+    collectAllSkills(validPlugins, disabledSkillsSet, enabledSkillsSet, warnings),
   );
   const pluginSkillMaps = buildPluginSkillNameMaps(allSkills);
 
@@ -2751,8 +2766,10 @@ export async function syncUserWorkspace(
   );
 
   // Compute deleted artifacts: compare previous state vs what was just synced
-  const availableUserSkillNames =
-    await collectAvailableSkillNames(validPlugins);
+  const availableUserSkillNames = await collectAvailableSkillNames(
+    validPlugins,
+    warnings,
+  );
   const allCopyResultsForState = pluginResults.flatMap((r) => r.copyResults);
   const resolvedUserMappings = resolveClientMappings(
     syncClients,
@@ -2799,6 +2816,7 @@ export async function syncUserWorkspace(
     );
   }
 
+  const uniqueWarnings = [...new Set(warnings)];
   return {
     success: totalFailed === 0,
     pluginResults,
@@ -2807,7 +2825,7 @@ export async function syncUserWorkspace(
     totalSkipped,
     totalGenerated,
     ...(deletedArtifacts.length > 0 && { deletedArtifacts }),
-    ...(warnings.length > 0 && { warnings }),
+    ...(uniqueWarnings.length > 0 && { warnings: uniqueWarnings }),
     ...(messages.length > 0 && { messages }),
     ...(Object.keys(mcpResults).length > 0 && { mcpResults }),
     ...(nativeResult && { nativeResult }),

--- a/src/core/transform.ts
+++ b/src/core/transform.ts
@@ -485,8 +485,10 @@ export async function collectPluginSkills(
   pluginName?: string,
   enabledSkills?: Set<string>,
   pluginSkillsConfig?: PluginSkillsConfig,
+  warnings?: string[],
 ): Promise<CollectedSkill[]> {
   const skillsDir = join(pluginPath, 'skills');
+  const skillWalkWarnings: string[] = [];
 
   // v1 fallback: only apply enabledSkills to plugins that actually have entries in the set
   const hasEnabledEntries =
@@ -498,20 +500,23 @@ export async function collectPluginSkills(
   let candidateDirs: { name: string; subpath: string; path: string }[];
 
   if (existsSync(skillsDir)) {
-    const entries = await discoverNestedSkillEntries(skillsDir);
+    const entries = await discoverNestedSkillEntries(
+      skillsDir,
+      skillWalkWarnings,
+    );
     candidateDirs = entries.map((entry) => ({
       name: entry.name,
       subpath: entry.subpath,
       path: entry.skillPath,
     }));
   } else {
-    const nestedDirs = (await discoverNestedSkillEntries(pluginPath)).map(
-      (entry) => ({
-        name: entry.name,
-        subpath: entry.subpath,
-        path: entry.skillPath,
-      }),
-    );
+    const nestedDirs = (
+      await discoverNestedSkillEntries(pluginPath, skillWalkWarnings)
+    ).map((entry) => ({
+      name: entry.name,
+      subpath: entry.subpath,
+      path: entry.skillPath,
+    }));
 
     if (nestedDirs.length > 0) {
       candidateDirs = nestedDirs;
@@ -569,6 +574,12 @@ export async function collectPluginSkills(
     }
   } else {
     filteredDirs = candidateDirs;
+  }
+
+  if (warnings && skillWalkWarnings.length > 0) {
+    warnings.push(
+      ...skillWalkWarnings.map((w) => `Plugin '${pluginSource}': ${w}`),
+    );
   }
 
   return filteredDirs.map((entry) => ({

--- a/src/core/user-workspace.ts
+++ b/src/core/user-workspace.ts
@@ -10,6 +10,7 @@ import type {
 } from '../models/workspace-config.js';
 import { getPluginSource } from '../models/workspace-config.js';
 import {
+  isFilesystemRoot,
   isGitHubUrl,
   parseGitHubUrl,
   validatePluginSource,
@@ -158,6 +159,12 @@ export async function addUserPlugin(
       return {
         success: false,
         error: `Plugin not found at ${plugin}`,
+      };
+    }
+    if (isFilesystemRoot(plugin)) {
+      return {
+        success: false,
+        error: `Plugin source cannot be a filesystem root directory: ${plugin}`,
       };
     }
   }

--- a/src/core/workspace-modify.ts
+++ b/src/core/workspace-modify.ts
@@ -12,6 +12,7 @@ import type {
 import { getPluginSource } from '../models/workspace-config.js';
 import { parseMarketplaceManifest } from '../utils/marketplace-manifest-parser.js';
 import {
+  isFilesystemRoot,
   isGitHubUrl,
   parseGitHubUrl,
   validatePluginSource,
@@ -161,6 +162,12 @@ export async function addPlugin(
       return {
         success: false,
         error: `Plugin not found at ${plugin}`,
+      };
+    }
+    if (isFilesystemRoot(fullPath) || isFilesystemRoot(plugin)) {
+      return {
+        success: false,
+        error: `Plugin source cannot be a filesystem root directory: ${plugin}`,
       };
     }
   }

--- a/src/utils/plugin-path.ts
+++ b/src/utils/plugin-path.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs';
-import { isAbsolute, join, resolve } from 'node:path';
+import { isAbsolute, join, parse, resolve } from 'node:path';
 import { getHomeDir } from '../constants.js';
 import {
   GitCloneError,
@@ -403,6 +403,17 @@ export function validatePluginSource(source: string): {
   }
 
   return { valid: true };
+}
+
+/**
+ * Check whether a path resolves to the root of a filesystem (e.g. `C:\` on
+ * Windows or `/` on POSIX). A local-path plugin source can never legitimately
+ * be a filesystem root — every real plugin is a specific, self-contained
+ * directory.
+ */
+export function isFilesystemRoot(candidatePath: string): boolean {
+  const resolved = resolve(candidatePath);
+  return resolved === parse(resolved).root;
 }
 
 /**

--- a/tests/unit/core/skills.test.ts
+++ b/tests/unit/core/skills.test.ts
@@ -1,9 +1,13 @@
-import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
-import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
+import { describe, it, expect, beforeEach, afterEach, test } from 'bun:test';
+import { mkdtemp, rm, mkdir, writeFile, symlink } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { dump } from 'js-yaml';
-import { getAllSkillsFromPlugins, type SkillInfo } from '../../../src/core/skills.js';
+import {
+  getAllSkillsFromPlugins,
+  discoverNestedSkillEntries,
+  type SkillInfo,
+} from '../../../src/core/skills.js';
 import { getPluginCachePath } from '../../../src/utils/plugin-path.js';
 
 describe('getAllSkillsFromPlugins', () => {
@@ -239,4 +243,66 @@ describe('getAllSkillsFromPlugins', () => {
       process.env.HOME = originalHome;
     }
   });
+});
+
+describe('discoverNestedSkillEntries error handling', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'allagents-skills-walk-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('records a warning instead of throwing when the scan root cannot be read', async () => {
+    // A file (not a directory) makes readdir() throw ENOTDIR, exercising the
+    // same catch path a real EPERM/EACCES on a restricted directory would.
+    const notADir = join(tmpDir, 'not-a-directory');
+    await writeFile(notADir, 'not a directory');
+
+    const warnings: string[] = [];
+    const entries = await discoverNestedSkillEntries(notADir, warnings);
+
+    expect(entries).toEqual([]);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain(notADir);
+    expect(warnings[0]).toContain('workspace.yaml');
+  });
+
+  it('still discovers sibling skills when one plugin path cannot be read', async () => {
+    const goodPlugin = join(tmpDir, 'good-plugin');
+    await mkdir(join(goodPlugin, 'skills', 'good-skill'), { recursive: true });
+    await writeFile(join(goodPlugin, 'skills', 'good-skill', 'SKILL.md'), '# good');
+
+    const badPlugin = join(tmpDir, 'bad-plugin-is-a-file');
+    await writeFile(badPlugin, 'not a directory');
+
+    const warnings: string[] = [];
+    const goodEntries = await discoverNestedSkillEntries(
+      join(goodPlugin, 'skills'),
+      warnings,
+    );
+    const badEntries = await discoverNestedSkillEntries(badPlugin, warnings);
+
+    expect(goodEntries.map((e) => e.name)).toEqual(['good-skill']);
+    expect(badEntries).toEqual([]);
+    expect(warnings).toHaveLength(1);
+  });
+
+  test.skipIf(process.platform === 'win32')(
+    'skips symlinked directories instead of following loops',
+    async () => {
+      const pluginDir = join(tmpDir, 'symlink-plugin');
+      await mkdir(join(pluginDir, 'real-skill'), { recursive: true });
+      await writeFile(join(pluginDir, 'real-skill', 'SKILL.md'), '# real');
+
+      // A symlink back to the plugin root would recurse forever if followed.
+      await symlink(pluginDir, join(pluginDir, 'loop'), 'dir');
+
+      const entries = await discoverNestedSkillEntries(pluginDir);
+      expect(entries.map((e) => e.name)).toEqual(['real-skill']);
+    },
+  );
 });

--- a/tests/unit/core/sync-resilient.test.ts
+++ b/tests/unit/core/sync-resilient.test.ts
@@ -89,6 +89,33 @@ describe('sync resilience - project scope', () => {
     expect(result.warnings).toBeDefined();
     expect(result.warnings!.length).toBe(2);
   });
+
+  it('should sync the good plugin and warn (not throw) when another plugin path cannot be scanned for skills', async () => {
+    // A plugin whose *source* resolves to a real file (not a directory) passes
+    // plugin validation (existsSync) but can't be readdir'd during skill
+    // collection — this is what used to crash the whole sync with an uncaught
+    // EPERM/ENOTDIR (see #433-style bad-path bugs).
+    const goodPlugin = await createLocalPlugin('good-plugin', 'good-skill');
+    const badPluginPath = join(testDir, 'bad-plugin-is-a-file');
+    await writeFile(badPluginPath, 'not a directory');
+
+    await writeProjectConfig({
+      repositories: [],
+      plugins: [goodPlugin, badPluginPath],
+      clients: ['claude'],
+    });
+
+    const result = await syncWorkspace(testDir);
+
+    expect(result.totalCopied).toBeGreaterThan(0);
+    expect(result.warnings).toBeDefined();
+    expect(result.warnings!.some((w) => w.includes(badPluginPath))).toBe(true);
+    // The same bad path is scanned twice internally (once to collect enabled
+    // skills, once to collect all skill names for deleted-artifact detection)
+    // — warnings should be deduplicated rather than shown twice.
+    const matching = result.warnings!.filter((w) => w.includes(badPluginPath));
+    expect(matching).toHaveLength(1);
+  });
 });
 
 describe('sync resilience - user scope', () => {

--- a/tests/unit/core/user-workspace.test.ts
+++ b/tests/unit/core/user-workspace.test.ts
@@ -135,6 +135,16 @@ describe('user-workspace', () => {
       expect(result.error).toContain('Plugin not found at');
       expect(result.error).toContain(nonExistentPath);
     });
+
+    test('rejects a bare path separator as a local plugin source', async () => {
+      const { sep } = await import('node:path');
+      const result = await addUserPlugin(sep);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('filesystem root');
+
+      const config = await getUserWorkspaceConfig();
+      expect(config?.plugins ?? []).toEqual([]);
+    });
   });
 
   describe('removeUserPlugin', () => {

--- a/tests/unit/core/workspace-modify.test.ts
+++ b/tests/unit/core/workspace-modify.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, beforeEach, afterEach, mock } from 'bun:test';
 import { mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, sep } from 'node:path';
 import { tmpdir } from 'node:os';
 import { dump, load } from 'js-yaml';
 import type { WorkspaceConfig } from '../../../src/models/workspace-config.js';
@@ -249,5 +249,32 @@ describe('addPlugin with --force flag', () => {
 
     const updated = load(readFileSync(configPath, 'utf-8')) as any;
     expect(updated.plugins.length).toBe(1);
+  });
+});
+
+describe('addPlugin rejects filesystem-root local paths', () => {
+  let testDir = join(tmpdir(), `allagents-root-reject-test-${Date.now()}`);
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `allagents-root-reject-test-${Date.now()}`);
+    mkdirSync(join(testDir, '.allagents'), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  test('rejects a bare path separator as a local plugin source', async () => {
+    const configPath = join(testDir, '.allagents', 'workspace.yaml');
+    const initialConfig = { repositories: [], plugins: [], clients: ['universal'] };
+    writeFileSync(configPath, dump(initialConfig, { lineWidth: -1 }));
+
+    const result = await addPlugin(sep, testDir, false);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('filesystem root');
+
+    const updated = load(readFileSync(configPath, 'utf-8')) as any;
+    expect(updated.plugins).toEqual([]);
   });
 });

--- a/tests/unit/utils/plugin-path.test.ts
+++ b/tests/unit/utils/plugin-path.test.ts
@@ -37,6 +37,7 @@ const {
   validatePluginSource,
   verifyGitHubUrlExists,
   formatPluginSource,
+  isFilesystemRoot,
 } = await import('../../../src/utils/plugin-path.js');
 
 describe('isGitHubUrl', () => {
@@ -337,6 +338,25 @@ describe('validatePluginSource', () => {
     const result = validatePluginSource('gh:invalid');
     expect(result.valid).toBe(false);
     expect(result.error).toContain('Invalid GitHub URL');
+  });
+});
+
+describe('isFilesystemRoot', () => {
+  it('treats a bare path separator as a filesystem root', () => {
+    expect(isFilesystemRoot(sep)).toBe(true);
+  });
+
+  it('treats the resolved root path itself as a filesystem root', () => {
+    const root = resolve('.').split(sep)[0] + sep;
+    expect(isFilesystemRoot(root)).toBe(true);
+  });
+
+  it('does not treat a normal plugin directory as a filesystem root', () => {
+    expect(isFilesystemRoot(join(tmpdir(), 'some-plugin'))).toBe(false);
+  });
+
+  it('does not treat a relative path to a subdirectory as a filesystem root', () => {
+    expect(isFilesystemRoot('./some-plugin')).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

A user reported that `npx allagents plugin uninstall <plugin>` printed `✓ Uninstalled plugin (user scope): ...` and then crashed with `Error: EPERM: operation not permitted, scandir 'C:\$WinREAgent\Scratch\Mount\Windows\System32\LogFiles\WMI\RtBackup'`. They were already on v1.13.2 (past the #434 `getHomeDir()` fix), so this was a different bug.

Root cause: their `~/.allagents/workspace.yaml` had a corrupted plugin entry — a bare `\` — which resolves to the drive root on Windows. `walkForSkillMd` (the recursive skill scanner in `src/core/skills.ts`) had no try/catch and no symlink guard (unlike its sibling `discoverRepoSkills` in `repo-skills.ts`), so it recursed unguarded into `C:\` and crashed the entire post-uninstall sync — even though the uninstall itself had already succeeded, and even though the bad plugin wasn't the one being uninstalled (sync scans *every* installed plugin).

- **`walkForSkillMd` hardening** (`src/core/skills.ts`): catches `readdir` errors and records a warning with remediation steps instead of throwing; skips symlinks/junctions to avoid unbounded recursion through loops. Warnings thread through `collectPluginSkills` → `collectAllSkills`/`collectAvailableSkillNames` → `SyncResult.warnings`, deduplicated since the same bad plugin gets scanned twice internally.
- **Entry-point validation** (`src/utils/plugin-path.ts`, `workspace-modify.ts`, `user-workspace.ts`): `addPlugin`/`addUserPlugin` now reject a local-path source that resolves to a filesystem root (new `isFilesystemRoot` helper) — closing the entry point that let the bare `\` get written in the first place. There's no legitimate use case for a plugin source that resolves to a drive/filesystem root.
- **Fixed a related silent gap**: `runUserSyncAndPrint` (`plugin.ts`) never printed the `Warnings:` section at all (unlike its project-scope sibling `runSyncAndPrint`) — user-scope syncs were silently swallowing every warning, not just the new ones.

## Test plan

- [x] `bun test` — new/extended unit tests in `skills.test.ts`, `plugin-path.test.ts`, `sync-resilient.test.ts`, `workspace-modify.test.ts`, `user-workspace.test.ts` all pass
- [x] `bun run typecheck` and `bun run lint` clean
- [x] Manual E2E against the built CLI (`bun run build`, `node dist/index.js ...`):
  - Temp workspace with a good plugin + a plugin whose resolved path is unreadable (a file standing in for the real bug's drive-root path) → `plugin uninstall <good-plugin> --scope user` succeeds, sync completes (exit 0), and prints exactly one deduplicated warning with remediation steps instead of crashing.
  - `plugin install "\"` (both project and user scope) → rejected with `Plugin source cannot be a filesystem root directory: \`, exit 1, `workspace.yaml` untouched.