### PR TITLE
fix(plugin): respect marketplace component boundaries

### DIFF
--- a/docs/src/content/docs/docs/guides/plugins.mdx
+++ b/docs/src/content/docs/docs/guides/plugins.mdx
@@ -29,6 +29,32 @@ to `~/.copilot/hooks/`. Potential copies from older versions are left untouched
 and reported for manual review because their ownership was not tracked.
 :::
 
+## Marketplace Component Boundaries
+
+AllAgents recognizes marketplace manifests at both
+`.claude-plugin/marketplace.json` and `.github/plugin/marketplace.json`. The
+GitHub Copilot location takes precedence when a repository contains both.
+
+A marketplace entry with `strict: false` defines the complete set of plugin
+components. For example, this entry syncs the repository's top-level skills
+without treating its top-level hooks or `.github/` development configuration as
+plugin artifacts:
+
+```json
+{
+  "name": "skills-only",
+  "source": "./",
+  "strict": false,
+  "skills": ["./skills/"]
+}
+```
+
+Without `strict: false`, AllAgents retains conventional plugin-directory
+discovery for compatibility. Top-level `hooks/` remains the portable hook
+location; `.github/` represents repository-scoped GitHub content. Component
+kind filtering currently uses AllAgents' conventional root directories, so
+custom marketplace component paths are not yet remapped.
+
 ## Duplicate Skill Handling
 
 When multiple plugins define skills with the same folder name, AllAgents automatically resolves naming conflicts:

--- a/src/core/codex-hooks.ts
+++ b/src/core/codex-hooks.ts
@@ -362,7 +362,10 @@ function writeProjectHooks(hooksPath: string, hooksFile: CodexHooksFile): void {
 }
 
 function pluginTargetsCodex(plugin: ValidatedPlugin): boolean {
-  return plugin.clients.includes('codex' as ClientType);
+  return (
+    plugin.clients.includes('codex' as ClientType) &&
+    plugin.fileArtifacts?.hooks !== false
+  );
 }
 
 export function syncCodexProjectHooks(

--- a/src/core/marketplace.ts
+++ b/src/core/marketplace.ts
@@ -4,6 +4,11 @@ import { basename, dirname, join, resolve } from 'node:path';
 import simpleGit from 'simple-git';
 import { getHomeDir } from '../constants.js';
 import {
+  type MarketplaceFileArtifacts,
+  getMarketplaceFileArtifacts,
+} from '../models/marketplace-manifest.js';
+import {
+  getEmbeddedMarketplaceFileArtifacts,
   parseMarketplaceManifest,
   resolvePluginSourcePath,
 } from '../utils/marketplace-manifest-parser.js';
@@ -749,6 +754,13 @@ export interface MarketplacePluginInfo {
   skills?: string[];
 }
 
+function normalizeComponentPaths(
+  paths: string | string[] | undefined,
+): string[] | undefined {
+  if (paths === undefined) return undefined;
+  return Array.isArray(paths) ? paths : [paths];
+}
+
 /**
  * Result of listing marketplace plugins, including any warnings
  * from lenient manifest parsing.
@@ -787,7 +799,8 @@ export async function getMarketplacePluginsFromManifest(
     };
     if (plugin.category) info.category = plugin.category;
     if (plugin.homepage) info.homepage = plugin.homepage;
-    if (plugin.skills) info.skills = plugin.skills;
+    const skills = normalizeComponentPaths(plugin.skills);
+    if (skills) info.skills = skills;
     return info;
   });
 
@@ -916,7 +929,12 @@ export async function resolvePluginSpec(
     fetchFn?: (url: string) => Promise<FetchResult>;
     workspacePath?: string;
   } = {},
-): Promise<{ path: string; marketplace: string; plugin: string } | null> {
+): Promise<{
+  path: string;
+  marketplace: string;
+  plugin: string;
+  fileArtifacts?: MarketplaceFileArtifacts;
+} | null> {
   const parsed = parsePluginSpec(spec);
   if (!parsed) {
     return null;
@@ -943,6 +961,7 @@ export async function resolvePluginSpec(
       (p) => p.name === parsed.plugin,
     );
     if (pluginEntry) {
+      const declaredFileArtifacts = getMarketplaceFileArtifacts(pluginEntry);
       if (typeof pluginEntry.source === 'string') {
         // Local path source - resolve relative to marketplace
         const resolvedPath = resolve(marketplacePath, pluginEntry.source);
@@ -951,6 +970,9 @@ export async function resolvePluginSpec(
             path: resolvedPath,
             marketplace: marketplaceName,
             plugin: parsed.plugin,
+            ...(declaredFileArtifacts && {
+              fileArtifacts: declaredFileArtifacts,
+            }),
           };
         }
       } else {
@@ -963,10 +985,17 @@ export async function resolvePluginSpec(
               parsedUrl.repo,
             );
             if (existsSync(cachePath)) {
+              const fileArtifacts =
+                declaredFileArtifacts ??
+                (await getEmbeddedMarketplaceFileArtifacts(
+                  cachePath,
+                  parsed.plugin,
+                ));
               return {
                 path: cachePath,
                 marketplace: marketplaceName,
                 plugin: parsed.plugin,
+                ...(fileArtifacts && { fileArtifacts }),
               };
             }
           }
@@ -976,10 +1005,17 @@ export async function resolvePluginSpec(
         const fetchFn = options.fetchFn ?? fetchPlugin;
         const fetchResult = await fetchFn(pluginEntry.source.url);
         if (fetchResult.success && fetchResult.cachePath) {
+          const fileArtifacts =
+            declaredFileArtifacts ??
+            (await getEmbeddedMarketplaceFileArtifacts(
+              fetchResult.cachePath,
+              parsed.plugin,
+            ));
           return {
             path: fetchResult.cachePath,
             marketplace: marketplaceName,
             plugin: parsed.plugin,
+            ...(fileArtifacts && { fileArtifacts }),
           };
         }
       }
@@ -1011,6 +1047,8 @@ export interface ResolvePluginSpecResult {
   registeredAs?: string;
   /** GitHub marketplace source (owner/repo) for native CLI registration */
   marketplaceSource?: string;
+  /** File artifacts declared by a non-strict marketplace entry. */
+  fileArtifacts?: MarketplaceFileArtifacts;
   error?: string;
 }
 
