### PR TITLE
fix(copilot): activate project plugin hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,11 +135,14 @@ that file. Codex plugins can declare hooks in `.codex-plugin/plugin.json` with a
 `hooks` path, path array, inline object, or inline object array; otherwise
 AllAgents falls back to `hooks/hooks.json`.
 
-For Copilot, root `hooks/` can sync to either project or user hook directories.
-Repository hooks under `.github/hooks/` remain project-scoped and are never
-promoted into the user-global `~/.copilot/hooks/` directory. Potential copies
-from older versions are left untouched and reported for manual review because
-their ownership was not tracked.
+For Copilot project sync, AllAgents combines plugin declarations from
+`hooks.json` or `hooks/hooks.json` in `.github/hooks/allagents.json` and binds
+`COPILOT_PLUGIN_ROOT` for each plugin. Other repository hooks under
+`.github/hooks/` remain project-scoped and are never promoted into the
+user-global `~/.copilot/hooks/` directory. Copilot package metadata under
+`.github/plugin/` is not copied into the project overlay. Potential user-scope
+copies from older versions are left untouched and reported for manual review
+because their ownership was not tracked.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ that file. Codex plugins can declare hooks in `.codex-plugin/plugin.json` with a
 `hooks` path, path array, inline object, or inline object array; otherwise
 AllAgents falls back to `hooks/hooks.json`.
 
-For Copilot project sync, AllAgents combines plugin declarations from
+For Copilot project sync, AllAgents combines plugin hook declarations from
 `hooks.json` or `hooks/hooks.json` in `.github/hooks/allagents.json` and binds
 `COPILOT_PLUGIN_ROOT` for each plugin. Other repository hooks under
 `.github/hooks/` remain project-scoped and are never promoted into the
@@ -143,6 +143,14 @@ user-global `~/.copilot/hooks/` directory. Copilot package metadata under
 `.github/plugin/` is not copied into the project overlay. Potential user-scope
 copies from older versions are left untouched and reported for manual review
 because their ownership was not tracked.
+
+Marketplace registration and `plugin.json` are not required for direct plugin
+sources. A plugin without a supported hook declaration continues syncing its
+other artifacts. AllAgents warns and omits a declaration that cannot be read or
+parsed as JSON or lacks the version-1 `hooks` object envelope. A declaration
+with `disableAllHooks: true` adds no entries; otherwise, a non-array event value
+also omits the declaration. Skipping a declaration does not reject the plugin
+or itself suppress other eligible artifacts, including repository hook files.
 
 ## Documentation
 

