### PR TITLE
fix(plugin): update project-scoped marketplaces

### DIFF
--- a/src/cli/commands/plugin.ts
+++ b/src/cli/commands/plugin.ts
@@ -1307,22 +1307,26 @@ const pluginUpdateCmd = command({
       const updateProject = scope === 'project' || (!scope && !updateAll) || updateAll;
 
       // Collect installed plugins based on scope
-      const pluginsToUpdate: string[] = [];
+      const pluginsToUpdate: Array<{ spec: string; scope: 'project' | 'user' }> = [];
+      const addPluginToUpdate = (spec: string, pluginScope: 'project' | 'user') => {
+        if (!pluginsToUpdate.some((entry) =>
+          entry.spec === spec && entry.scope === pluginScope
+        )) {
+          pluginsToUpdate.push({ spec, scope: pluginScope });
+        }
+      };
 
       if (updateProject && !isUserConfigPath(process.cwd())) {
         const projectPlugins = await getInstalledProjectPlugins(process.cwd());
         for (const p of projectPlugins) {
-          pluginsToUpdate.push(p.spec);
+          addPluginToUpdate(p.spec, 'project');
         }
       }
 
       if (updateUser) {
         const userPlugins = await getInstalledUserPlugins();
         for (const p of userPlugins) {
-          // Avoid duplicates if same plugin is in both scopes
-          if (!pluginsToUpdate.includes(p.spec)) {
-            pluginsToUpdate.push(p.spec);
-          }
+          addPluginToUpdate(p.spec, 'user');
         }
       }
 
@@ -1339,9 +1343,7 @@ const pluginUpdateCmd = command({
           const config = load(content) as { plugins?: PluginEntry[] };
           for (const entry of config.plugins ?? []) {
             const p = getPluginSource(entry);
-            if (!pluginsToUpdate.includes(p)) {
-              pluginsToUpdate.push(p);
-            }
+            addPluginToUpdate(p, 'project');
           }
         }
       }
@@ -1351,20 +1353,18 @@ const pluginUpdateCmd = command({
         if (userConfig) {
           for (const entry of userConfig.plugins ?? []) {
             const p = getPluginSource(entry);
-            if (!pluginsToUpdate.includes(p)) {
-              pluginsToUpdate.push(p);
-            }
+            addPluginToUpdate(p, 'user');
           }
         }
       }
 
       // Filter to specific plugin if provided
       const toUpdate = plugin
-        ? pluginsToUpdate.filter((p) => {
+        ? pluginsToUpdate.filter(({ spec }) => {
             // Match by full spec or just plugin name
-            if (p === plugin) return true;
-            const parsed = parsePluginSpec(p);
-            return parsed?.plugin === plugin || p.endsWith(`/${plugin}`);
+            if (spec === plugin) return true;
+            const parsed = parsePluginSpec(spec);
+            return parsed?.plugin === plugin || spec.endsWith(`/${plugin}`);
           })
         : pluginsToUpdate;
 
@@ -1398,28 +1398,39 @@ const pluginUpdateCmd = command({
 
       // Update each plugin
       const results: InstalledPluginUpdateResult[] = [];
-      const updatedMarketplaces = new Set<string>();
+      const updatedMarketplaces = {
+        project: new Set<string>(),
+        user: new Set<string>(),
+      };
+      const createUpdateDeps = (pluginScope: 'project' | 'user') => {
+        const workspacePath = pluginScope === 'project' ? process.cwd() : undefined;
+        const updatedForScope = updatedMarketplaces[pluginScope];
 
-      // Dependencies for updatePlugin (avoid circular imports)
-      const deps = {
-        parsePluginSpec,
-        getMarketplace: (name: string, sourceLocation?: string) => findMarketplace(name, sourceLocation),
-        parseMarketplaceManifest,
-        updateMarketplace: async (name: string) => {
-          // Skip if already updated in this run
-          if (updatedMarketplaces.has(name)) {
-            return [{ name, success: true }];
-          }
-          const result = await updateMarketplace(name);
-          if (result[0]?.success) {
-            updatedMarketplaces.add(name);
-          }
-          return result;
-        },
+        return {
+          parsePluginSpec,
+          getMarketplace: (name: string, sourceLocation?: string) =>
+            findMarketplace(name, sourceLocation, workspacePath),
+          parseMarketplaceManifest,
+          updateMarketplace: async (name: string) => {
+            // Skip if already updated in this scope during this run
+            if (updatedForScope.has(name)) {
+              return [{ name, success: true }];
+            }
+            const result = await updateMarketplace(name, workspacePath);
+            if (result[0]?.success) {
+              updatedForScope.add(name);
+            }
+            return result;
+          },
+        };
+      };
+      const depsByScope = {
+        project: createUpdateDeps('project'),
+        user: createUpdateDeps('user'),
       };
 
-      for (const pluginSpec of toUpdate) {
-        const result = await updatePlugin(pluginSpec, deps);
+      for (const { spec: pluginSpec, scope: pluginScope } of toUpdate) {
+        const result = await updatePlugin(pluginSpec, depsByScope[pluginScope]);
         results.push(result);
 
         if (!isJsonMode()) {

--- a/src/cli/tui/actions/plugins.ts
+++ b/src/cli/tui/actions/plugins.ts
@@ -38,17 +38,18 @@ const { select, text, confirm, multiselect, autocomplete } = p;
  * Create dependencies for updatePlugin.
  * Tracks which marketplaces have been updated to avoid redundant fetches.
  */
-function createUpdateDeps() {
+function createUpdateDeps(workspacePath?: string) {
   const updatedMarketplaces = new Set<string>();
   return {
     parsePluginSpec,
-    getMarketplace: (name: string, sourceLocation?: string) => findMarketplace(name, sourceLocation),
+    getMarketplace: (name: string, sourceLocation?: string) =>
+      findMarketplace(name, sourceLocation, workspacePath),
     parseMarketplaceManifest,
     updateMarketplace: async (name: string) => {
       if (updatedMarketplaces.has(name)) {
         return [{ name, success: true }];
       }
-      const result = await updateMarketplace(name);
+      const result = await updateMarketplace(name, workspacePath);
       if (result[0]?.success) {
         updatedMarketplaces.add(name);
       }
@@ -156,7 +157,8 @@ async function runUpdatePlugin(
   const s = p.spinner();
   s.start('Updating plugin...');
 
-  const result = await updatePlugin(pluginSource, createUpdateDeps());
+  const workspacePath = scope === 'project' ? context.workspacePath ?? undefined : undefined;
+  const result = await updatePlugin(pluginSource, createUpdateDeps(workspacePath));
 
   if (!result.success) {
     s.stop('Update failed');
@@ -205,8 +207,9 @@ export async function runUpdateAllPlugins(
 
   const userPlugins = await getInstalledUserPlugins();
   for (const plugin of userPlugins) {
-    // Avoid duplicates
-    if (!pluginsToUpdate.some((existing) => existing.spec === plugin.spec)) {
+    if (!pluginsToUpdate.some((existing) =>
+      existing.spec === plugin.spec && existing.scope === 'user'
+    )) {
       pluginsToUpdate.push({ spec: plugin.spec, scope: 'user' });
     }
   }
@@ -218,14 +221,15 @@ export async function runUpdateAllPlugins(
 
   s.message(`Updating ${pluginsToUpdate.length} plugin(s)...`);
 
-  const deps = createUpdateDeps();
+  const projectDeps = createUpdateDeps(context.workspacePath ?? undefined);
+  const userDeps = createUpdateDeps();
 
   const results: Array<{ plugin: string; action: string; error?: string }> = [];
   let needsProjectSync = false;
   let needsUserSync = false;
 
   for (const { spec, scope } of pluginsToUpdate) {
-    const result = await updatePlugin(spec, deps);
+    const result = await updatePlugin(spec, scope === 'project' ? projectDeps : userDeps);
     const entry: { plugin: string; action: string; error?: string } = {
       plugin: spec,
       action: result.action,

--- a/tests/e2e/plugin-update.test.ts
+++ b/tests/e2e/plugin-update.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+interface CliResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+function runCli(workdir: string, homeDir: string, args: string[]): CliResult {
+  const cliEntry = join(import.meta.dir, '..', '..', 'src', 'cli', 'index.ts');
+  const proc = Bun.spawnSync(['bun', 'run', cliEntry, '--json', ...args], {
+    cwd: workdir,
+    env: {
+      ...process.env,
+      ALLAGENTS_TEST_HOME: homeDir,
+      HOME: homeDir,
+    },
+    stderr: 'pipe',
+    stdout: 'pipe',
+  });
+
+  return {
+    exitCode: proc.exitCode,
+    stdout: new TextDecoder().decode(proc.stdout),
+    stderr: new TextDecoder().decode(proc.stderr),
+  };
+}
+
+describe('plugin update e2e', () => {
+  let rootDir: string;
+  let workspaceDir: string;
+  let marketplaceDir: string;
+  let homeDir: string;
+
+  beforeEach(() => {
+    rootDir = join(
+      tmpdir(),
+      `allagents-e2e-plugin-update-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    workspaceDir = join(rootDir, 'workspace');
+    marketplaceDir = join(rootDir, 'marketplace');
+    homeDir = join(rootDir, 'home');
+
+    mkdirSync(join(workspaceDir, '.allagents'), { recursive: true });
+    mkdirSync(join(marketplaceDir, '.claude-plugin'), { recursive: true });
+    mkdirSync(join(marketplaceDir, 'plugins', 'demo', 'skills', 'demo'), { recursive: true });
+    mkdirSync(homeDir, { recursive: true });
+
+    writeFileSync(
+      join(workspaceDir, '.allagents', 'workspace.yaml'),
+      'repositories: []\nplugins: []\nclients:\n  - claude\nversion: 2\n',
+      'utf-8',
+    );
+    writeFileSync(
+      join(marketplaceDir, '.claude-plugin', 'marketplace.json'),
+      JSON.stringify({
+        name: 'project-marketplace',
+        description: 'Project marketplace update fixture',
+        plugins: [
+          {
+            name: 'demo',
+            description: 'Demo plugin',
+            source: './plugins/demo',
+          },
+        ],
+      }),
+      'utf-8',
+    );
+    writeFileSync(
+      join(marketplaceDir, 'plugins', 'demo', 'skills', 'demo', 'SKILL.md'),
+      '---\nname: demo\ndescription: Demo skill\n---\n# Demo\n',
+      'utf-8',
+    );
+  });
+
+  afterEach(() => {
+    rmSync(rootDir, { recursive: true, force: true });
+  });
+
+  test('updates a plugin from a project-scoped marketplace', () => {
+    const addResult = runCli(workspaceDir, homeDir, [
+      'plugin',
+      'marketplace',
+      'add',
+      marketplaceDir,
+      '--scope',
+      'project',
+    ]);
+    expect(addResult.exitCode).toBe(0);
+
+    const installResult = runCli(workspaceDir, homeDir, [
+      'plugin',
+      'install',
+      'demo@project-marketplace',
+      '--scope',
+      'project',
+    ]);
+    expect(installResult.exitCode).toBe(0);
+
+    const updateResult = runCli(workspaceDir, homeDir, [
+      'plugin',
+      'update',
+      'demo@project-marketplace',
+      '--scope',
+      'project',
+    ]);
+
+    expect(updateResult.exitCode).toBe(0);
+    const payload = JSON.parse(updateResult.stdout);
+    expect(payload.success).toBe(true);
+    expect(payload.data.results).toEqual([
+      {
+        plugin: 'demo@project-marketplace',
+        success: true,
+        action: 'updated',
+      },
+    ]);
+  });
+
+  test('keeps user-scoped marketplace updates isolated from the workspace', () => {
+    const addResult = runCli(workspaceDir, homeDir, [
+      'plugin',
+      'marketplace',
+      'add',
+      marketplaceDir,
+      '--scope',
+      'user',
+    ]);
+    expect(addResult.exitCode).toBe(0);
+
+    const installResult = runCli(workspaceDir, homeDir, [
+      'plugin',
+      'install',
+      'demo@project-marketplace',
+      '--scope',
+      'user',
+    ]);
+    expect(installResult.exitCode).toBe(0);
+
+    const updateResult = runCli(workspaceDir, homeDir, [
+      'plugin',
+      'update',
+      'demo@project-marketplace',
+      '--scope',
+      'user',
+    ]);
+
+    expect(updateResult.exitCode).toBe(0);
+    const payload = JSON.parse(updateResult.stdout);
+    expect(payload.success).toBe(true);
+    expect(payload.data.results[0]).toEqual({
+      plugin: 'demo@project-marketplace',
+      success: true,
+      action: 'updated',
+    });
+  });
+
+  test('updates the same plugin independently when installed in both scopes', () => {
+    for (const scope of ['user', 'project']) {
+      const addResult = runCli(workspaceDir, homeDir, [
+        'plugin',
+        'marketplace',
+        'add',
+        marketplaceDir,
+        '--scope',
+        scope,
+      ]);
+      expect(addResult.exitCode).toBe(0);
+
+      const installResult = runCli(workspaceDir, homeDir, [
+        'plugin',
+        'install',
+        'demo@project-marketplace',
+        '--scope',
+        scope,
+      ]);
+      expect(installResult.exitCode).toBe(0);
+    }
+
+    const updateResult = runCli(workspaceDir, homeDir, [
+      'plugin',
+      'update',
+      'demo@project-marketplace',
+      '--scope',
+      'all',
+    ]);
+
+    expect(updateResult.exitCode).toBe(0);
+    const payload = JSON.parse(updateResult.stdout);
+    expect(payload.success).toBe(true);
+    expect(payload.data.results).toHaveLength(2);
+    expect(payload.data.results).toEqual([
+      {
+        plugin: 'demo@project-marketplace',
+        success: true,
+        action: 'updated',
+      },
+      {
+        plugin: 'demo@project-marketplace',
+        success: true,
+        action: 'updated',
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Project-scoped marketplace plugins can now be updated through both the headless CLI and interactive TUI. Previously, project marketplace add, list, install, and sync all worked, but `plugin update --scope project` searched only the user registry and failed with `Marketplace not found`.

Update targets now retain their installation scope through marketplace lookup, refresh, and deduplication. User updates remain user-registry-only, project updates use the workspace registry with project-over-user precedence, and `--scope all` updates the same plugin independently when it is installed in both scopes.

Related: #224

## Validation

The regression suite exercises project-only, user-only, and identical user + project installations using local network-free marketplaces:

```bash
bun test tests/e2e/plugin-update.test.ts
bun test
bun run typecheck
bun run lint
bun run build
```

- Focused: 3 passed, 0 failed.
- Full suite: 1,350 passed, 5 skipped, 0 failed.
- Independent review found a cross-scope deduplication gap; the added `--scope all` regression was confirmed red before the fix and green afterward.

Manual WTG.AI.Prompts validation used the built CLI with an isolated user registry:

```bash
WORKTREE=/home/entity/projects/EntityProcess/allagents.worktrees/fix-project-marketplace-update
CLI="$WORKTREE/dist/index.js"
WTG=/home/entity/projects/WiseTechGlobal/WTG.AI.Prompts
PROJECT=$(mktemp -d /tmp/allagents-marketplace-update.XXXXXX)

git init "$PROJECT"
"$CLI" init "$PROJECT" --client copilot

cd "$PROJECT"
ALLAGENTS_TEST_HOME="$PROJECT/home" "$CLI" plugin marketplace add "$WTG" --scope project
ALLAGENTS_TEST_HOME="$PROJECT/home" "$CLI" plugin install org@wtg-ai-prompts --scope project
ALLAGENTS_TEST_HOME="$PROJECT/home" "$CLI" plugin update org@wtg-ai-prompts --scope project
```

The final update completed with one plugin updated, zero skipped, zero failed, and the project workspace resynced successfully.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