@@ -1171,6 +1209,7 @@ export async function resolvePluginSpecWithAutoRegister(
     pluginName: resolved.plugin,
     ...(shouldReturnRegisteredAs && { registeredAs: marketplace.name }),
     ...(marketplaceSource && { marketplaceSource }),
+    ...(resolved.fileArtifacts && { fileArtifacts: resolved.fileArtifacts }),
   };
 }
 

--- a/src/core/sync.ts
+++ b/src/core/sync.ts
@@ -56,6 +56,8 @@ import {
   resolveClientMappings,
 } from '../models/client-mapping.js';
 import type { ClientMapping } from '../models/client-mapping.js';
+import type { MarketplaceFileArtifacts } from '../models/marketplace-manifest.js';
+import { getEmbeddedMarketplaceFileArtifacts } from '../utils/marketplace-manifest-parser.js';
 import {
   resolveSkillNames,
   getSkillKey,
@@ -337,6 +339,8 @@ export interface ValidatedPlugin {
   registeredAs?: string;
   /** GitHub marketplace source (owner/repo) for native CLI registration */
   marketplaceSource?: string;
+  /** File artifacts declared by a non-strict marketplace entry. */
+  fileArtifacts?: MarketplaceFileArtifacts;
   /** Glob patterns of files to exclude when syncing (from workspace.yaml) */
   exclude?: string[];
   /** Inline skill selection config from plugin entry (v2+) */
@@ -1103,6 +1107,7 @@ async function collectAvailableSkillNames(
 ): Promise<Set<string>> {
   const names = new Set<string>();
   for (const plugin of validPlugins) {
+    if (plugin.fileArtifacts && !plugin.fileArtifacts.skills) continue;
     const skills = await collectPluginSkills(
       plugin.resolved,
       plugin.plugin,
@@ -1157,6 +1162,9 @@ async function validatePlugin(
       ...(resolved.marketplaceSource && {
         marketplaceSource: resolved.marketplaceSource,
       }),
+      ...(resolved.fileArtifacts && {
+        fileArtifacts: resolved.fileArtifacts,
+      }),
     };
   }
 
@@ -1183,12 +1191,17 @@ async function validatePlugin(
     const resolvedPath = parsed?.subpath
       ? join(fetchResult.cachePath, parsed.subpath)
       : fetchResult.cachePath;
+    const fileArtifacts = await getEmbeddedMarketplaceFileArtifacts(
+      resolvedPath,
+      parsed?.repo,
+    );
     return {
       plugin: pluginSource,
       resolved: resolvedPath,
       success: true,
       clients: [],
       nativeClients: [],
+      ...(fileArtifacts && { fileArtifacts }),
     };
   }
 
@@ -1204,12 +1217,17 @@ async function validatePlugin(
       error: `Plugin not found at ${resolvedPath}`,
     };
   }
+  const fileArtifacts = await getEmbeddedMarketplaceFileArtifacts(
+    resolvedPath,
+    getPluginName(resolvedPath),
+  );
   return {
     plugin: pluginSource,
     resolved: resolvedPath,
     success: true,
     clients: [],
     nativeClients: [],
+    ...(fileArtifacts && { fileArtifacts }),
   };
 }
 
@@ -1387,6 +1405,9 @@ async function copyValidatedPlugin(
             clientMappings: mappings,
             syncMode: 'copy',
             ...(exclude && { exclude }),
+            ...(validatedPlugin.fileArtifacts && {
+              fileArtifacts: validatedPlugin.fileArtifacts,
+            }),
           },
         );
         copyResults.push(...results);
@@ -1403,6 +1424,9 @@ async function copyValidatedPlugin(
             syncMode: 'symlink',
             canonicalSkillsPath: CANONICAL_SKILLS_PATH,
             ...(exclude && { exclude }),
+            ...(validatedPlugin.fileArtifacts && {
+              fileArtifacts: validatedPlugin.fileArtifacts,
+            }),
           },
         );
         copyResults.push(...results);