--- a/docs/decisions/0001-project-plugin-hooks.md
+++ b/docs/decisions/0001-project-plugin-hooks.md
@@ -12,6 +12,12 @@ not loaded by Copilot as a native plugin, so copying its scripts alone does not
 activate its hook declaration. See the
 [GitHub Copilot hooks reference](https://docs.github.com/en/copilot/reference/hooks-reference).
 
+This translation is independent of marketplace registration and package
+metadata. AllAgents continues to support direct local and GitHub plugin sources
+without a marketplace manifest or `plugin.json`. A plugin with no `hooks.json`
+or `hooks/hooks.json` simply declares no Copilot hooks; its other artifacts
+continue to sync normally.
+
 AllAgents also needs to remove one plugin's hooks without disturbing another
 plugin or user-owned repository configuration.
 
@@ -22,33 +28,44 @@ declarations into one AllAgents-owned repository hook file:
 `.github/hooks/allagents.json`.
 
 One aggregate file is used instead of one file per plugin because it gives the
-sync engine a single ownership boundary and an atomic reconciliation target.
+sync engine a single ownership boundary and one reconciliation target.
 Install, update, and uninstall can regenerate the complete desired state
 without inventing stable filenames, leaving stale per-plugin files, or touching
 sibling user-owned hook files.
 
-AllAgents creates or updates the aggregate only when its sync state records the
-file as managed. An existing unowned `.github/hooks/allagents.json` is preserved
-and reported as a warning. When no managed plugin hooks remain, AllAgents removes
-only its managed aggregate.
+When at least one managed hook entry remains, AllAgents creates the aggregate if
+the path is absent. It updates an existing aggregate only when sync state
+records the file as managed. An existing unowned
+`.github/hooks/allagents.json` is preserved and reported as a warning. When no
+managed plugin hooks remain, AllAgents removes only its managed aggregate.
 
-Each plugin declaration is validated independently. If any event value is not
-an array, the entire declaration from that plugin is rejected; valid declarations
-from other plugins still aggregate. This matches GitHub's structural semantics
-and avoids partially activating a malformed plugin.
+Each hook declaration is checked independently. If it cannot be read or parsed
+as JSON or lacks the version-1 `hooks` object envelope, AllAgents warns and
+omits every entry from that declaration from the managed aggregate. A valid
+envelope with `disableAllHooks: true` adds no entries. Otherwise, a non-array
+event value also warns and omits the declaration. AllAgents does not fully
+validate each hook entry. Skipping a declaration does not itself suppress the
+plugin's other eligible artifacts, including repository hook files, and valid
+hook declarations from other plugins still aggregate. Rejecting the
+declaration as a unit avoids partial managed activation when its enabled event
+structure is invalid.
 
 For every command entry, AllAgents preserves declared environment variables but
-binds `COPILOT_PLUGIN_ROOT` to that plugin's resolved installation path. The
-trusted binding prevents one plugin declaration from redirecting commands to a
-different root. Excluded declarations or hook payloads are not activated.
+overrides any declared `COPILOT_PLUGIN_ROOT` with that plugin's resolved
+installation path. References through that variable therefore resolve to the
+plugin's actual root. Excluded declarations or hook payloads are not activated.
 
 ## Consequences
 
 - Project-installed plugin hooks execute through Copilot's native repository
   hook discovery.
+- Marketplace registration and `plugin.json` remain optional for direct plugin
+  sources; hook materialization runs only when a supported hook declaration is
+  present.
 - User-owned hook files remain independent from AllAgents reconciliation.
-- One malformed plugin does not suppress valid hooks from other plugins, but it
-  receives no partial activation.
+- Skipping a hook declaration does not itself suppress that plugin's other
+  eligible artifacts or valid declarations from other plugins, but none of its
+  entries enter the managed aggregate.
 - The generated file contains absolute plugin paths. It is machine-local and
   should not be treated as portable configuration for cloud agents or another
   checkout where those paths do not exist.

--- a/docs/decisions/0001-project-plugin-hooks.md
+++ b/docs/decisions/0001-project-plugin-hooks.md
@@ -1,0 +1,64 @@
+# ADR 0001: Materialize project plugin hooks as one managed repository hook file
+
+- Status: Accepted
+- Date: 2026-07-30
+
+## Context
+
+GitHub Copilot discovers repository hooks from `.github/hooks/*.json`, while
+native plugin hooks may be declared in a plugin's `hooks.json` or
+`hooks/hooks.json`. A plugin installed through an AllAgents project overlay is
+not loaded by Copilot as a native plugin, so copying its scripts alone does not
+activate its hook declaration. See the
+[GitHub Copilot hooks reference](https://docs.github.com/en/copilot/reference/hooks-reference).
+
+AllAgents also needs to remove one plugin's hooks without disturbing another
+plugin or user-owned repository configuration.
+
+## Decision
+
+For project-scoped Copilot plugins, AllAgents materializes native plugin hook
+declarations into one AllAgents-owned repository hook file:
+`.github/hooks/allagents.json`.
+
+One aggregate file is used instead of one file per plugin because it gives the
+sync engine a single ownership boundary and an atomic reconciliation target.
+Install, update, and uninstall can regenerate the complete desired state
+without inventing stable filenames, leaving stale per-plugin files, or touching
+sibling user-owned hook files.
+
+AllAgents creates or updates the aggregate only when its sync state records the
+file as managed. An existing unowned `.github/hooks/allagents.json` is preserved
+and reported as a warning. When no managed plugin hooks remain, AllAgents removes
+only its managed aggregate.
+
+Each plugin declaration is validated independently. If any event value is not
+an array, the entire declaration from that plugin is rejected; valid declarations
+from other plugins still aggregate. This matches GitHub's structural semantics
+and avoids partially activating a malformed plugin.
+
+For every command entry, AllAgents preserves declared environment variables but
+binds `COPILOT_PLUGIN_ROOT` to that plugin's resolved installation path. The
+trusted binding prevents one plugin declaration from redirecting commands to a
+different root. Excluded declarations or hook payloads are not activated.
+
+## Consequences
+
+- Project-installed plugin hooks execute through Copilot's native repository
+  hook discovery.
+- User-owned hook files remain independent from AllAgents reconciliation.
+- One malformed plugin does not suppress valid hooks from other plugins, but it
+  receives no partial activation.
+- The generated file contains absolute plugin paths. It is machine-local and
+  should not be treated as portable configuration for cloud agents or another
+  checkout where those paths do not exist.
+- A user who already owns `.github/hooks/allagents.json` must rename it or choose
+  another ownership arrangement before AllAgents can activate project hooks.
+
+## Reconsider when
+
+Revisit this decision if Copilot gains native project-overlay plugin loading,
+provides a portable plugin-root binding for repository hooks, or remote/cloud
+execution becomes a supported project-plugin target. Also reconsider the single
+aggregate if plugins need independent trust, enablement, or failure policies that
+cannot be represented safely in one managed file.

--- a/docs/src/content/docs/docs/guides/plugins.mdx
+++ b/docs/src/content/docs/docs/guides/plugins.mdx
@@ -24,13 +24,25 @@ my-plugin/
 ```
 
 :::note
-At project scope, Copilot plugin declarations from `hooks.json` or
+At project scope, Copilot plugin hook declarations from `hooks.json` or
 `hooks/hooks.json` are combined in the AllAgents-owned
 `.github/hooks/allagents.json` file. Each entry receives its plugin-specific
 `COPILOT_PLUGIN_ROOT`, so declarations continue to resolve files from the
 plugin package. The generated file is tracked independently from other
 repository hook files. Package metadata under `.github/plugin/` is not copied
 into the project overlay.
+
+This does not require a marketplace manifest or `plugin.json`. Direct local and
+GitHub plugin sources continue to use conventional directory discovery. If a
+plugin has no supported hook declaration, its other artifacts still sync and it
+adds no entries to `allagents.json`. AllAgents warns and omits a declaration
+that cannot be read or parsed as JSON or lacks the version-1 `hooks` object
+envelope. A declaration with `disableAllHooks: true` adds no entries; otherwise,
+a non-array event value also warns and omits the declaration. AllAgents does not
+fully validate each hook entry. Skipping a declaration does not reject the
+plugin or itself suppress other eligible artifacts—including repository hook
+files—or valid declarations from other plugins. Ordinary client selection and
+exclusion settings still apply.
 
 At user scope, root `hooks/` entries sync to the client's user hook directory.
 Repository hooks under `.github/hooks/` stay project-scoped and are not copied

--- a/docs/src/content/docs/docs/guides/plugins.mdx
+++ b/docs/src/content/docs/docs/guides/plugins.mdx
@@ -12,6 +12,7 @@ my-plugin/
 ├── skills/          # Cross-client skills
 ├── agents/          # Agent definitions (Claude, Copilot, Factory)
 ├── hooks/           # Hook definitions (Claude, Copilot, Factory)
+├── hooks.json       # Copilot plugin hook declaration (optional)
 ├── commands/        # Commands (Claude, OpenCode)
 ├── .github/         # Project-scoped GitHub overrides (Copilot, VSCode)
 │   ├── copilot-instructions.md
@@ -23,6 +24,14 @@ my-plugin/
 ```
 
 :::note
+At project scope, Copilot plugin declarations from `hooks.json` or
+`hooks/hooks.json` are combined in the AllAgents-owned
+`.github/hooks/allagents.json` file. Each entry receives its plugin-specific
+`COPILOT_PLUGIN_ROOT`, so declarations continue to resolve files from the
+plugin package. The generated file is tracked independently from other
+repository hook files. Package metadata under `.github/plugin/` is not copied
+into the project overlay.
+
 At user scope, root `hooks/` entries sync to the client's user hook directory.
 Repository hooks under `.github/hooks/` stay project-scoped and are not copied
 to `~/.copilot/hooks/`. Potential copies from older versions are left untouched

--- a/docs/src/content/docs/docs/reference/clients.mdx
+++ b/docs/src/content/docs/docs/reference/clients.mdx
@@ -43,7 +43,7 @@ These clients use their own skills directory:
 | Kiro | `.kiro/skills/` | `AGENTS.md` | No | No |
 
 :::note
-Skills are the cross-client way to share reusable prompts. GitHub overrides (`.github/prompts/`, `.github/agents/`, `.github/hooks/`, `copilot-instructions.md`) are copied to the workspace's `.github/` folder for Copilot/VSCode; package-only `.github/plugin/` metadata is omitted. Root `agents/` and `hooks/` also map to `.github/agents/` and `.github/hooks/` for Copilot. At project scope, plugin `hooks.json` or `hooks/hooks.json` declarations are combined in `.github/hooks/allagents.json`. At user scope, root `hooks/` maps to `~/.copilot/hooks/`, while repository `.github/hooks/` remains project-scoped.
+Skills are the cross-client way to share reusable prompts. GitHub overrides (`.github/prompts/`, `.github/agents/`, `.github/hooks/`, `copilot-instructions.md`) are copied to the workspace's `.github/` folder for Copilot/VSCode; package-only `.github/plugin/` metadata is omitted. Root `agents/` and `hooks/` also map to `.github/agents/` and `.github/hooks/` for Copilot. At project scope, plugin hook declarations from `hooks.json` or `hooks/hooks.json` are combined in `.github/hooks/allagents.json`. This translation does not require marketplace registration or `plugin.json`; a missing or disabled declaration adds no managed entries. AllAgents warns and omits a declaration that cannot be read or parsed, lacks the version-1 `hooks` object envelope, or—unless disabled—has a non-array event value. Skipping a declaration does not itself suppress other eligible plugin artifacts or valid declarations from other plugins. At user scope, root `hooks/` maps to `~/.copilot/hooks/`, while repository `.github/hooks/` remains project-scoped.
 :::
 
 ### VSCode

--- a/docs/src/content/docs/docs/reference/clients.mdx
+++ b/docs/src/content/docs/docs/reference/clients.mdx
@@ -43,7 +43,7 @@ These clients use their own skills directory:
 | Kiro | `.kiro/skills/` | `AGENTS.md` | No | No |
 
 :::note
-Skills are the cross-client way to share reusable prompts. GitHub overrides (`.github/prompts/`, `.github/agents/`, `.github/hooks/`, `copilot-instructions.md`) are copied to the workspace's `.github/` folder for Copilot/VSCode. Root `agents/` and `hooks/` also map to `.github/agents/` and `.github/hooks/` for Copilot. At user scope, root `hooks/` maps to `~/.copilot/hooks/`, while repository `.github/hooks/` remains project-scoped.
+Skills are the cross-client way to share reusable prompts. GitHub overrides (`.github/prompts/`, `.github/agents/`, `.github/hooks/`, `copilot-instructions.md`) are copied to the workspace's `.github/` folder for Copilot/VSCode; package-only `.github/plugin/` metadata is omitted. Root `agents/` and `hooks/` also map to `.github/agents/` and `.github/hooks/` for Copilot. At project scope, plugin `hooks.json` or `hooks/hooks.json` declarations are combined in `.github/hooks/allagents.json`. At user scope, root `hooks/` maps to `~/.copilot/hooks/`, while repository `.github/hooks/` remains project-scoped.
 :::
 
 ### VSCode

--- a/src/core/copilot-hooks.ts
+++ b/src/core/copilot-hooks.ts
@@ -1,0 +1,208 @@
+import { existsSync } from 'node:fs';
+import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import type { ValidatedPlugin } from './sync.js';
+import { isExcluded, type CopyResult } from './transform.js';
+
+export const COPILOT_MANAGED_HOOKS_RELATIVE_PATH =
+  '.github/hooks/allagents.json';
+
+const PLUGIN_HOOK_PATHS = ['hooks.json', 'hooks/hooks.json'] as const;
+
+type JsonRecord = Record<string, unknown>;
+
+interface CopilotHooksFile {
+  version: 1;
+  hooks: Record<string, unknown[]>;
+}
+
+export interface CopilotHookSyncResult {
+  copyResults: CopyResult[];
+  warnings: string[];
+}
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function parseHooksFile(
+  content: string,
+  source: string,
+  warnings: string[],
+): CopilotHooksFile | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch (error) {
+    warnings.push(
+      `Copilot hooks: failed to parse ${source}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return null;
+  }
+
+  if (!isRecord(parsed) || parsed.version !== 1 || !isRecord(parsed.hooks)) {
+    warnings.push(
+      `Copilot hooks: ${source} must contain version 1 and a hooks object`,
+    );
+    return null;
+  }
+
+  if (parsed.disableAllHooks === true) {
+    return { version: 1, hooks: {} };
+  }
+
+  const hooks: Record<string, unknown[]> = {};
+  for (const [eventName, entries] of Object.entries(parsed.hooks)) {
+    if (!Array.isArray(entries)) {
+      warnings.push(
+        `Copilot hooks: event '${eventName}' in ${source} must be an array`,
+      );
+      continue;
+    }
+    hooks[eventName] = entries;
+  }
+
+  return { version: 1, hooks };
+}
+
+function withPluginRoot(
+  hooksFile: CopilotHooksFile,
+  pluginRoot: string,
+): CopilotHooksFile {
+  const hooks = Object.fromEntries(
+    Object.entries(hooksFile.hooks).map(([eventName, entries]) => [
+      eventName,
+      entries.map((entry) => {
+        if (!isRecord(entry)) return entry;
+        const existingEnv = isRecord(entry.env) ? entry.env : {};
+        return {
+          ...entry,
+          env: {
+            ...existingEnv,
+            COPILOT_PLUGIN_ROOT: pluginRoot,
+          },
+        };
+      }),
+    ]),
+  );
+  return { version: 1, hooks };
+}
+
+async function collectPluginHooks(
+  plugin: ValidatedPlugin,
+  warnings: string[],
+): Promise<CopilotHooksFile | null> {
+  const relativePath = PLUGIN_HOOK_PATHS.find((candidate) =>
+    existsSync(join(plugin.resolved, candidate)),
+  );
+  if (!relativePath) return null;
+
+  const hooksPath = join(plugin.resolved, relativePath);
+  if (isExcluded(plugin.resolved, hooksPath, plugin.exclude)) return null;
+
+  let hooksFile: CopilotHooksFile | null;
+  try {
+    hooksFile = parseHooksFile(
+      await readFile(hooksPath, 'utf-8'),
+      hooksPath,
+      warnings,
+    );
+  } catch (error) {
+    warnings.push(
+      `Copilot hooks: failed to read ${hooksPath}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return null;
+  }
+
+  if (!hooksFile) return null;
+
+  // The declaration executes payloads from the installed plugin root. If a
+  // user excluded any root hooks/ payload, activating the declaration would
+  // bypass that exclusion even though the file was not copied to the project.
+  // Skip the plugin's generated declaration rather than execute excluded code.
+  if (await hasExcludedHookPayload(plugin)) return null;
+
+  return withPluginRoot(hooksFile, plugin.resolved);
+}
+
+async function hasExcludedHookPayload(plugin: ValidatedPlugin): Promise<boolean> {
+  if (!plugin.exclude || plugin.exclude.length === 0) return false;
+
+  const hooksDir = join(plugin.resolved, 'hooks');
+  if (!existsSync(hooksDir)) return false;
+
+  async function visit(directory: string): Promise<boolean> {
+    const entries = await readdir(directory, { withFileTypes: true });
+    for (const entry of entries) {
+      const sourcePath = join(directory, entry.name);
+      if (isExcluded(plugin.resolved, sourcePath, plugin.exclude)) return true;
+      if (entry.isDirectory() && (await visit(sourcePath))) return true;
+    }
+    return false;
+  }
+
+  return visit(hooksDir);
+}
+
+function pluginTargetsCopilot(plugin: ValidatedPlugin): boolean {
+  return (
+    plugin.success &&
+    plugin.clients.includes('copilot') &&
+    plugin.fileArtifacts?.hooks !== false
+  );
+}
+
+function mergeHooks(files: CopilotHooksFile[]): CopilotHooksFile {
+  const hooks: Record<string, unknown[]> = {};
+  for (const file of files) {
+    for (const [eventName, entries] of Object.entries(file.hooks)) {
+      if (entries.length === 0) continue;
+      hooks[eventName] = [...(hooks[eventName] ?? []), ...entries];
+    }
+  }
+  return { version: 1, hooks };
+}
+
+export async function syncCopilotProjectHooks(
+  validatedPlugins: ValidatedPlugin[],
+  workspacePath: string,
+  options: { dryRun?: boolean; previouslyManaged?: boolean } = {},
+): Promise<CopilotHookSyncResult> {
+  const warnings: string[] = [];
+  const hookFiles = await Promise.all(
+    validatedPlugins
+      .filter(pluginTargetsCopilot)
+      .map((plugin) => collectPluginHooks(plugin, warnings)),
+  );
+  const merged = mergeHooks(
+    hookFiles.filter((file): file is CopilotHooksFile => file !== null),
+  );
+
+  if (Object.keys(merged.hooks).length === 0) {
+    return { copyResults: [], warnings };
+  }
+
+  const hooksPath = join(workspacePath, COPILOT_MANAGED_HOOKS_RELATIVE_PATH);
+  if (existsSync(hooksPath) && !options.previouslyManaged) {
+    warnings.push(
+      `Copilot hooks: not updating ${COPILOT_MANAGED_HOOKS_RELATIVE_PATH} because the existing file is not owned by AllAgents`,
+    );
+    return { copyResults: [], warnings };
+  }
+
+  if (!options.dryRun) {
+    await mkdir(dirname(hooksPath), { recursive: true });
+    await writeFile(hooksPath, `${JSON.stringify(merged, null, 2)}\n`, 'utf-8');
+  }
+
+  return {
+    copyResults: [
+      {
+        source: 'copilot-plugin-hooks',
+        destination: hooksPath,
+        action: 'generated',
+      },
+    ],
+    warnings,
+  };
+}

--- a/src/core/copilot-hooks.ts
+++ b/src/core/copilot-hooks.ts
@@ -57,7 +57,7 @@ function parseHooksFile(
       warnings.push(
         `Copilot hooks: event '${eventName}' in ${source} must be an array`,
       );
-      continue;
+      return null;
     }
     hooks[eventName] = entries;
   }

--- a/src/core/sync.ts
+++ b/src/core/sync.ts
@@ -102,6 +102,10 @@ import { applyMcpProxy } from './mcp-proxy.js';
 import { syncCodexMcpServers } from './codex-mcp.js';
 import { syncCodexProjectHooks } from './codex-hooks.js';
 import {
+  COPILOT_MANAGED_HOOKS_RELATIVE_PATH,
+  syncCopilotProjectHooks,
+} from './copilot-hooks.js';
+import {
   syncClaudeMcpConfig,
   syncClaudeMcpServersViaCli,
 } from './claude-mcp.js';
@@ -2248,10 +2252,27 @@ export async function syncWorkspace(
   );
   warnings.push(...codexHookSync.warnings);
 
+  // Step 4d: Materialize Copilot plugin hook declarations as a repository hook
+  // file. Copilot discovers project hooks only from .github/hooks/*.json;
+  // copying a plugin's hook scripts there does not activate its root hooks.json.
+  const copilotHookSync = await sw.measure('copilot-hooks-sync', () =>
+    syncCopilotProjectHooks(validPlugins, workspacePath, {
+      dryRun,
+      previouslyManaged: getPreviouslySyncedFiles(
+        previousState,
+        'copilot',
+      ).includes(COPILOT_MANAGED_HOOKS_RELATIVE_PATH),
+    }),
+  );
+  warnings.push(...copilotHookSync.warnings);
+
   // Step 5: Copy workspace files if configured
   // Supports both workspace.source (default base) and file-level sources
   // Skip when workspace.source was configured but validation failed (plugins still synced above)
-  const workspaceFileResults: CopyResult[] = [...codexHookSync.copyResults];
+  const workspaceFileResults: CopyResult[] = [
+    ...codexHookSync.copyResults,
+    ...copilotHookSync.copyResults,
+  ];
   let writtenSkillsIndexFiles: string[] = [];
   const skipWorkspaceFiles =
     !!config.workspace?.source && !validatedWorkspaceSource;

--- a/src/core/transform.ts
+++ b/src/core/transform.ts
@@ -105,7 +105,7 @@ export interface CopyOptions {
 /**
  * Check if a file path (relative to plugin root) matches any exclude pattern.
  */
-function isExcluded(
+export function isExcluded(
   pluginPath: string,
   filePath: string,
   exclude?: string[],
@@ -629,6 +629,16 @@ export async function copyHooks(
 
   const destDir = join(workspacePath, mapping.hooksPath);
 
+  // hooks/hooks.json is a plugin declaration, not a repository hook payload.
+  // Project Copilot sync materializes it separately with COPILOT_PLUGIN_ROOT
+  // bound to the plugin installation path; copying it verbatim would register
+  // the same hooks twice and leave the plugin-root variable unresolved.
+  const effectiveExclude =
+    mapping.hooksPath === '.github/hooks/' &&
+    existsSync(join(sourceDir, 'hooks.json'))
+      ? [...(options.exclude ?? []), 'hooks/hooks.json']
+      : options.exclude;
+
   if (dryRun) {
     results.push({ source: sourceDir, destination: destDir, action: 'copied' });
     return results;
@@ -637,12 +647,12 @@ export async function copyHooks(
   await mkdir(destDir, { recursive: true });
 
   try {
-    if (options.exclude && options.exclude.length > 0) {
+    if (effectiveExclude && effectiveExclude.length > 0) {
       await copyDirectoryWithExclusions(
         sourceDir,
         destDir,
         pluginPath,
-        options.exclude,
+        effectiveExclude,
       );
     } else {
       await cp(sourceDir, destDir, { recursive: true });
@@ -746,11 +756,21 @@ function githubContentExcludes(
   mapping: ClientMapping,
   exclude?: string[],
 ): string[] | undefined {
-  if (!relocatesGitHubContent(mapping)) return exclude;
+  const effectiveExclude = [...(exclude ?? [])];
+
+  // Copilot plugin package metadata is used to discover a native plugin, but
+  // it has no runtime role after file-mode content is overlaid into a project.
+  if (!relocatesGitHubContent(mapping)) {
+    effectiveExclude.push('.github/plugin');
+  }
 
   // .github/hooks is repository-owned. Root hooks/ remains the portable
   // plugin artifact that can be installed into a client's user hook path.
-  return [...(exclude ?? []), '.github/hooks'];
+  if (relocatesGitHubContent(mapping)) {
+    effectiveExclude.push('.github/hooks');
+  }
+
+  return effectiveExclude.length > 0 ? effectiveExclude : undefined;
 }
 
 export interface RelocatedGitHubHooksSource {

--- a/tests/unit/core/copilot-hooks.test.ts
+++ b/tests/unit/core/copilot-hooks.test.ts
@@ -145,6 +145,42 @@ syncMode: copy
     expect(existsSync(join(testDir, '.github', 'hooks', 'user.json'))).toBe(true);
   });
 
+  it('rejects an entire plugin declaration when any event is not an array', async () => {
+    const invalidPlugin = await writePlugin('invalid-plugin', 'SessionStart');
+    const validPlugin = await writePlugin('valid-plugin', 'PostToolUse');
+    await writeFile(
+      join(invalidPlugin, 'hooks.json'),
+      JSON.stringify({
+        version: 1,
+        hooks: {
+          SessionStart: [
+            {
+              type: 'command',
+              bash: 'bash "${COPILOT_PLUGIN_ROOT}/hooks/invalid-plugin.sh"',
+            },
+          ],
+          UserPromptSubmit: { type: 'command', bash: 'echo invalid' },
+        },
+      }),
+    );
+    await writeWorkspace(['invalid-plugin', 'valid-plugin']);
+
+    const result = await syncWorkspace(testDir);
+
+    expect(result.success).toBe(true);
+    expect(result.warnings).toContain(
+      `Copilot hooks: event 'UserPromptSubmit' in ${join(invalidPlugin, 'hooks.json')} must be an array`,
+    );
+    const hooks = JSON.parse(
+      await readFile(join(testDir, '.github', 'hooks', 'allagents.json'), 'utf-8'),
+    ) as {
+      hooks: Record<string, Array<{ env: Record<string, string> }>>;
+    };
+    expect(hooks.hooks.SessionStart).toBeUndefined();
+    expect(hooks.hooks.PostToolUse).toHaveLength(1);
+    expect(hooks.hooks.PostToolUse?.[0]?.env.COPILOT_PLUGIN_ROOT).toBe(validPlugin);
+  });
+
   it('does not overwrite an existing unowned allagents hook file', async () => {
     await writePlugin('plugin-a', 'SessionStart');
     await writeWorkspace(['plugin-a']);

--- a/tests/unit/core/copilot-hooks.test.ts
+++ b/tests/unit/core/copilot-hooks.test.ts
@@ -102,6 +102,30 @@ syncMode: copy
     expect(hooks.hooks.SessionStart?.[0]?.env?.COPILOT_PLUGIN_ROOT).toBe(pluginDir);
   });
 
+  it('syncs a direct manifest-less plugin that has no hook declaration', async () => {
+    await mkdir(join(testDir, 'direct-plugin', 'skills', 'direct-skill'), {
+      recursive: true,
+    });
+    await writeFile(
+      join(testDir, 'direct-plugin', 'skills', 'direct-skill', 'SKILL.md'),
+      '---\nname: direct-skill\ndescription: Direct plugin skill\n---\n# Direct skill\n',
+    );
+    await writeWorkspace(['direct-plugin']);
+
+    const result = await syncWorkspace(testDir);
+
+    expect(result.success).toBe(true);
+    expect(
+      existsSync(join(testDir, '.github', 'skills', 'direct-skill', 'SKILL.md')),
+    ).toBe(true);
+    expect(existsSync(join(testDir, '.github', 'hooks', 'allagents.json'))).toBe(
+      false,
+    );
+    expect(
+      (result.warnings ?? []).some((warning) => warning.startsWith('Copilot hooks:')),
+    ).toBe(false);
+  });
+
   it('merges multiple plugins and reconciles only the AllAgents-owned hook file', async () => {
     const pluginA = await writePlugin('plugin-a', 'SessionStart');
     const pluginB = await writePlugin('plugin-b', 'PostToolUse');
@@ -145,9 +169,16 @@ syncMode: copy
     expect(existsSync(join(testDir, '.github', 'hooks', 'user.json'))).toBe(true);
   });
 
-  it('rejects an entire plugin declaration when any event is not an array', async () => {
+  it('skips an entire hook declaration when any event is not an array', async () => {
     const invalidPlugin = await writePlugin('invalid-plugin', 'SessionStart');
     const validPlugin = await writePlugin('valid-plugin', 'PostToolUse');
+    await mkdir(join(invalidPlugin, 'skills', 'invalid-plugin-skill'), {
+      recursive: true,
+    });
+    await writeFile(
+      join(invalidPlugin, 'skills', 'invalid-plugin-skill', 'SKILL.md'),
+      '---\nname: invalid-plugin-skill\ndescription: Still syncs\n---\n# Skill\n',
+    );
     await writeFile(
       join(invalidPlugin, 'hooks.json'),
       JSON.stringify({
@@ -179,6 +210,11 @@ syncMode: copy
     expect(hooks.hooks.SessionStart).toBeUndefined();
     expect(hooks.hooks.PostToolUse).toHaveLength(1);
     expect(hooks.hooks.PostToolUse?.[0]?.env.COPILOT_PLUGIN_ROOT).toBe(validPlugin);
+    expect(
+      existsSync(
+        join(testDir, '.github', 'skills', 'invalid-plugin-skill', 'SKILL.md'),
+      ),
+    ).toBe(true);
   });
 
   it('does not overwrite an existing unowned allagents hook file', async () => {

--- a/tests/unit/core/copilot-hooks.test.ts
+++ b/tests/unit/core/copilot-hooks.test.ts
@@ -1,0 +1,233 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { CONFIG_DIR, WORKSPACE_CONFIG_FILE } from '../../../src/constants.js';
+import { syncWorkspace } from '../../../src/core/sync.js';
+
+describe('syncWorkspace Copilot hooks', () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'allagents-sync-copilot-hooks-'));
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  async function writeWorkspace(plugins: string[]): Promise<void> {
+    await mkdir(join(testDir, CONFIG_DIR), { recursive: true });
+    await writeFile(
+      join(testDir, CONFIG_DIR, WORKSPACE_CONFIG_FILE),
+      `
+repositories: []
+${plugins.length > 0 ? `plugins:\n${plugins.map((plugin) => `  - ./${plugin}`).join('\n')}` : 'plugins: []'}
+clients:
+  - copilot
+syncMode: copy
+`,
+    );
+  }
+
+  async function writePlugin(
+    name: string,
+    event: string,
+    options: { nestedDeclaration?: boolean } = {},
+  ): Promise<string> {
+    const pluginDir = join(testDir, name);
+    await mkdir(join(pluginDir, 'hooks'), { recursive: true });
+    await writeFile(join(pluginDir, 'hooks', `${name}.sh`), '#!/bin/sh\n');
+    const declarationPath = options.nestedDeclaration
+      ? join(pluginDir, 'hooks', 'hooks.json')
+      : join(pluginDir, 'hooks.json');
+    await writeFile(
+      declarationPath,
+      JSON.stringify({
+        version: 1,
+        hooks: {
+          [event]: [
+            {
+              type: 'command',
+              bash: `bash "\${COPILOT_PLUGIN_ROOT}/hooks/${name}.sh"`,
+            },
+          ],
+        },
+      }),
+    );
+    return pluginDir;
+  }
+
+  it('materializes root plugin hook declarations as executable repository hooks', async () => {
+    const pluginDir = join(testDir, 'org');
+    await mkdir(join(pluginDir, 'hooks'), { recursive: true });
+    await writeFile(join(pluginDir, 'hooks', 'session-start.sh'), '#!/bin/sh\n');
+    await writeFile(
+      join(pluginDir, 'hooks.json'),
+      JSON.stringify({
+        version: 1,
+        hooks: {
+          SessionStart: [
+            {
+              type: 'command',
+              bash: 'bash "${COPILOT_PLUGIN_ROOT}/hooks/session-start.sh"',
+            },
+          ],
+        },
+      }),
+    );
+    await mkdir(join(testDir, CONFIG_DIR), { recursive: true });
+    await writeFile(
+      join(testDir, CONFIG_DIR, WORKSPACE_CONFIG_FILE),
+      `
+repositories: []
+plugins:
+  - ./org
+clients:
+  - copilot
+syncMode: copy
+`,
+    );
+
+    const result = await syncWorkspace(testDir);
+
+    expect(result.success).toBe(true);
+    const hooks = JSON.parse(
+      await readFile(join(testDir, '.github', 'hooks', 'allagents.json'), 'utf-8'),
+    ) as {
+      hooks: Record<string, Array<{ env?: Record<string, string> }>>;
+    };
+    expect(hooks.hooks.SessionStart).toHaveLength(1);
+    expect(hooks.hooks.SessionStart?.[0]?.env?.COPILOT_PLUGIN_ROOT).toBe(pluginDir);
+  });
+
+  it('merges multiple plugins and reconciles only the AllAgents-owned hook file', async () => {
+    const pluginA = await writePlugin('plugin-a', 'SessionStart');
+    const pluginB = await writePlugin('plugin-b', 'PostToolUse');
+    await writeWorkspace(['plugin-a', 'plugin-b']);
+    await mkdir(join(testDir, '.github', 'hooks'), { recursive: true });
+    await writeFile(
+      join(testDir, '.github', 'hooks', 'user.json'),
+      '{"version":1,"hooks":{}}',
+    );
+
+    const first = await syncWorkspace(testDir);
+
+    expect(first.success).toBe(true);
+    let hooks = JSON.parse(
+      await readFile(join(testDir, '.github', 'hooks', 'allagents.json'), 'utf-8'),
+    ) as {
+      hooks: Record<string, Array<{ env: Record<string, string> }>>;
+    };
+    expect(hooks.hooks.SessionStart?.[0]?.env.COPILOT_PLUGIN_ROOT).toBe(pluginA);
+    expect(hooks.hooks.PostToolUse?.[0]?.env.COPILOT_PLUGIN_ROOT).toBe(pluginB);
+    expect(existsSync(join(testDir, '.github', 'hooks', 'user.json'))).toBe(true);
+
+    await writeWorkspace(['plugin-b']);
+    const second = await syncWorkspace(testDir);
+
+    expect(second.success).toBe(true);
+    hooks = JSON.parse(
+      await readFile(join(testDir, '.github', 'hooks', 'allagents.json'), 'utf-8'),
+    ) as typeof hooks;
+    expect(hooks.hooks.SessionStart).toBeUndefined();
+    expect(hooks.hooks.PostToolUse).toHaveLength(1);
+    expect(existsSync(join(testDir, '.github', 'hooks', 'user.json'))).toBe(true);
+
+    await writeWorkspace([]);
+    const third = await syncWorkspace(testDir);
+
+    expect(third.success).toBe(true);
+    expect(existsSync(join(testDir, '.github', 'hooks', 'allagents.json'))).toBe(
+      false,
+    );
+    expect(existsSync(join(testDir, '.github', 'hooks', 'user.json'))).toBe(true);
+  });
+
+  it('does not overwrite an existing unowned allagents hook file', async () => {
+    await writePlugin('plugin-a', 'SessionStart');
+    await writeWorkspace(['plugin-a']);
+    await mkdir(join(testDir, '.github', 'hooks'), { recursive: true });
+    const original = '{"version":1,"hooks":{"SessionStart":[]}}';
+    await writeFile(join(testDir, '.github', 'hooks', 'allagents.json'), original);
+
+    const result = await syncWorkspace(testDir);
+
+    expect(result.success).toBe(true);
+    expect(result.warnings).toContain(
+      'Copilot hooks: not updating .github/hooks/allagents.json because the existing file is not owned by AllAgents',
+    );
+    expect(
+      await readFile(join(testDir, '.github', 'hooks', 'allagents.json'), 'utf-8'),
+    ).toBe(original);
+  });
+
+  it('materializes hooks/hooks.json once instead of copying an unresolved duplicate', async () => {
+    await writePlugin('plugin-a', 'SessionStart', { nestedDeclaration: true });
+    await writeWorkspace(['plugin-a']);
+
+    const result = await syncWorkspace(testDir);
+
+    expect(result.success).toBe(true);
+    expect(existsSync(join(testDir, '.github', 'hooks', 'allagents.json'))).toBe(
+      true,
+    );
+    expect(existsSync(join(testDir, '.github', 'hooks', 'hooks.json'))).toBe(
+      false,
+    );
+  });
+
+  it('does not activate a root declaration when its hook payload is excluded', async () => {
+    await writePlugin('plugin-a', 'SessionStart');
+    await mkdir(join(testDir, CONFIG_DIR), { recursive: true });
+    await writeFile(
+      join(testDir, CONFIG_DIR, WORKSPACE_CONFIG_FILE),
+      `
+repositories: []
+plugins:
+  - source: ./plugin-a
+    exclude:
+      - hooks/plugin-a.sh
+clients:
+  - copilot
+syncMode: copy
+`,
+    );
+
+    const result = await syncWorkspace(testDir);
+
+    expect(result.success).toBe(true);
+    expect(existsSync(join(testDir, '.github', 'hooks', 'allagents.json'))).toBe(
+      false,
+    );
+    expect(existsSync(join(testDir, '.github', 'hooks', 'plugin-a.sh'))).toBe(
+      false,
+    );
+  });
+
+  it('does not activate an excluded nested declaration', async () => {
+    await writePlugin('plugin-a', 'SessionStart', { nestedDeclaration: true });
+    await mkdir(join(testDir, CONFIG_DIR), { recursive: true });
+    await writeFile(
+      join(testDir, CONFIG_DIR, WORKSPACE_CONFIG_FILE),
+      `
+repositories: []
+plugins:
+  - source: ./plugin-a
+    exclude:
+      - hooks/hooks.json
+clients:
+  - copilot
+syncMode: copy
+`,
+    );
+
+    const result = await syncWorkspace(testDir);
+
+    expect(result.success).toBe(true);
+    expect(existsSync(join(testDir, '.github', 'hooks', 'allagents.json'))).toBe(
+      false,
+    );
+  });
+});

--- a/tests/unit/core/github-content.test.ts
+++ b/tests/unit/core/github-content.test.ts
@@ -67,6 +67,26 @@ describe('copyGitHubContent', () => {
     expect(content).toBe('{"hooks":[]}');
   });
 
+  it('does not copy Copilot package metadata into the project overlay', async () => {
+    await mkdir(join(pluginDir, '.github', 'plugin'), { recursive: true });
+    await mkdir(join(pluginDir, '.github', 'prompts'), { recursive: true });
+    await writeFile(
+      join(pluginDir, '.github', 'plugin', 'plugin.json'),
+      '{"name":"package-only"}',
+    );
+    await writeFile(join(pluginDir, '.github', 'prompts', 'keep.md'), '# Keep');
+
+    const results = await copyGitHubContent(pluginDir, workspaceDir, 'copilot');
+
+    expect(results).toHaveLength(1);
+    expect(
+      existsSync(join(workspaceDir, '.github', 'plugin', 'plugin.json')),
+    ).toBe(false);
+    expect(existsSync(join(workspaceDir, '.github', 'prompts', 'keep.md'))).toBe(
+      true,
+    );
+  });
+
   it('skips clients without githubPath', async () => {
     await mkdir(join(pluginDir, '.github', 'prompts'), { recursive: true });
     await writeFile(join(pluginDir, '.github', 'prompts', 'test.md'), '# Test');


### PR DESCRIPTION
## Summary

Project-scoped Copilot plugin installs now activate declared hooks instead of only copying their scripts. AllAgents materializes plugin `hooks.json` / `hooks/hooks.json` declarations into one owned `.github/hooks/allagents.json`, binds each entry to its plugin-specific `COPILOT_PLUGIN_ROOT`, and reconciles multiple plugins without touching sibling user hook files.

File-mode project overlays also omit package-only `.github/plugin/` metadata. Plugin exclusions remain authoritative: an excluded declaration or hook payload is not activated through the generated file.

Hook translation is independent of marketplace registration and package metadata. Direct local and GitHub plugin sources do not require a marketplace manifest or `plugin.json`. A missing declaration—or a declaration with `disableAllHooks: true`—adds no managed entries while the plugin's other eligible artifacts continue syncing.

AllAgents warns and omits a hook declaration that cannot be read or parsed as JSON or lacks the version-1 `hooks` object envelope. Unless the declaration is disabled, a non-array event value also warns and omits that declaration as a unit. This does not reject the plugin or suppress valid declarations from other plugins. The exact ownership, validation, exclusion, and compatibility boundaries are recorded in `docs/decisions/0001-project-plugin-hooks.md`.

This closes the gap between Copilot's two discovery modes: installed native plugins load declarations from the plugin directory, while repositories load `.github/hooks/*.json`. See the [GitHub Copilot hooks reference](https://docs.github.com/en/copilot/reference/hooks-reference).

## WTG.AI.Prompts validation

Validated against WiseTechGlobal/WTG.AI.Prompts commit `6f36ea718dcb` using the built CLI:

```bash
WORKTREE=/home/entity/projects/EntityProcess/allagents.worktrees/fix-copilot-project-hooks
CLI="$WORKTREE/dist/index.js"
WTG=/tmp/allagents-wtg-hook-fix.4b9Xwu/WTG.AI.Prompts
PROJECT=/tmp/allagents-wtg-e2e.JWJpDm

cd "$WORKTREE"
bun run build

cd "$PROJECT"
git init
"$CLI" init . --client copilot
"$CLI" plugin marketplace add "$WTG" --scope project
"$CLI" plugin install org@wtg-ai-prompts --scope project
"$CLI" plugin install skill-usage-metrics@wtg-ai-prompts --scope project
```

The generated file contained six entries across five event types: two `SessionStart` entries plus `UserPromptSubmit`, `PostToolUse`, `PostToolUseFailure`, and `SessionEnd`. Both plugin roots were present, `.github/plugin/plugin.json` was absent, and sync state owned `.github/hooks/allagents.json`.

Reconciliation was exercised with:

```bash
cd "$PROJECT"
"$CLI" plugin uninstall org@wtg-ai-prompts --scope project
"$CLI" plugin install org@wtg-ai-prompts --scope project
"$CLI" update --offline
```

Uninstall removed only `org` entries and preserved skill-usage metrics. Reinstall restored both roots and all six entries. Offline workspace update regenerated the same hook file.

Live execution used Copilot CLI 1.0.70 with an isolated home and instrumented `bash` / `pwsh` wrappers:

```bash
cd "$PROJECT"
HOME="$PROJECT/isolated-home" \
COPILOT_HOME="$PROJECT/copilot-home" \
PATH="$PROJECT/harness-bin:$PATH" \
WTG_HOOK_MARKER="$PROJECT/hook-invocations.log" \
NO_COLOR=1 \
copilot --log-level debug --log-dir "$PROJECT/logs4"
```

Copilot displayed `Loading: 8 hooks` and attributed `UserPromptSubmit` to `.github/hooks/allagents.json`. WTG's `org/hooks/emit-advisory.sh` and `org/hooks/resolve-context.sh` executed. The expected `org` and `skill-usage-metrics` PowerShell command paths were resolved and invoked; the host has no `pwsh`, so a shim recorded those invocations rather than executing the PowerShell bodies.

## Compatibility regression coverage

The regression tests now explicitly verify both boundaries discussed in review:

- A direct, manifest-less plugin with no hook declaration still installs its skill, emits no Copilot-hook warning, and creates no managed aggregate.
- A plugin whose enabled declaration has a non-array event contributes no managed hook entries, but its skill still syncs and a valid second plugin still contributes hooks.

## Automated validation

```bash
bun test tests/unit/core/copilot-hooks.test.ts tests/unit/core/github-content.test.ts tests/unit/core/transform-glob.test.ts
bun test
bun run test:e2e
bun run typecheck
bun run lint
bun run build
bun run docs:build
```

- Focused final pass: 43 passed, 0 failed.
- Full final suite: 1,356 passed, 5 skipped, 0 failed.
- Dedicated E2E suite: 117 passed, 4 skipped.
- Documentation build: 13 pages built successfully.
- Independent review corrected the ownership, disabled-declaration, and `COPILOT_PLUGIN_ROOT` wording; the final documentation now matches runtime behavior.

## Related follow-up

Project-scoped `plugin update` lookup is intentionally outside this hook PR and is fixed separately by the still-open, green [#446](https://github.com/EntityProcess/allagents/pull/446). User/global marketplace update behavior was already unaffected. Until #446 merges, dedicated project-scoped plugin update can still report `Marketplace not found`; install, uninstall, reinstall, and `update --offline` validation for this PR passed.

Related: [WiseTechGlobal/mcp-ediprod#467](https://github.com/WiseTechGlobal/mcp-ediprod/pull/467), EntityProcess/allagents#442, EntityProcess/allagents#443

## Post-Deploy Monitoring & Validation

During the first release window, exercise a project-scoped WTG install and search CLI output for `Copilot hooks:` warnings. Healthy signals are an owned `.github/hooks/allagents.json`, the expected plugin roots/events, and Copilot reporting the loaded hooks. Missing generated state, an ownership warning on a fresh workspace, or absent WTG hook invocations is the rollback trigger; revert this PR while preserving user-owned hook files. Validation window: first release candidate and first downstream WTG install. Owner: AllAgents maintainer.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
