### PR TITLE
test(cli): isolate skill removal cache fixtures

### DIFF
--- a/tests/unit/cli/skill-removal.test.ts
+++ b/tests/unit/cli/skill-removal.test.ts
@@ -5,8 +5,12 @@ import { join } from 'node:path';
 import { load, dump } from 'js-yaml';
 import { removeInstalledSkill } from '../../../src/cli/skill-removal.js';
 import type { WorkspaceConfig } from '../../../src/models/workspace-config.js';
-import type { SkillInfo } from '../../../src/core/skills.js';
+import {
+  getAllSkillsFromPlugins,
+  type SkillInfo,
+} from '../../../src/core/skills.js';
 import { resetFetchCache } from '../../../src/core/plugin.js';
+import { stubHomeDir } from '../../helpers/env.js';
 
 describe('removeInstalledSkill', () => {
   let tmpDir: string;
@@ -164,8 +168,8 @@ describe('removeInstalledSkill', () => {
   });
 
   it('removes a single-skill GitHub source instead of leaving an empty allowlist', async () => {
-    const originalHome = process.env.HOME;
     const fakeHome = join(tmpDir, 'home');
+    const restoreHomeDir = stubHomeDir(fakeHome);
     const pluginDir = join(
       fakeHome,
       '.allagents/plugins/marketplaces/NousResearch-hermes-agent@main/skills/research/llm-wiki',
@@ -185,10 +189,16 @@ describe('removeInstalledSkill', () => {
     };
     await writeFile(join(tmpDir, '.allagents/workspace.yaml'), dump(config), 'utf-8');
 
-    process.env.HOME = fakeHome;
     resetFetchCache();
 
     try {
+      const discoveredSkills = await getAllSkillsFromPlugins(tmpDir);
+      expect(
+        discoveredSkills.map(({ name, pluginSource, path }) => ({ name, pluginSource, path })),
+      ).toEqual([
+        { name: 'llm-wiki', pluginSource: source, path: pluginDir },
+      ]);
+
       const result = await removeInstalledSkill({
         targetSkill: {
           name: 'llm-wiki',
@@ -206,7 +216,7 @@ describe('removeInstalledSkill', () => {
       const updated = load(content) as WorkspaceConfig;
       expect(updated.plugins).toEqual([]);
     } finally {
-      process.env.HOME = originalHome;
+      restoreHomeDir();
       resetFetchCache();
     }
   });

--- a/tests/unit/core/skills.test.ts
+++ b/tests/unit/core/skills.test.ts
@@ -3,11 +3,13 @@ import { mkdtemp, rm, mkdir, writeFile, symlink } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { dump } from 'js-yaml';
+import { stubHomeDir } from '../../helpers/env.js';
 import {
   getAllSkillsFromPlugins,
   discoverNestedSkillEntries,
   type SkillInfo,
 } from '../../../src/core/skills.js';
+import { resetFetchCache } from '../../../src/core/plugin.js';
 import { getPluginCachePath } from '../../../src/utils/plugin-path.js';
 
 describe('getAllSkillsFromPlugins', () => {
@@ -224,23 +226,33 @@ describe('getAllSkillsFromPlugins', () => {
   });
 
   it('skips GitHub URL entries whose subpath no longer exists in cache', async () => {
-    const originalHome = process.env.HOME;
-    process.env.HOME = tmpDir;
+    const restoreHomeDir = stubHomeDir(tmpDir);
+    resetFetchCache();
     try {
       const cachePath = getPluginCachePath('owner', 'repo', 'main');
-      await mkdir(cachePath, { recursive: true });
+      const siblingPath = join(cachePath, 'available');
+      await mkdir(siblingPath, { recursive: true });
+      await writeFile(join(siblingPath, 'SKILL.md'), '# Cached sibling');
+
+      const missingSource = 'https://github.com/owner/repo/tree/main/missing/path';
+      const siblingSource = 'https://github.com/owner/repo/tree/main/available';
 
       const config = {
         repositories: [],
-        plugins: ['https://github.com/owner/repo/tree/main/missing/path'],
+        plugins: [missingSource, siblingSource],
         clients: ['claude'],
       };
       await writeFile(join(tmpDir, '.allagents/workspace.yaml'), dump(config));
 
       const skills = await getAllSkillsFromPlugins(tmpDir);
-      expect(skills).toEqual([]);
+      expect(
+        skills.map(({ name, pluginSource, path }) => ({ name, pluginSource, path })),
+      ).toEqual([
+        { name: 'available', pluginSource: siblingSource, path: siblingPath },
+      ]);
     } finally {
-      process.env.HOME = originalHome;
+      restoreHomeDir();
+      resetFetchCache();
     }
   });
 });


### PR DESCRIPTION
## Summary

The skill-removal suite now stays inside its explicit AllAgents test home instead of missing its cache fixture and attempting a real GitHub clone in CI. The affected tests also prove that the intended cached plugin paths were discovered, so a failed fetch cannot produce a false green.

## Validation

Red reproduction on `origin/main`:

```bash
ALLAGENTS_TEST_HOME=/tmp/allagents-skill-removal-red-90740423134 bun test tests/unit/cli/skill-removal.test.ts --timeout 5000
```

The target case timed out at 5004 ms and Bun killed one dangling clone process.

Green verification:

```bash
bun test tests/unit/cli/skill-removal.test.ts tests/unit/core/skills.test.ts tests/unit/core/plugin.test.ts tests/unit/constants.test.ts --timeout 5000
bun test
bun run lint
bun run typecheck
bun run build
```

- Focused coverage: 32 passed, 1 Windows-only skip.
- Stress coverage: 50 isolated iterations, 900 passes, and no writes to the ambient test home.
- Full suite: 1,347 passed, 5 skipped, 0 failed.
- No manual CLI E2E was needed because production code and runtime behavior are unchanged.

Related: [failing Actions job](https://github.com/EntityProcess/allagents/actions/runs/30501000825/job/90740423134)

## Post-Deploy Monitoring & Validation

No additional operational monitoring required because this is a test-only isolation fix with no production/runtime impact. The PR `Test` job is the validation signal; a timeout or dangling-process report in `removeInstalledSkill` is the rollback trigger. Validation window: this PR's CI run. Owner: repository maintainer.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