@@ -1426,6 +1450,9 @@ async function copyValidatedPlugin(
           clientMappings: mappings,
           syncMode: 'copy',
           ...(exclude && { exclude }),
+          ...(validatedPlugin.fileArtifacts && {
+            fileArtifacts: validatedPlugin.fileArtifacts,
+          }),
         },
       );
       copyResults.push(...results);
@@ -1473,6 +1500,7 @@ async function collectAllSkills(
   const allSkills: CollectedSkillEntry[] = [];
 
   for (const plugin of validatedPlugins) {
+    if (plugin.fileArtifacts && !plugin.fileArtifacts.skills) continue;
     const pluginName = plugin.pluginName ?? getPluginName(plugin.resolved);
     const skills = await collectPluginSkills(
       plugin.resolved,
@@ -2586,7 +2614,11 @@ export async function syncUserWorkspace(
       () =>
         findRelocatedGitHubHooks(
           validPlugins
-            .filter((plugin) => plugin.clients.includes('copilot'))
+            .filter(
+              (plugin) =>
+                plugin.clients.includes('copilot') &&
+                plugin.fileArtifacts?.github !== false,
+            )
             .map((plugin) => ({
               pluginPath: plugin.resolved,
               ...(plugin.exclude && { exclude: plugin.exclude }),

--- a/src/core/transform.ts
+++ b/src/core/transform.ts
@@ -19,6 +19,7 @@ import {
   isUniversalClient,
 } from '../models/client-mapping.js';
 import type { ClientMapping } from '../models/client-mapping.js';
+import type { MarketplaceFileArtifacts } from '../models/marketplace-manifest.js';
 import type {
   ClientType,
   PluginSkillsConfig,
@@ -971,6 +972,11 @@ export async function copyGitHubContent(
  */
 export interface PluginCopyOptions extends CopyOptions {
   /**
+   * File artifacts explicitly exposed by a non-strict marketplace entry.
+   * Undefined preserves conventional plugin-directory discovery.
+   */
+  fileArtifacts?: MarketplaceFileArtifacts;
+  /**
    * Map of skill folder name to resolved name for this specific plugin.
    * When provided, skills will be copied using the resolved name instead of folder name.
    */
@@ -1003,33 +1009,45 @@ export async function copyPluginToWorkspace(
   client: ClientType,
   options: PluginCopyOptions = {},
 ): Promise<CopyResult[]> {
-  const { skillNameMap, syncMode, canonicalSkillsPath, ...baseOptions } =
-    options;
+  const {
+    skillNameMap,
+    syncMode,
+    canonicalSkillsPath,
+    fileArtifacts,
+    ...baseOptions
+  } = options;
+  const shouldCopy = (artifact: keyof MarketplaceFileArtifacts): boolean =>
+    fileArtifacts?.[artifact] ?? true;
 
   // Phase 1: Copy root-level artifacts in parallel
   const [commandResults, skillResults, hookResults, agentResults] =
     await Promise.all([
-      copyCommands(pluginPath, workspacePath, client, baseOptions),
-      copySkills(pluginPath, workspacePath, client, {
-        ...baseOptions,
-        ...(skillNameMap && { skillNameMap }),
-        ...(syncMode && { syncMode }),
-        ...(canonicalSkillsPath && { canonicalSkillsPath }),
-      }),
-      copyHooks(pluginPath, workspacePath, client, baseOptions),
-      copyAgents(pluginPath, workspacePath, client, baseOptions),
+      shouldCopy('commands')
+        ? copyCommands(pluginPath, workspacePath, client, baseOptions)
+        : [],
+      shouldCopy('skills')
+        ? copySkills(pluginPath, workspacePath, client, {
+            ...baseOptions,
+            ...(skillNameMap && { skillNameMap }),
+            ...(syncMode && { syncMode }),
+            ...(canonicalSkillsPath && { canonicalSkillsPath }),
+          })
+        : [],
+      shouldCopy('hooks')
+        ? copyHooks(pluginPath, workspacePath, client, baseOptions)
+        : [],
+      shouldCopy('agents')
+        ? copyAgents(pluginPath, workspacePath, client, baseOptions)
+        : [],
     ]);
 
   // Phase 2: Copy .github/ content — overrides root-level on name conflicts
-  const githubResults = await copyGitHubContent(
-    pluginPath,
-    workspacePath,
-    client,
-    {
-      ...baseOptions,
-      ...(skillNameMap && { skillNameMap }),
-    },
-  );
+  const githubResults = shouldCopy('github')
+    ? await copyGitHubContent(pluginPath, workspacePath, client, {
+        ...baseOptions,
+        ...(skillNameMap && { skillNameMap }),
+      })
+    : [];
 
   return [
     ...commandResults,

--- a/src/core/vscode-mcp.ts
+++ b/src/core/vscode-mcp.ts
@@ -120,6 +120,7 @@ export function collectMcpServers(
   const warnings: string[] = [];
 
   for (const plugin of validatedPlugins) {
+    if (plugin.fileArtifacts?.mcpServers === false) continue;
     const mcpServers = readPluginMcpConfig(plugin.resolved);
     if (!mcpServers) continue;
 

--- a/src/models/marketplace-manifest.ts
+++ b/src/models/marketplace-manifest.ts
@@ -32,6 +32,12 @@ export const PluginSourceRefSchema = z.union([z.string(), UrlSourceSchema, GitHu
 
 export type PluginSourceRef = z.infer<typeof PluginSourceRefSchema>;
 
+/** A plugin component may be declared as one path or several paths. */
+export const ComponentPathSchema = z.union([
+  z.string(),
+  z.array(z.string()),
+]);
+
 /**
  * Author/owner contact info
  */
@@ -67,11 +73,45 @@ export const MarketplacePluginEntrySchema = z.object({
   homepage: z.string().optional(),
   strict: z.boolean().optional(),
   tags: z.array(z.string()).optional(),
-  skills: z.array(z.string()).optional(),
+  skills: ComponentPathSchema.optional(),
+  commands: ComponentPathSchema.optional(),
+  agents: ComponentPathSchema.optional(),
+  hooks: z.union([z.string(), z.record(z.unknown())]).optional(),
+  mcpServers: z.union([z.string(), z.record(z.unknown())]).optional(),
   lspServers: z.record(LspServerSchema).optional(),
 });
 
 export type MarketplacePluginEntry = z.infer<typeof MarketplacePluginEntrySchema>;
+
+/** File artifact kinds AllAgents can copy from a plugin source. */
+export interface MarketplaceFileArtifacts {
+  commands: boolean;
+  skills: boolean;
+  hooks: boolean;
+  agents: boolean;
+  mcpServers: boolean;
+  github: boolean;
+}
+
+/**
+ * In non-strict mode the marketplace entry is the complete component
+ * definition. Omitted components must not be inferred from repository files.
+ */
+export function getMarketplaceFileArtifacts(
+  entry: MarketplacePluginEntry,
+): MarketplaceFileArtifacts | undefined {
+  if (entry.strict !== false) return undefined;
+
+  return {
+    commands: entry.commands !== undefined,
+    skills: entry.skills !== undefined,
+    hooks: entry.hooks !== undefined,
+    agents: entry.agents !== undefined,
+    mcpServers: entry.mcpServers !== undefined,
+    // .github is repository configuration, not a marketplace component kind.
+    github: false,
+  };
+}
 
 /**
  * Top-level marketplace.json schema

--- a/src/utils/marketplace-manifest-parser.ts
+++ b/src/utils/marketplace-manifest-parser.ts
@@ -1,17 +1,22 @@
-import { readFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import {
-  MarketplaceManifestSchema,
-  MarketplaceManifestLenientSchema,
-  MarketplacePluginEntrySchema,
-  PluginSourceRefSchema,
+  type MarketplaceFileArtifacts,
   type MarketplaceManifest,
+  MarketplaceManifestLenientSchema,
+  MarketplaceManifestSchema,
   type MarketplacePluginEntry,
+  MarketplacePluginEntrySchema,
   type PluginSourceRef,
+  PluginSourceRefSchema,
+  getMarketplaceFileArtifacts,
 } from '../models/marketplace-manifest.js';
 
-const MANIFEST_PATH = '.claude-plugin/marketplace.json';
+const MANIFEST_PATHS = [
+  '.github/plugin/marketplace.json',
+  '.claude-plugin/marketplace.json',
+] as const;
 
 export type ParseResult =
   | { success: true; data: MarketplaceManifest; warnings: string[] }
@@ -19,7 +24,7 @@ export type ParseResult =
 
 /**
  * Parse and validate a marketplace.json from a marketplace directory.
- * Looks for .claude-plugin/marketplace.json within the given path.
+ * Prefers GitHub Copilot's marketplace location and falls back to Claude's.
  *
  * Uses a two-tier approach:
  * 1. Try strict validation first — if it passes, return with no warnings
@@ -29,12 +34,14 @@ export type ParseResult =
 export async function parseMarketplaceManifest(
   marketplacePath: string,
 ): Promise<ParseResult> {
-  const manifestPath = join(marketplacePath, MANIFEST_PATH);
+  const manifestPath = MANIFEST_PATHS
+    .map((path) => join(marketplacePath, path))
+    .find((path) => existsSync(path));
 
-  if (!existsSync(manifestPath)) {
+  if (!manifestPath) {
     return {
       success: false,
-      error: `Marketplace manifest not found: ${manifestPath}`,
+      error: `Marketplace manifest not found (checked ${MANIFEST_PATHS.join(', ')})`,
     };
   }
 
@@ -66,6 +73,34 @@ export async function parseMarketplaceManifest(
 
   // Tier 2: lenient parsing
   return parseLeniently(json);
+}
+
+/**
+ * Read a plugin repository's own marketplace manifest and return the file
+ * artifact boundary for the entry whose source is the repository root.
+ *
+ * A preferred name disambiguates repositories that expose multiple root
+ * entries. When there is only one root entry, it is safe to use for direct
+ * repository sources whose directory name differs from the plugin name.
+ */
+export async function getEmbeddedMarketplaceFileArtifacts(
+  pluginPath: string,
+  preferredName?: string,
+): Promise<MarketplaceFileArtifacts | undefined> {
+  const manifestResult = await parseMarketplaceManifest(pluginPath);
+  if (!manifestResult.success) return undefined;
+
+  const pluginRoot = resolve(pluginPath);
+  const rootEntries = manifestResult.data.plugins.filter(
+    (entry) =>
+      typeof entry.source === 'string' &&
+      resolve(pluginPath, entry.source) === pluginRoot,
+  );
+  const entry =
+    rootEntries.find((candidate) => candidate.name === preferredName) ??
+    (rootEntries.length === 1 ? rootEntries[0] : undefined);
+
+  return entry ? getMarketplaceFileArtifacts(entry) : undefined;
 }
 
 /**
@@ -169,8 +204,28 @@ function extractPluginEntry(
     ...(typeof obj.version === 'string' && { version: obj.version }),
     ...(typeof obj.category === 'string' && { category: obj.category }),
     ...(typeof obj.homepage === 'string' && { homepage: obj.homepage }),
-    ...(Array.isArray(obj.skills) && obj.skills.every((s: unknown) => typeof s === 'string') && { skills: obj.skills as string[] }),
+    ...(isComponentPath(obj.skills) && { skills: obj.skills }),
+    ...(isComponentPath(obj.commands) && { commands: obj.commands }),
+    ...(isComponentPath(obj.agents) && { agents: obj.agents }),
+    ...((typeof obj.hooks === 'string' || isRecord(obj.hooks)) && {
+      hooks: obj.hooks,
+    }),
+    ...((typeof obj.mcpServers === 'string' || isRecord(obj.mcpServers)) && {
+      mcpServers: obj.mcpServers,
+    }),
+    ...(typeof obj.strict === 'boolean' && { strict: obj.strict }),
   };
+}
+
+function isComponentPath(value: unknown): value is string | string[] {
+  return (
+    typeof value === 'string' ||
+    (Array.isArray(value) && value.every((item) => typeof item === 'string'))
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
 /**

--- a/tests/e2e/plugin-skills.test.ts
+++ b/tests/e2e/plugin-skills.test.ts
@@ -253,4 +253,95 @@ description: Blog watcher
       }
     }
   });
+
+  it('honors skills-only Copilot marketplace entries without copying repository config', async () => {
+    const originalTestHome = process.env.ALLAGENTS_TEST_HOME;
+    const fakeHome = join(tmpDir, 'home');
+    const marketplaceDir = join(tmpDir, 'ediprod-marketplace');
+
+    process.env.ALLAGENTS_TEST_HOME = fakeHome;
+    try {
+      await mkdir(join(marketplaceDir, '.github', 'plugin'), {
+        recursive: true,
+      });
+      await mkdir(join(marketplaceDir, '.github', 'hooks'), {
+        recursive: true,
+      });
+      await mkdir(join(marketplaceDir, 'hooks'), { recursive: true });
+      await mkdir(join(marketplaceDir, 'skills', 'ediprod'), {
+        recursive: true,
+      });
+      await writeFile(
+        join(marketplaceDir, '.github', 'plugin', 'marketplace.json'),
+        JSON.stringify({
+          name: 'ediprod-plugins',
+          description: 'ediProd plugins',
+          plugins: [
+            {
+              name: 'ediprod',
+              description: 'ediProd skills',
+              source: './',
+              strict: false,
+              skills: ['./skills/'],
+            },
+          ],
+        }),
+      );
+      await writeFile(
+        join(marketplaceDir, 'skills', 'ediprod', 'SKILL.md'),
+        '---\nname: ediprod\ndescription: ediProd\n---\n',
+      );
+      await writeFile(
+        join(marketplaceDir, 'hooks', 'portable.json'),
+        '{"hooks":{}}',
+      );
+      await writeFile(
+        join(marketplaceDir, '.github', 'hooks', 'repository.json'),
+        '{"hooks":{}}',
+      );
+      await writeFile(
+        join(marketplaceDir, '.mcp.json'),
+        JSON.stringify({
+          mcpServers: {
+            undeclared: {
+              type: 'http',
+              url: 'https://undeclared.test',
+            },
+          },
+        }),
+      );
+
+      const config: WorkspaceConfig = {
+        repositories: [],
+        // Direct repository sources should honor their embedded marketplace
+        // boundary instead of treating repository configuration as plugin data.
+        plugins: [marketplaceDir],
+        clients: ['copilot'],
+        syncMode: 'copy',
+        version: 2,
+      };
+      await writeFile(
+        join(tmpDir, '.allagents/workspace.yaml'),
+        dump(config),
+        'utf-8',
+      );
+
+      const result = await syncWorkspace(tmpDir);
+
+      expect(result.success).toBe(true);
+      expect(
+        existsSync(join(tmpDir, '.github', 'skills', 'ediprod', 'SKILL.md')),
+      ).toBe(true);
+      expect(existsSync(join(tmpDir, '.github', 'hooks'))).toBe(false);
+      expect(existsSync(join(tmpDir, '.copilot', 'mcp-config.json'))).toBe(
+        false,
+      );
+    } finally {
+      if (originalTestHome === undefined) {
+        delete process.env.ALLAGENTS_TEST_HOME;
+      } else {
+        process.env.ALLAGENTS_TEST_HOME = originalTestHome;
+      }
+    }
+  });
 });

--- a/tests/unit/core/codex-hooks.test.ts
+++ b/tests/unit/core/codex-hooks.test.ts
@@ -220,6 +220,34 @@ describe('syncCodexProjectHooks', () => {
     expect(result.warnings.some((warning) => warning.includes('not updating'))).toBe(true);
     expect(await readFile(hooksPath, 'utf-8')).toBe(originalContent);
   });
+
+  it('does not import hooks omitted by a non-strict marketplace entry', async () => {
+    await writeFile(
+      join(pluginB, 'hooks', 'hooks.json'),
+      JSON.stringify({
+        hooks: {
+          UserPromptSubmit: [
+            { hooks: [{ type: 'command', command: 'echo undeclared' }] },
+          ],
+        },
+      }),
+      'utf-8',
+    );
+    const plugin = validatedCodexPlugin(pluginB, './plugin-b');
+    plugin.fileArtifacts = {
+      agents: false,
+      commands: false,
+      github: false,
+      hooks: false,
+      mcpServers: false,
+      skills: true,
+    };
+
+    const result = syncCodexProjectHooks([plugin], workspaceDir, undefined);
+
+    expect(result.managedHooks).toBeUndefined();
+    expect(existsSync(join(workspaceDir, '.codex', 'hooks.json'))).toBe(false);
+  });
 });
 
 describe('syncWorkspace Codex hooks', () => {

--- a/tests/unit/core/copilot-artifacts.test.ts
+++ b/tests/unit/core/copilot-artifacts.test.ts
@@ -65,6 +65,37 @@ describe('copilot agents and hooks sync', () => {
   });
 
   describe('github override precedence', () => {
+    it('copies only declared artifacts for a non-strict marketplace entry', async () => {
+      await mkdir(join(pluginDir, 'skills', 'public-skill'), { recursive: true });
+      await writeFile(
+        join(pluginDir, 'skills', 'public-skill', 'SKILL.md'),
+        '---\nname: public-skill\n---\n',
+      );
+      await mkdir(join(pluginDir, 'hooks'), { recursive: true });
+      await writeFile(join(pluginDir, 'hooks', 'portable.json'), '{"hooks":[]}');
+      await mkdir(join(pluginDir, '.github', 'hooks'), { recursive: true });
+      await writeFile(
+        join(pluginDir, '.github', 'hooks', 'repository.json'),
+        '{"hooks":[]}',
+      );
+
+      await copyPluginToWorkspace(pluginDir, workspaceDir, 'copilot', {
+        fileArtifacts: {
+          agents: false,
+          commands: false,
+          github: false,
+          hooks: false,
+          mcpServers: false,
+          skills: true,
+        },
+      });
+
+      expect(
+        existsSync(join(workspaceDir, '.github', 'skills', 'public-skill', 'SKILL.md')),
+      ).toBe(true);
+      expect(existsSync(join(workspaceDir, '.github', 'hooks'))).toBe(false);
+    });
+
     it('.github/agents/ overrides root agents/ on name conflict', async () => {
       // Root agent
       await mkdir(join(pluginDir, 'agents'), { recursive: true });

--- a/tests/unit/core/marketplace.test.ts
+++ b/tests/unit/core/marketplace.test.ts
@@ -203,6 +203,77 @@ describe('getMarketplacePluginsFromManifest', () => {
     expect(result!.plugin).toBe('external');
   });
 
+  it('should expose only declared artifacts for a strict-false skills-only plugin', async () => {
+    mkdirSync(join(testDir, 'skills', 'skill-a'), { recursive: true });
+    mkdirSync(join(testDir, '.github', 'hooks'), { recursive: true });
+    writeFileSync(
+      join(testDir, 'skills', 'skill-a', 'SKILL.md'),
+      '---\nname: skill-a\n---\n',
+    );
+    writeFileSync(
+      join(testDir, '.github', 'hooks', 'post-edit.json'),
+      '{}',
+    );
+    writeFileSync(
+      join(testDir, '.claude-plugin', 'marketplace.json'),
+      JSON.stringify({
+        name: 'test',
+        description: 'Test',
+        plugins: [
+          {
+            name: 'skills-only',
+            description: 'Skills only',
+            source: './',
+            strict: false,
+            skills: ['./skills/'],
+          },
+        ],
+      }),
+    );
+
+    const result = await resolvePluginSpec('skills-only@test-marketplace', {
+      marketplacePathOverride: testDir,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.path).toBe(testDir);
+    expect(result!.fileArtifacts).toEqual({
+      agents: false,
+      commands: false,
+      github: false,
+      hooks: false,
+      mcpServers: false,
+      skills: true,
+    });
+  });
+
+  it('should keep the plugin root when strict mode can merge other components', async () => {
+    mkdirSync(join(testDir, 'skills', 'skill-a'), { recursive: true });
+    writeFileSync(
+      join(testDir, '.claude-plugin', 'marketplace.json'),
+      JSON.stringify({
+        name: 'test',
+        description: 'Test',
+        plugins: [
+          {
+            name: 'full-plugin',
+            description: 'Full plugin',
+            source: './',
+            skills: ['./skills/'],
+          },
+        ],
+      }),
+    );
+
+    const result = await resolvePluginSpec('full-plugin@test-marketplace', {
+      marketplacePathOverride: testDir,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.path).toBe(testDir);
+    expect(result!.fileArtifacts).toBeUndefined();
+  });
+
   it('should return null for URL source plugins when fetch fails', async () => {
     const manifest = {
       name: 'test',
@@ -279,6 +350,66 @@ describe('getMarketplacePluginsFromManifest', () => {
     expect(result!.plugin).toBe('ediprod');
     // Verify the github source was normalized to a full URL
     expect(fetchedUrl).toBe('https://github.com/WiseTechGlobal/mcp-ediprod');
+  });
+
+  it('should honor an external plugin repository embedded marketplace boundary', async () => {
+    const cachedPluginDir = join(testDir, 'cached-ediprod');
+    mkdirSync(join(cachedPluginDir, '.github', 'plugin'), {
+      recursive: true,
+    });
+    writeFileSync(
+      join(cachedPluginDir, '.github', 'plugin', 'marketplace.json'),
+      JSON.stringify({
+        name: 'ediprod-plugins',
+        description: 'ediProd plugins',
+        plugins: [
+          {
+            name: 'ediprod',
+            description: 'ediProd skills',
+            source: './',
+            strict: false,
+            skills: ['./skills/'],
+          },
+        ],
+      }),
+    );
+    writeFileSync(
+      join(testDir, '.claude-plugin', 'marketplace.json'),
+      JSON.stringify({
+        name: 'wtg-ai-prompts',
+        description: 'WTG plugins',
+        plugins: [
+          {
+            name: 'ediprod',
+            description: 'ediProd',
+            source: {
+              source: 'github',
+              repo: 'WiseTechGlobal/mcp-ediprod',
+            },
+          },
+        ],
+      }),
+    );
+
+    const result = await resolvePluginSpec('ediprod@test-marketplace', {
+      marketplacePathOverride: testDir,
+      fetchFn: async () => ({
+        success: true,
+        action: 'cloned' as const,
+        cachePath: cachedPluginDir,
+      }),
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.path).toBe(cachedPluginDir);
+    expect(result!.fileArtifacts).toEqual({
+      agents: false,
+      commands: false,
+      github: false,
+      hooks: false,
+      mcpServers: false,
+      skills: true,
+    });
   });
 
   it('should handle GitHub source plugins in plugin listing', async () => {

--- a/tests/unit/core/vscode-mcp.test.ts
+++ b/tests/unit/core/vscode-mcp.test.ts
@@ -125,6 +125,31 @@ describe('collectMcpServers', () => {
     expect(warnings[0]).toContain('plugin-b');
     expect(warnings[0]).toContain('dup');
   });
+
+  test('skips MCP servers omitted by a non-strict marketplace entry', () => {
+    writeFileSync(
+      join(tempDir1, '.mcp.json'),
+      JSON.stringify({
+        mcpServers: {
+          undeclared: { type: 'http', url: 'https://undeclared.test' },
+        },
+      }),
+    );
+    const plugin = makePlugin(tempDir1);
+    plugin.fileArtifacts = {
+      agents: false,
+      commands: false,
+      github: false,
+      hooks: false,
+      mcpServers: false,
+      skills: true,
+    };
+
+    const { servers, warnings } = collectMcpServers([plugin]);
+
+    expect(servers.size).toBe(0);
+    expect(warnings).toEqual([]);
+  });
 });
 
 describe('syncVscodeMcpConfig', () => {

--- a/tests/unit/utils/marketplace-manifest-parser.test.ts
+++ b/tests/unit/utils/marketplace-manifest-parser.test.ts
@@ -41,6 +41,63 @@ describe('parseMarketplaceManifest', () => {
     }
   });
 
+  it('should fall back to the GitHub Copilot marketplace location', async () => {
+    rmSync(join(testDir, '.claude-plugin'), { recursive: true, force: true });
+    mkdirSync(join(testDir, '.github', 'plugin'), { recursive: true });
+    writeFileSync(
+      join(testDir, '.github', 'plugin', 'marketplace.json'),
+      JSON.stringify({
+        name: 'copilot-marketplace',
+        description: 'Copilot marketplace',
+        plugins: [
+          {
+            name: 'skills-only',
+            description: 'Skills only',
+            source: './',
+            strict: false,
+            skills: './skills/',
+          },
+        ],
+      }),
+    );
+
+    const result = await parseMarketplaceManifest(testDir);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.name).toBe('copilot-marketplace');
+      expect(result.data.plugins[0].strict).toBe(false);
+      expect(result.data.plugins[0].skills).toBe('./skills/');
+    }
+  });
+
+  it('should prefer the GitHub Copilot marketplace location', async () => {
+    writeFileSync(
+      join(testDir, '.claude-plugin', 'marketplace.json'),
+      JSON.stringify({
+        name: 'claude-marketplace',
+        description: 'Claude marketplace',
+        plugins: [],
+      }),
+    );
+    mkdirSync(join(testDir, '.github', 'plugin'), { recursive: true });
+    writeFileSync(
+      join(testDir, '.github', 'plugin', 'marketplace.json'),
+      JSON.stringify({
+        name: 'copilot-marketplace',
+        description: 'Copilot marketplace',
+        plugins: [],
+      }),
+    );
+
+    const result = await parseMarketplaceManifest(testDir);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.name).toBe('copilot-marketplace');
+    }
+  });
+
   it('should return error when marketplace.json does not exist', async () => {
     rmSync(join(testDir, '.claude-plugin'), { recursive: true, force: true });
     const result = await parseMarketplaceManifest(testDir);


### PR DESCRIPTION
## Summary

Skills-only repositories no longer leak their development hooks, GitHub configuration, or MCP servers into consumer workspaces. AllAgents now reads both Copilot and Claude marketplace manifests and honors the component kinds declared by a `strict: false` entry, including when the repository is installed directly or fetched through another marketplace.

Before this change, `source: "./"` made the whole repository look like plugin content, so `.github/hooks` could be interpreted as distributable configuration. After this change, a root source can remain a plugin while `skills: ["./skills/"]` is the only exposed component; top-level `hooks/` remains available to conventional or explicitly hook-bearing plugins.

The boundary is enforced in the normal file copier, Codex hook aggregation, MCP discovery, skill scanning, and legacy user-hook relocation. Custom marketplace component paths are parsed but not remapped yet; this PR applies the declared component-kind boundary to AllAgents' conventional root directories.

Related: WiseTechGlobal/mcp-ediprod#448

## Validation

- `bun run build`
- `bun run typecheck`
- `bun run lint`
- `bun test` — 1,347 passed, 5 skipped
- `bun run test:e2e` — 117 passed, 4 skipped

Manual E2E:

1. Cloned `WiseTechGlobal/mcp-ediprod` into a temporary directory.
2. Set its root marketplace entry to `strict: false` with `skills: ["./skills/"]`.
3. Configured a temporary Copilot workspace with the cloned repository as a direct plugin source.
4. Ran the built CLI with `dist/index.js update`.
5. Verified all five skills appeared under `.github/skills`, while `.github/hooks`, `.github/plugin`, and `.copilot/mcp-config.json` were absent.
